### PR TITLE
Add data table of hours spent on project detail page.

### DIFF
--- a/tock/hours/tests/test_views.py
+++ b/tock/hours/tests/test_views.py
@@ -22,7 +22,9 @@ class UtilTests(TestCase):
 
 class ReportTests(WebTest):
     fixtures = [
-        'projects/fixtures/projects.json', 'tock/fixtures/dev_user.json']
+        'projects/fixtures/projects.json',
+        'tock/fixtures/dev_user.json',
+    ]
 
     def setUp(self):
         self.reporting_period = hours.models.ReportingPeriod.objects.create(

--- a/tock/projects/templatetags/project_tags.py
+++ b/tock/projects/templatetags/project_tags.py
@@ -7,4 +7,9 @@ def get(value, key):
     return value.get(key)
 
 
+def default(value, default):
+    return value or default
+
+
 register.filter('get', get)
+register.filter('default', default)

--- a/tock/projects/templatetags/project_tags.py
+++ b/tock/projects/templatetags/project_tags.py
@@ -7,9 +7,4 @@ def get(value, key):
     return value.get(key)
 
 
-def default(value, default):
-    return value or default
-
-
 register.filter('get', get)
-register.filter('default', default)

--- a/tock/projects/templatetags/project_tags.py
+++ b/tock/projects/templatetags/project_tags.py
@@ -1,0 +1,10 @@
+from django import template
+
+register = template.Library()
+
+
+def get(value, key):
+    return value.get(key)
+
+
+register.filter('get', get)

--- a/tock/projects/tests.py
+++ b/tock/projects/tests.py
@@ -1,6 +1,16 @@
-from django_webtest import WebTest
-from projects.models import Agency, Project, AccountingCode
+import random
+import datetime
+
+from django.conf import settings
+from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
+from django.utils.dateformat import format as date_format
+from django_webtest import WebTest
+
+from projects.views import project_timeline
+from projects.models import Agency, Project, AccountingCode
+
+from hours.models import ReportingPeriod, Timecard, TimecardObject
 
 
 class ProjectsTest(WebTest):
@@ -41,8 +51,64 @@ class ProjectsTest(WebTest):
             len(response.html.find('a', href='/projects/1')), 1)
         self.assertEqual(response.status_code, 200)
 
-    def test_projects_details_view(self):
-        """ Check that the project detail view is open and the saved project
-        exists """
+
+class TestProjectTimeline(WebTest):
+    fixtures = ['tock/fixtures/dev_user.json']
+
+    def setUp(self):
+        super(TestProjectTimeline, self).setUp()
+        self.user = User.objects.first()
+        agency = Agency.objects.create(name='General Services Administration')
+        accounting_code = AccountingCode.objects.create(
+            code='abc',
+            agency=agency,
+            office='18F',
+            billable=True,
+        )
+        self.project = Project.objects.create(
+            accounting_code=accounting_code,
+            name='Test Project',
+        )
+        self.dates = [
+            datetime.date.today() + datetime.timedelta(weeks * 7)
+            for weeks in range(5)
+        ]
+        self.objs = [
+            TimecardObject.objects.create(
+                timecard=Timecard.objects.create(
+                    user=self.user,
+                    reporting_period=ReportingPeriod.objects.create(
+                        start_date=date,
+                        end_date=date + datetime.timedelta(days=6),
+                    ),
+                ),
+                project=self.project,
+                hours_spent=random.randint(5, 35),
+            )
+            for date in self.dates
+        ]
+
+    def test_project_timeline(self):
+        res = project_timeline(self.project)
+        self.assertEqual(res['periods'], self.dates)
+        self.assertEqual(
+            res['groups'],
+            {
+                self.user: {
+                    obj.timecard.reporting_period.start_date: obj.hours_spent
+                    for obj in self.objs
+                }
+            },
+        )
+
+    def test_project_timeline_view(self):
         response = self.app.get(reverse('ProjectView', args=[self.project.pk]))
-        self.assertEqual(response.status_code, 200)
+        table = response.html.find('table')
+        self.assertEqual(
+            [each.text for each in table.find_all('th')[1:]],
+            [date_format(each, settings.DATE_FORMAT) for each in self.dates],
+        )
+        self.assertEqual(
+            [each.text for each in table.find_all('td')[1:]],
+            [str(float(each.hours_spent)) for each in self.objs],
+        )

--- a/tock/projects/views.py
+++ b/tock/projects/views.py
@@ -49,11 +49,11 @@ def project_timeline(project):
     periods = set()
     for user, rows in itertools.groupby(timecards, lambda row: row.timecard.user):
         groups[user] = {
-            row.timecard.reporting_period.start_date: row.hours_spent
+            row.timecard.reporting_period.start_date: float(row.hours_spent)
             for row in rows
         }
         periods.update(groups[user].keys())
     return {
         'groups': groups,
-        'periods': periods,
+        'periods': sorted(periods),
     }

--- a/tock/projects/views.py
+++ b/tock/projects/views.py
@@ -1,5 +1,8 @@
+import itertools
+
 from django.views.generic import ListView
 from django.views.generic.detail import DetailView
