### PR TITLE
Simple API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ psycopg2==2.6
 model-mommy==1.2.3
 waitress==0.8.9
 whitenoise==1.0.6
+djangorestframework==3.1.2
+djangorestframework-csv==1.3.3

--- a/tock/api/admin.py
+++ b/tock/api/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/tock/api/models.py
+++ b/tock/api/models.py
@@ -1,0 +1,3 @@
+from django.db import models
+
+# Create your models here.

--- a/tock/api/tests.py
+++ b/tock/api/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/tock/api/urls.py
+++ b/tock/api/urls.py
@@ -1,0 +1,15 @@
+from django.conf.urls import patterns, include, url
+from rest_framework.urlpatterns import format_suffix_patterns
+from api import views
+
+# Uncomment the next two lines to enable the admin:
+# from django.contrib import admin
+# admin.autodiscover()
+
+urlpatterns = patterns('',
+    url(r'^projects.(?P<format>csv|json)$', views.ProjectList.as_view(), name='list_projects'),
+    url(r'^users.(?P<format>csv|json)$', views.UserList.as_view(), name='list_users'),
+
+    # Uncomment the next line to enable the admin:
+    # url(r'^admin/', include(admin.site.urls)),
+)

--- a/tock/api/views.py
+++ b/tock/api/views.py
@@ -1,0 +1,31 @@
+from django.shortcuts import render
+from django.http import HttpResponse, HttpResponseBadRequest
+from django.conf import settings
+from django.db.models import Count, Sum
+from decimal import Decimal
+
+from django.contrib.auth.models import User, Group
+from hours.models import ReportingPeriod, Timecard, TimecardObject
+from projects.models import Project, Agency, AccountingCode
+
+from rest_framework import serializers
+from rest_framework import generics
+
+class ProjectSerializer(serializers.ModelSerializer):
+    billable = serializers.BooleanField(source='accounting_code.billable')
+    class Meta:
+        model = Project
+        fields = ('id', 'name', 'description', 'billable',)
+
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ('id', 'username', 'first_name', 'last_name',)
+
+class ProjectList(generics.ListAPIView):
+    queryset = Project.objects.all()
+    serializer_class = ProjectSerializer
+
+class UserList(generics.ListAPIView):
+    queryset = User.objects.all()
+    serializer_class = UserSerializer

--- a/tock/tock/settings/base.py
+++ b/tock/tock/settings/base.py
@@ -21,7 +21,8 @@ DATABASES = {}
 INSTALLED_APPS = ('django.contrib.contenttypes',  # may be okay to remove
                   'django.contrib.staticfiles', 'django.contrib.admin',
                   'django.contrib.auth', 'django.contrib.sessions',
-                  'django.contrib.messages', 'tock', 'projects', 'hours', 'employees')
+                  'django.contrib.messages',
+                  'tock', 'projects', 'hours', 'employees', 'api')
 
 ROOT_URLCONF = 'tock.urls'
 WSGI_APPLICATION = 'tock.wsgi.application'
@@ -68,4 +69,11 @@ STATIC_URL = '/static/'
 
 ALLOWED_EMAIL_DOMAINS = {
     'gsa.gov',
+}
+
+REST_FRAMEWORK = {
+    'DEFAULT_RENDERER_CLASSES': (
+        'rest_framework.renderers.JSONRenderer',
+        'rest_framework_csv.renderers.CSVRenderer',
+    )
 }

--- a/tock/tock/urls.py
+++ b/tock/tock/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import patterns, include, url
-from django.conf.urls.static import static
+# from django.conf.urls.static import static
 from django.conf import settings
-from django.views.generic import TemplateView
+# from django.views.generic import TemplateView
 
 # Uncomment the next two lines to enable the admin:
 from django.contrib import admin
@@ -10,10 +10,12 @@ admin.autodiscover()
 import hours.views
 import api.urls
 
-urlpatterns = patterns('',
+urlpatterns = patterns(
+    '',
     url(r'^$', hours.views.ReportingPeriodListView.as_view(),
         name='ListReportingPeriods'),
-    url(r'^reporting_period/', include("hours.urls.timesheets", namespace="reportingperiod")),
+    url(r'^reporting_period/', include("hours.urls.timesheets",
+        namespace="reportingperiod")),
     url(r'^reports/', include("hours.urls.reports", namespace="reports")),
     url(r'^employees/', include("employees.urls", namespace="employees")),
 

--- a/tock/tock/urls.py
+++ b/tock/tock/urls.py
@@ -8,21 +8,26 @@ from django.contrib import admin
 admin.autodiscover()
 
 import hours.views
+import api.urls
 
-urlpatterns = patterns(
-    '', url(r'^$', hours.views.ReportingPeriodListView.as_view(),
-            name='ListReportingPeriods'),
+urlpatterns = patterns('',
+    url(r'^$', hours.views.ReportingPeriodListView.as_view(),
+        name='ListReportingPeriods'),
     url(r'^reporting_period/', include("hours.urls.timesheets", namespace="reportingperiod")),
     url(r'^reports/', include("hours.urls.reports", namespace="reports")),
     url(r'^employees/', include("employees.urls", namespace="employees")),
 
     # Uncomment the next line to enable the admin:
-    url(r'^admin/', include(admin.site.urls)),)
+    url(r'^admin/', include(admin.site.urls)),
+
+    url(r'^api/', include(api.urls))
+)
+
 
 if settings.DEBUG:
-  import debug_toolbar
-  urlpatterns += patterns(
-      '', url(r'^__debug__/', include(debug_toolbar.urls)),)
+    import debug_toolbar
+    urlpatterns += patterns(
+        '', url(r'^__debug__/', include(debug_toolbar.urls)),)
 
 # Uncomment the next line to serve media files in dev.
 # urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
This PR adds two API endpoints, each in JSON and CSV formats:

* `/api/projects.(json|csv)` lists the projects and their billable flag
* `/api/users.(json|csv)` lists the users by email, first and last name

I'm using [Django REST Framework](http://www.django-rest-framework.org/) because I'm lazy.

I also tweaked the whitespace in `tock/tock/urls.py`. FWIW, [flake8](https://flake8.readthedocs.org/) reports a ton of other whitespace-related warnings throughout the project, though.

No tests yet. :cry: 