### PR TITLE
Fix link to snippets from top of time card

### DIFF
--- a/tock/tock/templates/hours/timecard_form.html
+++ b/tock/tock/templates/hours/timecard_form.html
@@ -3,7 +3,7 @@
 {% block content %}
 <h2>Tell us about your time</h2>
 <div class="alert">
-  <p class="alert-body"> Thank you for being a valued Tock customer.  As a reminder, please enter a total of 40 hours per reporting period.  This would also be a good time to enter your <a herf="https://hub.18f.gov/snippets/">Snippets</a> for the week!</p>
+  <p class="alert-body"> Thank you for being a valued Tock customer.  As a reminder, please enter a total of 40 hours per reporting period.  This would also be a good time to enter your <a href="https://hub.18f.gov/snippets/">Snippets</a> for the week!</p>
 </div>
 
 <form class="form-horizontal form-inline" method="post">


### PR DESCRIPTION
Was: `<a herf>`.