### PR TITLE
Stream CSV in bulk

### DIFF
--- a/tock/api/renderers.py
+++ b/tock/api/renderers.py
@@ -30,8 +30,7 @@ def stream_csv(queryset, serializer):
     """
     rows = map(serializer.to_representation, queryset)
     fields = list(serializer.fields.keys())
-    response = StreamingHttpResponse(generate_csv(rows, fields), content_type='text/csv')
-    return response
+    return StreamingHttpResponse(generate_csv(rows, fields), content_type='text/csv')
 
 class Echo(object):
     """

--- a/tock/api/renderers.py
+++ b/tock/api/renderers.py
@@ -1,4 +1,7 @@
 from rest_framework_csv.renderers import CSVRenderer
+from django.http import StreamingHttpResponse
+
+import csv
 
 # This class is needed to extract the "results" list from paginated data.
 # see: https://github.com/mjumbewu/django-rest-framework-csv#pagination
@@ -16,3 +19,24 @@ class PaginatedCSVRenderer(CSVRenderer):
         if not self.headers and len(data) > 0:
             self.headers = data[0].keys()
         return super(PaginatedCSVRenderer, self).render(data, media_type, renderer_context)
+
+class Buffer(object):
+    """
+    A pseudo-buffer, see:
+    <https://docs.djangoproject.com/en/1.8/howto/outputting-csv/#streaming-large-csv-files>
+    """
+    def write(self, value):
+        return value
+
+def stream_csv(queryset, serializer):
+    """
+    Stream data as CSV, given an interable queryset and a DRF
+    Serializer instance with a .fields dict and .to_representation()
+    method.
+    """
+    rows = map(serializer.to_representation, queryset)
+    fieldnames = list(serializer.fields.keys())
+    writer = csv.DictWriter(Buffer(), fieldnames=fieldnames)
+    data = map(writer.writerow, rows)
+    response = StreamingHttpResponse(data, content_type='text/csv')
+    return response

