### PR TITLE
adding cask install step to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A simple time tracking experiment
 Make sure you have `vagrant` installed. For instance, on OS X with Homebrew:
 
 ```
+$ brew install caskroom/cask/brew-cask
 $ brew cask install vagrant
 ```
 


### PR DESCRIPTION
I don't have much experience with vagrant, so I didn't know I needed to install cask separately. Added that step to the instructions in case anyone else has that problem!