### PR TITLE
Restore correct URL template in project detail chart.

### DIFF
--- a/tock/tock/templates/projects/project_detail.html
+++ b/tock/tock/templates/projects/project_detail.html
@@ -10,7 +10,7 @@
   <utilization-chart
     class="timeline timeline--project"
     data-url="{% url 'UserTimelineView' %}?project={{ object.id }}"
-    href="{% url 'employees:UserFormView' user %}"
+    href="/employees/{% verbatim %}{{ user }} {% endverbatim %}"
     layer="user"
     color="user"
     x="start_date"


### PR DESCRIPTION
In my zeal to replace hard-coded URLs with `reverse` calls, I didn't
notice that the URL in the `utilization-chart` was actually a template.
rendered in the JS. This patch restores the previous, correct logic.

:confounded: 