### PR TITLE
Connecting timecard working hours to admin formset

### DIFF
--- a/tock/hours/admin.py
+++ b/tock/hours/admin.py
@@ -29,16 +29,19 @@ class TimecardObjectFormset(BaseInlineFormSet):
             return
 
         hours = Decimal(0.0)
+        working_hours = self.instance.reporting_period.working_hours
         for unit in self.cleaned_data:
             try:
                 hours = hours + unit["hours_spent"]
             except KeyError:
                 pass
-        if hours > 40:
-            raise ValidationError('You have entered more than 40 hours')
+        if hours > working_hours:
+            raise ValidationError(
+                'You have entered more than %s hours' % working_hours)
 
-        if hours < 40:
-            raise ValidationError('You have entered fewer than 40 hours')
+        if hours < working_hours:
+            raise ValidationError(
+                'You have entered fewer than %s hours' % working_hours)
 
 
 class ReportingPeriodAdmin(admin.ModelAdmin):


### PR DESCRIPTION
This should allow admins to modify people's timecards without being forced to enter 40 hours for time periods shorter than 40 hours. 