--- a/tock/api/renderers.py
+++ b/tock/api/renderers.py
@@ -28,7 +28,7 @@ def stream_csv(queryset, serializer):
     Serializer instance with a .fields dict and .to_representation()
     method.
     """
-    rows = map(serializer.to_representation, queryset)
+    rows = map(serializer.to_representation, queryset.iterator())
     fields = list(serializer.fields.keys())
     return StreamingHttpResponse(generate_csv(rows, fields), content_type='text/csv')
 

--- a/tock/api/renderers.py
+++ b/tock/api/renderers.py
@@ -3,9 +3,11 @@ from django.http import StreamingHttpResponse
 
 import csv
 
-# This class is needed to extract the "results" list from paginated data.
-# see: https://github.com/mjumbewu/django-rest-framework-csv#pagination
 class PaginatedCSVRenderer(CSVRenderer):
+    """
+    This class extracts the "results" list from paginated data. See:
+    <https://github.com/mjumbewu/django-rest-framework-csv#pagination>
+    """
     results_field = 'results'
 
     def render(self, data, media_type=None, renderer_context=None):

--- a/tock/api/tests.py
+++ b/tock/api/tests.py
@@ -7,11 +7,25 @@ from django.contrib.auth.models import User
 from projects.models import Project
 from hours.models import TimecardObject
 
+import csv
+import logging
+
+# common fixtures for all API tests
+FIXTURES = [
+    'tock/fixtures/dev_user.json',
+    'projects/fixtures/projects.json',
+    'hours/fixtures/timecards.json'
+]
+
 class ProjectsAPITests(TestCase):
-    def setUp(self):
+    fixtures = FIXTURES
+
+    @classmethod
+    def setUpClass(self):
         pass
 
-    def tearDown(self):
+    @classmethod
+    def tearDownClass(self):
         pass
 
     def test_projects_json(self):
@@ -22,10 +36,14 @@ class ProjectsAPITests(TestCase):
 
 
 class UsersAPITests(TestCase):
-    def setUp(self):
+    fixtures = FIXTURES
+
+    @classmethod
+    def setUpClass(self):
         pass
 
-    def tearDown(self):
+    @classmethod
+    def tearDownClass(self):
         pass
 
     def test_users_json(self):
@@ -36,6 +54,8 @@ class UsersAPITests(TestCase):
 
 
 class TimecardsAPITests(TestCase):
+    fixtures = FIXTURES
+
     def setUp(self):
         pass
 
@@ -50,10 +70,14 @@ class TimecardsAPITests(TestCase):
 
 
 class ProjectTimelineTests(TestCase):
-    def setUp(self):
+    fixtures = FIXTURES
+
+    @classmethod
+    def setUpClass(self):
         pass
 
-    def tearDown(self):
+    @classmethod
+    def tearDownClass(self):
         pass
 
     def test_project_timeline(self):
@@ -61,13 +85,36 @@ class ProjectTimelineTests(TestCase):
 
 
 class BulkTimecardsTests(TestCase):
-    def setUp(self):
+    fixtures = FIXTURES
+
+    @classmethod
+    def setUpClass(self):
         pass
 
-    def tearDown(self):
+    @classmethod
+    def tearDownClass(self):
         pass
 
     def test_bulk_timecards(self):
-        pass
+        response = self.client.get(reverse('BulkTimecardList'))
+        rows = decode_streaming_csv(response)
+        expected_fields = set((
+            'project_name',
+            'project_id',
+            'billable',
+            'employee',
+            'start_date',
+            'end_date',
+            'modified_date',
+            'hours_spent',
+        ))
+        rows_read = 0
+        for row in rows:
+            self.assertEqual(set(row.keys()), expected_fields)
+            self.assertEqual(row['project_id'], '1')
+            rows_read += 1
+        self.assertTrue(rows_read > 0, 'no rows read, expecting 1 or more')
 
-
+def decode_streaming_csv(response, reader_options={}):
+    lines = [line.decode('utf-8') for line in response.streaming_content]
+    return csv.DictReader(lines, **reader_options)

--- a/tock/api/tests.py
+++ b/tock/api/tests.py
@@ -1,3 +1,73 @@
 from django.test import TestCase
+from django.core.urlresolvers import reverse
+from django.core.exceptions import ValidationError
+from django.conf import settings
 
-# Create your tests here.
+from django.contrib.auth.models import User
+from projects.models import Project
+from hours.models import TimecardObject
+
+class ProjectsAPITests(TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_projects_json(self):
+        pass
+
+    def test_projects_csv(self):
+        pass
+
+
+class UsersAPITests(TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_users_json(self):
+        pass
+
+    def test_users_csv(self):
+        pass
+
+
+class TimecardsAPITests(TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_timecards_json(self):
+        pass
+
+    def test_timecards_csv(self):
+        pass
+
+
+class ProjectTimelineTests(TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_project_timeline(self):
+        pass
+
+
+class BulkTimecardsTests(TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_bulk_timecards(self):
+        pass
+
+

--- a/tock/api/urls.py
+++ b/tock/api/urls.py
@@ -11,4 +11,5 @@ urlpatterns = patterns('',
     url(r'^users.(?P<format>csv|json)$', views.UserList.as_view(), name='UserList'),
     url(r'^timecards.(?P<format>csv|json)$', views.TimecardList.as_view(), name='TimecardList'),
     url(r'^project_timeline.csv$', views.ProjectTimelineView, name='ProjectTimelineView'),
+    url(r'^timecards_bulk.csv$', views.timecard_list_bulk, name='TimecardListBulk'),
 )

--- a/tock/api/urls.py
+++ b/tock/api/urls.py
@@ -11,5 +11,5 @@ urlpatterns = patterns('',
     url(r'^users.(?P<format>csv|json)$', views.UserList.as_view(), name='UserList'),
     url(r'^timecards.(?P<format>csv|json)$', views.TimecardList.as_view(), name='TimecardList'),
     url(r'^project_timeline.csv$', views.ProjectTimelineView, name='ProjectTimelineView'),
-    url(r'^timecards_bulk.csv$', views.timecard_list_bulk, name='TimecardListBulk'),
+    url(r'^timecards_bulk.csv$', views.bulk_timecard_list, name='BulkTimecardList'),
 )

--- a/tock/api/views.py
+++ b/tock/api/views.py
@@ -75,6 +75,7 @@ class BulkTimecardSerializer(serializers.ModelSerializer):
             'employee',
             'start_date',
             'end_date',
+            'modified_date',
             'hours_spent',
         )
     project_name = serializers.CharField(source='project.name')
@@ -83,6 +84,12 @@ class BulkTimecardSerializer(serializers.ModelSerializer):
     employee = serializers.StringRelatedField(source='timecard.user')
     start_date = serializers.DateField(source='timecard.reporting_period.start_date')
     end_date = serializers.DateField(source='timecard.reporting_period.end_date')
+    modified_date = serializers.DateTimeField(source='modified')
+
+    def to_representation(self, obj, *args, **kwargs):
+        data = super(BulkTimecardSerializer, self).to_representation(obj, *args, **kwargs)
+        data['modified_date'] = obj.modified.strftime('%Y-%m-%d %H:%M:%S')
+        return data
 
 # API Views
 

--- a/tock/api/views.py
+++ b/tock/api/views.py
@@ -121,7 +121,7 @@ def ProjectTimelineView(request):
         writer.writerow(row)
     return response
 
-def get_timecards(queryset, params={}):
+def get_timecards(queryset, params=None):
     """
     Filter a TimecardObject queryset according to the provided GET
     query string parameters:
