### PR TITLE
Ensure that authenticated users have `UserData` records.

### DIFF
--- a/tock/hours/tests/test_views.py
+++ b/tock/hours/tests/test_views.py
@@ -65,30 +65,12 @@ class ReportTests(WebTest):
         response = response.content.decode('utf-8')
         self.assertTrue(response.index('2016') < response.index('2015'))
 
-    def test_report_list_authenticated_without_userdata(self):
-        """ Check that report list throws error when there is no user data """
-        new_user = get_user_model().objects.create(
-            username='new',
-            email='new@gsa.gov',
-        )
-        has_error = False
-        try:
-            self.app.get(
-                reverse('ListReportingPeriods'),
-                headers={'X_FORWARDED_EMAIL': new_user.email},
-                expect_errors=True,
-            )
-        except:
-            has_error = True
-        self.assertTrue(has_error)
-
-    def test_report_list_authenticated_with_userdata(self):
+    def test_report_list_authenticated(self):
         """ Check that main page loads with reporting periods for authenticated
         user with with userdata """
         response = self.app.get(
             reverse('ListReportingPeriods'),
             headers={'X_FORWARDED_EMAIL': self.regular_user.email},
-            expect_errors=True,
         )
         self.assertEqual(response.status_code, 200)
 

--- a/tock/tock/remote_user_auth.py
+++ b/tock/tock/remote_user_auth.py
@@ -33,14 +33,15 @@ class TockUserBackend(RemoteUserBackend):
         """
         return email_to_username(email_address)
 
-    def configure_user(self, user):
-        """
-        Configures a user after creation
-        """
-        user_data, created = UserData.objects.get_or_create(user=user)
-        user_data.save()
-        return user
-
 
 class EmailHeaderMiddleware(RemoteUserMiddleware):
     header = 'HTTP_X_FORWARDED_EMAIL'
+
+
+class UserDataMiddleware(object):
+
+    def process_request(self, request):
+        """Ensure that authenticated users have associated `UserData` records.
+        """
+        if request.user.is_authenticated():
+            UserData.objects.get_or_create(user=request.user)

--- a/tock/tock/settings/base.py
+++ b/tock/tock/settings/base.py
@@ -45,9 +45,11 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'tock.remote_user_auth.EmailHeaderMiddleware',
+    'tock.remote_user_auth.UserDataMiddleware',
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',)
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+)
 
 AUTHENTICATION_BACKENDS = ('tock.remote_user_auth.TockUserBackend',)
 


### PR DESCRIPTION
[Resolves #212]

Note: I put the check to ensure `UserData` in a middleware rather than the authentication backend, since it's possible (although unlikely) that a user could authenticate, somehow have their `UserData` lost, and return to Tock before their session expires. If this is too much of an edge case to worry about, we can put the check in the authentication backend.