### PR TITLE
Add time cards API endpoint

### DIFF
--- a/tock/api/urls.py
+++ b/tock/api/urls.py
@@ -7,8 +7,9 @@ from api import views
 # admin.autodiscover()
 
 urlpatterns = patterns('',
-    url(r'^projects.(?P<format>csv|json)$', views.ProjectList.as_view(), name='list_projects'),
-    url(r'^users.(?P<format>csv|json)$', views.UserList.as_view(), name='list_users'),
+    url(r'^projects.(?P<format>csv|json)$', views.ProjectList.as_view(), name='ProjectList'),
+    url(r'^users.(?P<format>csv|json)$', views.UserList.as_view(), name='UserList'),
+    url(r'^timecards.(?P<format>csv|json)$', views.TimecardList.as_view(), name='TimecardList'),
 
     # Uncomment the next line to enable the admin:
     # url(r'^admin/', include(admin.site.urls)),

--- a/tock/api/views.py
+++ b/tock/api/views.py
@@ -22,6 +22,16 @@ class UserSerializer(serializers.ModelSerializer):
         model = User
         fields = ('id', 'username', 'first_name', 'last_name',)
 
+class TimecardSerializer(serializers.ModelSerializer):
+    user = serializers.StringRelatedField(source='timecard.user')
+    project = serializers.CharField(source='project.name')
+    start_date = serializers.DateField(source='timecard.reporting_period.start_date')
+    end_date = serializers.DateField(source='timecard.reporting_period.end_date')
+    billable = serializers.BooleanField(source='project.accounting_code.billable')
+    class Meta:
+        model = TimecardObject
+        fields = ('user', 'project', 'start_date', 'end_date', 'hours_spent', 'billable',)
+
 class ProjectList(generics.ListAPIView):
     queryset = Project.objects.all()
     serializer_class = ProjectSerializer
@@ -29,3 +39,28 @@ class ProjectList(generics.ListAPIView):
 class UserList(generics.ListAPIView):
     queryset = User.objects.all()
     serializer_class = UserSerializer
+
+class TimecardList(generics.ListAPIView):
+    serializer_class = TimecardSerializer
+
+    def get_queryset(self):
+        params = self.request.QUERY_PARAMS
+        queryset = TimecardObject.objects.all()
+
+        if 'user' in params:
+            # allow either user name or ID
+            user = params.get('user')
+            if user.isnumeric():
+                queryset = queryset.filter(timecard__user__id=user)
+            else:
+                queryset = queryset.filter(timecard__user__username=user)
+
+        if 'project' in params:
+            # allow either project name or ID
+            project = params.get('project')
+            if project.isnumeric():
+                queryset = queryset.filter(project__id=project)
+            else:
+                queryset = queryset.filter(project__name=project)
+
+        return queryset


### PR DESCRIPTION
The timecards endpoint accessible at `/api/timecards.(json|csv)` accepts the following query string parameters to filter the response:

* `user`: either a username, e.g. `shawn.allen`, or a user's numeric ID
* `project`: either a project's name, e.g. `General`, or numeric ID

This endpoint returns all of the fields that should be necessary to visualize person- or project-specific reports:

- `user`: the user's username, e.g. `shawn.allen` (user IDs and full names can be cross-referenced from `/api/users.json`)
- `project`: the project name (project ID can be cross-referenced from `/api/project.json`)
- `start_date`: the reporting period start date in `YYYY-MM-DD` form
- `end_date`: the reporting period end date `YYYY-MM-DD` form
- `hours_spent`: a decimal number (encoded as a string in JSON)
- `billable`: whether the associated project is billable (in CSV the values will be `True` or `False`)