### PR TITLE
Start coverage before tests.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,1 @@
-django-debug-toolbardjango-webtestdjango-nosecoverage
+django-debug-toolbardjango-webtestcoverage

--- a/tock/manage.py
+++ b/tock/manage.py
@@ -2,9 +2,23 @@
 import os
 import sys
 
-if __name__ == "__main__":
-  os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tock.settings.dev")
+if __name__ == '__main__':
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'tock.settings.dev')
+    from django.core.management import execute_from_command_line
+    testing = 'test' in sys.argv
 
-  from django.core.management import execute_from_command_line
+    if testing:
+        import coverage
+        cov = coverage.coverage(
+            source=['tock', 'employees', 'projects', 'hours', 'api'],
+            omit=['*/tests*', '*/migrations/*', '*/settings/*'],
+        )
+        cov.erase()
+        cov.start()
 
-  execute_from_command_line(sys.argv)
+    execute_from_command_line(sys.argv)
+
+    if testing:
+        cov.stop()
+        cov.save()
+        cov.report()

--- a/tock/tock/settings/test.py
+++ b/tock/tock/settings/test.py
@@ -11,11 +11,4 @@ DATABASES = {
     }
 }
 
-INSTALLED_APPS += ('django_nose', )
-TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
-NOSE_ARGS = [
-    '--with-coverage',
-    '--cover-package=tock,employees,projects,hours,api',
-]
-
 MEDIA_ROOT = './media/'


### PR DESCRIPTION
Django 1.7+ imports models before starting the testing process, so
models appear to never be tested. This patch uses a workaround described
in https://github.com/django-nose/django-nose/issues/180.

[Resolves #198]