### PR TITLE
order timecards by date, add "date" parameter

### DIFF
--- a/tock/api/views.py
+++ b/tock/api/views.py
@@ -54,7 +54,18 @@ class TimecardList(generics.ListAPIView):
 
     def get_queryset(self):
         params = self.request.QUERY_PARAMS
-        queryset = TimecardObject.objects.all()
+        queryset = TimecardObject.objects.order_by('timecard__reporting_period__start_date')
+
+        # if the `date` query string parameter (in YYYY-MM-DD format) is
+        # provided, get rows for which the date falls within their reporting
+        # date range
+        if 'date' in params:
+            reporting_date = params.get('date')
+            # TODO: validate YYYY-MM-DD format
+            queryset = queryset.filter(
+                timecard__reporting_period__start_date__lte=reporting_date,
+                timecard__reporting_period__end_date__gte=reporting_date
+            )
 
         if 'user' in params:
             # allow either user name or ID


### PR DESCRIPTION
This PR orders the timecards API endpoint results by reporting date ascending and introduces a `date` query string parameter that filters results by whether the provided date string (in `YYYY-MM-DD` form) falls within their reporting date range.

@seanherron we could probably speed these queries up significantly with some indexes. Let me know if you want to huddle today and figure out which ones make sense so we can coordinate the order in which filters are applied to take advantage of them.