### PR TITLE
Removing email field from employee form

### DIFF
--- a/tock/employees/forms.py
+++ b/tock/employees/forms.py
@@ -2,7 +2,6 @@ from django import forms
 
 
 class UserForm(forms.Form):
-    email = forms.EmailField(required=True, label="Email Address")
     first_name = forms.CharField(required=False, label="First Name")
     last_name = forms.CharField(required=False, label="Last Name")
     start_date = forms.DateField(

--- a/tock/employees/tests/test_forms.py
+++ b/tock/employees/tests/test_forms.py
@@ -9,7 +9,6 @@ class UserFormTests(TestCase):
 
     def test_user_update(self):
         form_data = {
-            'email': 'testuser@gsa.gov',
             'first_name': 'Test',
             'last_name': 'User',
             'start_date': '2014-01-01',
@@ -17,7 +16,6 @@ class UserFormTests(TestCase):
         }
         form = UserForm(form_data)
         self.assertTrue(form.is_valid())
-        self.assertEqual(form.cleaned_data['email'], "testuser@gsa.gov")
         self.assertEqual(form.cleaned_data['first_name'], "Test")
         self.assertEqual(form.cleaned_data['last_name'], "User")
         self.assertEqual(

--- a/tock/employees/tests/test_views.py
+++ b/tock/employees/tests/test_views.py
@@ -102,7 +102,6 @@ class UserViewTests(WebTest):
             reverse('employees:UserFormView', args=['regular.user']),
             headers={'X_FORWARDED_EMAIL': 'test.user@gsa.gov'},
         ).form
-        form['email'] = 'regular.user@gsa.gov'
         form['first_name'] = 'Regular'
         form['last_name'] = 'User'
         form['start_date'] = '2013-01-01'
@@ -123,7 +122,6 @@ class UserViewTests(WebTest):
             reverse('employees:UserFormView', args=['regular.user']),
             headers={'X_FORWARDED_EMAIL': 'regular.user@gsa.gov'},
         ).form
-        form['email'] = 'regular.user@gsa.gov'
         form['first_name'] = 'Regular'
         form['last_name'] = 'User'
         form['start_date'] = '2015-01-01'

--- a/tock/employees/views.py
+++ b/tock/employees/views.py
@@ -5,7 +5,6 @@ from django.core.urlresolvers import reverse
 from django.views.generic import ListView
 from django.views.generic.edit import FormView
 
-from tock.remote_user_auth import email_to_username
 from tock.utils import PermissionMixin, IsSuperUserOrSelf
 
 from .forms import UserForm
@@ -41,7 +40,6 @@ class UserFormView(PermissionMixin, FormView):
         initial = super(UserFormView, self).get_initial()
         user, created = User.objects.get_or_create(
             username=self.kwargs['username'])
-        initial['email'] = user.email
         initial['first_name'] = user.first_name
         initial['last_name'] = user.last_name
 
@@ -55,8 +53,6 @@ class UserFormView(PermissionMixin, FormView):
         if form.is_valid():
             user, created = User.objects.get_or_create(
                 username=self.kwargs['username'])
-            user.email = form.cleaned_data['email']
-            user.username = email_to_username(form.cleaned_data['email'])
             user.first_name = form.cleaned_data['first_name']
             user.last_name = form.cleaned_data['last_name']
             user.save()


### PR DESCRIPTION
Changing emails causes historical data to be disassociated from the user account. The option to change your email should not be readily available. 
[Resolves #195]