### PR TITLE
[WIP] Use Django 1.8, fix #173

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.7.6
+Django==1.8
 dj-database-url==0.3.0
 psycopg2==2.6
 model-mommy==1.2.3

--- a/tock/hours/forms.py
+++ b/tock/hours/forms.py
@@ -70,15 +70,8 @@ def projects_as_choices():
     return accounting_codes
 
 
-class ProjectChoiceField(forms.ChoiceField):
-    widget = SelectWithData()
-
-    def __init__(self, *args, **kwargs):
-        super(ProjectChoiceField, self).__init__(*args, **kwargs)
-        self.choices = projects_as_choices()
-
 class TimecardObjectForm(forms.ModelForm):
-    project = ProjectChoiceField()
+    project = forms.ChoiceField(widget=SelectWithData(), choices=projects_as_choices)
 
     class Meta:
         model = TimecardObject


### PR DESCRIPTION
This PR should fix #173. The [Django 1.8 docs](https://docs.djangoproject.com/en/1.8/ref/forms/fields/#choicefield) for `django.forms.ChoiceField` claim that:

> If the [choices] argument is a callable, it is evaluated each time the field’s form is initialized.

So I've updated the `TimecardObjectForm` to look like this, and ditched the `ProjectChoiceField` class altogether:

```python
class TimecardObjectForm(forms.ModelForm):
    project = forms.ChoiceField(widget=SelectWithData(), choices=projects_as_choices)

    class Meta:
        model = TimecardObject
        fields = ['project', 'hours_spent']
```

This works for me. I've tested it:

1. by adding and removing projects while the app is running, then checking the timecard entry form to see if the list gets updated; and
1. by running the tests, naturally

and in both cases the issue appears to have been resolved. I could use a code review to make sure that this is a legitimate solution, though. @jmcarp, I'd love your brain on this if you have a moment.