@@ -135,6 +135,9 @@ def get_timecards(queryset, params={}):
     * if `project` is provided as a numeric id or name, get rows for
       that project.
     """
+    if not params:
+        return queryset
+
     if 'date' in params:
         reporting_date = params.get('date')
         # TODO: validate YYYY-MM-DD format

--- a/tock/api/views.py
+++ b/tock/api/views.py
@@ -182,7 +182,7 @@ def get_timecards(queryset, params={}):
 
 
 
-def timecard_list_bulk(request):
+def bulk_timecard_list(request):
     """
     Stream all the timecards as CSV.
     """

--- a/tock/api/views.py
+++ b/tock/api/views.py
@@ -4,9 +4,9 @@ from django.conf import settings
 from django.db.models import Count, Sum
 from decimal import Decimal
 
-from django.contrib.auth.models import User, Group
-from hours.models import ReportingPeriod, Timecard, TimecardObject
-from projects.models import Project, Agency, AccountingCode
+from django.contrib.auth.models import User
+from projects.models import Project
+from hours.models import TimecardObject
 
 from rest_framework import serializers, generics, pagination, renderers
 

--- a/tock/api/views.py
+++ b/tock/api/views.py
@@ -96,9 +96,19 @@ def ProjectTimelineView(request):
     return response
 
 def get_timecards(queryset, params={}):
-    # if the `date` query string parameter (in YYYY-MM-DD format) is
-    # provided, get rows for which the date falls within their reporting
-    # date range
+    """
+    Filter a TimecardObject queryset according to the provided GET
+    query string parameters:
+
+    * if `date` (in YYYY-MM-DD format) is provided, get rows for
+      which the date falls within their reporting date range.
+
+    * if `user` (in either `first.last` or numeric id) is provided,
+      get rows for that user.
+
+    * if `project` is provided as a numeric id or name, get rows for
+      that project.
+    """
     if 'date' in params:
         reporting_date = params.get('date')
         # TODO: validate YYYY-MM-DD format

--- a/tock/api/views.py
+++ b/tock/api/views.py
@@ -10,10 +10,8 @@ from projects.models import Project, Agency, AccountingCode
 
 from rest_framework import serializers, generics, pagination, renderers
 
-from rest_framework.renderers import JSONRenderer
-from .renderers import PaginatedCSVRenderer
-
 import csv
+from .renderers import PaginatedCSVRenderer, stream_csv
 
 class StandardResultsSetPagination(pagination.PageNumberPagination):
     page_size = 100
@@ -126,3 +124,11 @@ def get_timecards(queryset, params={}):
             queryset = queryset.filter(project__name=project)
 
     return queryset
+
+def timecard_list_bulk(request):
+    """
+    Stream all the timecards as CSV.
+    """
+    queryset = get_timecards(TimecardList.queryset, request.GET)
+    serializer = TimecardSerializer()
+    return stream_csv(queryset, serializer)

--- a/tock/api/views.py
+++ b/tock/api/views.py
@@ -46,50 +46,24 @@ class UserSerializer(serializers.ModelSerializer):
             'last_name',
         )
 
-class TimecardSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = TimecardObject
-        fields = (
-            'user',
-            'project_name',
-            'project_id',
-            'start_date',
-            'end_date',
-            'hours_spent',
-            'billable',
-        )
+class TimecardSerializer(serializers.Serializer):
     user = serializers.StringRelatedField(source='timecard.user')
     project_id = serializers.CharField(source='project.id')
     project_name = serializers.CharField(source='project.name')
+    hours_spent = serializers.DecimalField(max_digits=5, decimal_places=2)
     start_date = serializers.DateField(source='timecard.reporting_period.start_date')
     end_date = serializers.DateField(source='timecard.reporting_period.end_date')
     billable = serializers.BooleanField(source='project.accounting_code.billable')
 
-class BulkTimecardSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = TimecardObject
-        fields = (
-            'project_name',
-            'project_id',
-            'billable',
-            'employee',
-            'start_date',
-            'end_date',
-            'modified_date',
-            'hours_spent',
-        )
+class BulkTimecardSerializer(serializers.Serializer):
     project_name = serializers.CharField(source='project.name')
     project_id = serializers.CharField(source='project.id')
-    billable = serializers.BooleanField(source='project.accounting_code.billable')
     employee = serializers.StringRelatedField(source='timecard.user')
     start_date = serializers.DateField(source='timecard.reporting_period.start_date')
     end_date = serializers.DateField(source='timecard.reporting_period.end_date')
-    modified_date = serializers.DateTimeField(source='modified')
-
-    def to_representation(self, obj, *args, **kwargs):
-        data = super(BulkTimecardSerializer, self).to_representation(obj, *args, **kwargs)
-        data['modified_date'] = obj.modified.strftime('%Y-%m-%d %H:%M:%S')
-        return data
+    hours_spent = serializers.DecimalField(max_digits=5, decimal_places=2)
+    billable = serializers.BooleanField(source='project.accounting_code.billable')
+    modified_date = serializers.DateTimeField(source='modified', format='%Y-%m-%d %H:%M:%S')
 
 # API Views
 

--- a/tock/hours/fixtures/timecards.json
+++ b/tock/hours/fixtures/timecards.json
@@ -1,0 +1,31 @@
+[
+  {
+    "model": "hours.reportingperiod",
+    "fields": {
+      "start_date": "2015-06-01",
+      "end_date": "2015-06-08"
+    },
+    "pk": 1
+  },
+  {
+    "model": "hours.timecard",
+    "fields": {
+      "user": 1,
+      "reporting_period": 1,
+      "created": "2015-06-08T12:00:00.000Z",
+      "modified": "2015-06-08T12:00:00.000Z"
+    },
+    "pk": 1
+  },
+  {
+    "model": "hours.timecardobject",
+    "fields": {
+      "timecard": 1,
+      "project": 1,
+      "hours_spent": 20,
+      "created": "2015-06-08T12:00:00.000Z",
+      "modified": "2015-06-08T12:00:00.000Z"
+    },
+    "pk": 1
+  }
+]


### PR DESCRIPTION
This PR introduces a new API endpoint, `/api/timecards_bulk.csv`, that streams the data as CSV, and should resolve #163. I basically followed [these instructions](https://docs.djangoproject.com/en/1.8/howto/outputting-csv/#streaming-large-csv-files), and wrapped up the streaming logic in a rendering function that we can use later on.

I didn't go as far as to create a [DRF renderer](http://www.django-rest-framework.org/api-guide/renderers/) class because I couldn't figure out how to get access to the view's serializer from within the renderer's `render()` method, but this would be a good thing to do in the future if we wanted any of the other CSV views to stream. The downside of this approach is that you can't calculate the `Content-Length` HTTP header, which means that browsers can't display progress when downloading.