### PR TITLE
[WIP] Vary billing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ install:
 
 script:
   - cd tock
+  - python manage.py makemigrations --noinput --settings=tock.settings.test
   - python manage.py migrate --noinput --settings=tock.settings.test
   - python manage.py test --noinput --settings=tock.settings.test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
 
 script:
   - cd tock
-  - python manage.py syncdb --noinput --settings=tock.settings.test
+  - python manage.py migrate --noinput --settings=tock.settings.test
   - python manage.py test --noinput --settings=tock.settings.test
 
 after_success:

--- a/tock/hours/admin.py
+++ b/tock/hours/admin.py
@@ -4,7 +4,7 @@ from django.contrib import admin
 from django.core.exceptions import ValidationError
 from django.forms.models import BaseInlineFormSet
 
-from .models import ReportingPeriod, Timecard, TimecardObject
+from .models import ReportingPeriod, Timecard, TimecardObject, ProjectPeriod
 
 
 class ReportingPeriodListFilter(admin.SimpleListFilter):
@@ -56,5 +56,10 @@ class TimecardAdmin(admin.ModelAdmin):
     inlines = (TimecardObjectInline,)
 
 
+class ProjectPeriodAdmin(admin.ModelAdmin):
+    pass
+
+
 admin.site.register(ReportingPeriod, ReportingPeriodAdmin)
 admin.site.register(Timecard, TimecardAdmin)
+admin.site.register(ProjectPeriod, ProjectPeriodAdmin)

--- a/tock/hours/models.py
+++ b/tock/hours/models.py
@@ -30,7 +30,7 @@ class ReportingPeriod(ValidateOnSaveMixin, models.Model):
                     ProjectPeriod.objects.create(
                         reporting_period=self,
                         project=last_project_period.project,
-                        billable=last_project_period.billable,
+                        accounting_code=last_project_period.accounting_code,
                         active=last_project_period.active,
                     )
 
@@ -88,5 +88,11 @@ class TimecardObject(models.Model):
 class ProjectPeriod(models.Model):
     project = models.ForeignKey(Project, related_name='project_periods')
     reporting_period = models.ForeignKey(ReportingPeriod, related_name='project_periods')
-    billable = models.BooleanField()
+    accounting_code = models.ForeignKey('projects.AccountingCode', related_name='project_periods')
     active = models.BooleanField()
+
+    def __str__(self):
+        return '{0}:{1}'.format(
+            self.project.name,
+            self.reporting_period.start_date.strftime('%Y-%m-%d'),
+        )

--- a/tock/hours/models.py
+++ b/tock/hours/models.py
@@ -14,6 +14,11 @@ class ReportingPeriod(ValidateOnSaveMixin, models.Model):
     message = models.TextField(
         help_text='A message to provide at the top of the reporting period.',
         blank=True)
+    projects = models.ManyToManyField(
+        Project,
+        through='ProjectPeriod',
+        related_name='reporting_periods',
+    )
 
     def __str__(self):
         return str(self.start_date)
@@ -64,3 +69,10 @@ class TimecardObject(models.Model):
 
     def hours(self):
         return self.hours_spent
+
+
+class ProjectPeriod(models.Model):
+    project = models.ForeignKey(Project, related_name='project_periods')
+    period = models.ForeignKey(ReportingPeriod, related_name='project_periods')
+    billable = models.BooleanField()
+    active = models.BooleanField()

--- a/tock/projects/models.py
+++ b/tock/projects/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.conf import settings
 from django.db.models.loading import get_model
 
 
@@ -59,7 +60,7 @@ class Project(models.Model):
                 ProjectPeriod.objects.create(
                     project=self,
                     reporting_period=last_period,
-                    billable=True,
+                    accounting_code_id=settings.DEFAULT_ACCOUNTING_CODE,
                     active=True,
                 )
 

--- a/tock/tock/settings/base.py
+++ b/tock/tock/settings/base.py
@@ -78,3 +78,5 @@ REST_FRAMEWORK = {
         'api.renderers.PaginatedCSVRenderer',
     ),
 }
+
+DEFAULT_ACCOUNTING_CODE = 1


### PR DESCRIPTION
This patch allows each project to change active status and accounting code for each reporting period. This allows projects to change from nonbillable to billable and back, while preserving the history of accounting codes over time. Projects can also be marked as active or inactive for any given reporting period. The idea is to obviate the spreadsheet that @batemapf is currently using to store this information.

As implemented, creating a new reporting period automatically copies the reporting code and active status of each project to the new period, and newly created projects default to active, with a configurable default reporting code. If the overall proposal makes sense to @batemapf and @ramirezg, then I'll flesh this out with the following:
- [ ] Unit tests
- [ ] Migration from old data model to new
- [ ] Better admin interface for updating reporting codes over time
- [ ] Hiding inactive projects from timecard interface
