### PR TITLE
Add regression tests for #175.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,1 @@
-django-debug-toolbar
+django-debug-toolbardjango-webtest


### PR DESCRIPTION
Add integration tests checking that the options in the project selector
are populated correctly. The `test_project_select_dynamic` test should
succeed after merging #175 but fail without the patch.