### PR TITLE
Map application to 18f.gov.

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -25,10 +25,10 @@ deploy()
 	cf push $next_deployment -n $app_name-$timestamp
 	echo "Mapping $next_deployment to the Main Domain"
 	cf map-route $next_deployment 18f.gov -n $app_name
-	cf map-route $next_deployment cf.18f.us -n $app_name
+  cf map-route $next_deployment 18f.gov -n $app_name-app
 	echo "Removing $current_deployment From the Main Domain"
 	cf unmap-route $current_deployment 18f.gov -n $app_name
-	cf unmap-route $current_deployment cf.18f.us -n $app_name
+  cf unmap-route $current_deployment 18f.gov -n $app_name-app
 	read -p "Check your app. Is it functioning properly? (y/n)" -n 1 -r
 	echo    # (optional) move to a new line
 	if [[ $REPLY =~ ^[Yy]$ ]]; then


### PR DESCRIPTION
Since all CF requests are now redirected to HTTPS, we need to use a URL
that handles SSL. This patch maps the Tock app to tock-app.18f.gov; the
"-app" suffix is used to distinguish the route used by nginx
(tock.18f.gov) from the route used by the app.

Ping @ramirezg. We'll also need to update the staging app to live at tock-app-staging.18f.gov. See https://github.com/18F/hub/pull/358 for full configuration.