### PR TITLE
flat-rate-option

### DIFF
--- a/tock/projects/migrations/0002_auto_20151020_2043.py
+++ b/tock/projects/migrations/0002_auto_20151020_2043.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('projects', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='accountingcode',
+            name='flat_rate',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AlterField(
+            model_name='agency',
+            name='name',
+            field=models.CharField(help_text="Don't make crappy names!", verbose_name='Name', max_length=200),
+        ),
+    ]

--- a/tock/projects/models.py
+++ b/tock/projects/models.py
@@ -22,6 +22,7 @@ class AccountingCode(models.Model):
     agency = models.ForeignKey(Agency)
     office = models.CharField(max_length=200, blank=True)
     billable = models.BooleanField(default=False)
+    flat_rate = models.BooleanField(default=False)
 
     class Meta:
         verbose_name = "Accounting Code"


### PR DESCRIPTION
add flat rate option to accounting codes.

per alan d:

1. do migrations need to run for this to take effect?
2. how can we get this field to show up in the admin panel, in the 'modify accounting code' box?