+from django.db.models.loading import get_model
 
 from .models import Project
 
@@ -23,4 +26,34 @@ class ProjectView(DetailView):
 
     def get_context_data(self, **kwargs):
         context = super(ProjectView, self).get_context_data(**kwargs)
+        context['table'] = project_timeline(kwargs['object'])
         return context
+
+
+def project_timeline(project):
+    """Gather hours spent per user per reporting period for the specified
+    project. Returns hours per user per period, plus an ordered list of
+    relevant periods.
+    """
+    TimecardObject = get_model('hours.TimecardObject')
+    timecards = TimecardObject.objects.filter(
+        project=project,
+    ).order_by(
+        'timecard__user__pk',
+        '-timecard__reporting_period__start_date',
+    ).select_related(
+        'timecard__user',
+        'timecard__reporting_period',
+    ).all()
+    groups = {}
+    periods = set()
+    for user, rows in itertools.groupby(timecards, lambda row: row.timecard.user):
+        groups[user] = {
+            row.timecard.reporting_period.start_date: row.hours_spent
+            for row in rows
+        }
+        periods.update(groups[user].keys())
+    return {
+        'groups': groups,
+        'periods': periods,
+    }

--- a/tock/tock/static/css/style.css
+++ b/tock/tock/static/css/style.css
@@ -127,7 +127,6 @@ table {
   font-feature-settings: "kern", "liga", "tnum";
   border-collapse: collapse;
   margin: 0.75em 0;
-  table-layout: fixed;
   width: 100%; }
 
 th {
@@ -144,6 +143,10 @@ tr,
 td,
 th {
   vertical-align: middle; }
+
+table.dataTable {
+  table-layout: auto;
+}
 
 body {
   -webkit-font-feature-settings: "kern", "liga", "pnum";

--- a/tock/tock/templates/projects/project_detail.html
+++ b/tock/tock/templates/projects/project_detail.html
@@ -19,7 +19,7 @@
   </utilization-chart>
 </figure>
 
-<table id="dataTable">
+<table id="dataTable" class="striped">
   <thead>
     <th>Name</th>
     {% for period in table.periods %}
@@ -31,7 +31,7 @@
     <tr>
       <td>{{ user }}</td>
       {% for period in table.periods %}
-      <td>{{ rows|get:period }}</td>
+      <td>{{ rows|get:period|default:0.0 }}</td>
       {% endfor %}
     </tr>
     {% endfor %}

--- a/tock/tock/templates/projects/project_detail.html
+++ b/tock/tock/templates/projects/project_detail.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load project_tags %}
 
 {% block content %}
 <h2><a href="{% url 'ProjectListView' %}">Tock Projects</a> / {{ object.name }}</h2>
@@ -17,5 +18,36 @@
     y="hours_spent">
   </utilization-chart>
 </figure>
+
+<table id="dataTable">
+  <thead>
+    <th>Name</th>
+    {% for period in table.periods %}
+      <th>{{ period }}</th>
+    {% endfor %}
+  </thead>
+  <tbody>
+    {% for user, rows in table.groups.items %}
+    <tr>
+      <td>{{ user }}</td>
+      {% for period in table.periods %}
+      <td>{{ rows|get:period }}</td>
+      {% endfor %}
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+
+<link rel="stylesheet" href="//cdn.datatables.net/1.10.7/css/jquery.dataTables.min.css" />
+<script src="//cdn.datatables.net/1.10.7/js/jquery.dataTables.min.js"></script>
+<script type="text/javascript">
+$(document).ready(function() {
+  $('#dataTable').dataTable({
+    scrollX: true,
+    paging: false,
+    lengthChange: false,
+  });
+});
+</script>
 
 {% endblock %}

--- a/tock/tock/templates/projects/project_detail.html
+++ b/tock/tock/templates/projects/project_detail.html
@@ -39,14 +39,16 @@
 </table>
 
 <link rel="stylesheet" href="//cdn.datatables.net/1.10.7/css/jquery.dataTables.min.css" />
-<script src="//cdn.datatables.net/1.10.7/js/jquery.dataTables.min.js"></script>
+<script src="https://cdn.datatables.net/1.10.7/js/jquery.dataTables.min.js"></script>
+<script src="https://www.datatables.net/release-datatables/extensions/FixedColumns/js/dataTables.fixedColumns.js"></script>
 <script type="text/javascript">
 $(document).ready(function() {
-  $('#dataTable').dataTable({
+  var $table = $('#dataTable').dataTable({
     scrollX: true,
     paging: false,
-    lengthChange: false,
+    lengthChange: false
   });
+  new $.fn.dataTable.FixedColumns($table);
 });
 </script>
 


### PR DESCRIPTION
It looks kind of like this:
<img width="934" alt="screen shot 2015-07-17 at 5 51 04 pm" src="https://cloud.githubusercontent.com/assets/1633460/8758002/4806ad7a-2cad-11e5-8e5e-0d5b8c370c5a.png">
Just imagine it with more users and reporting periods. @batemapf is this what you had in mind?

Todo:
* [x] Unit tests
* [x] Code review (paging @ramirezg)