### PR TITLE
Added project detail in API

### DIFF
--- a/tock/api/tests.py
+++ b/tock/api/tests.py
@@ -33,6 +33,13 @@ class ProjectsAPITests(TestCase):
         pass
 
 
+class ProjectInstanceAPITests(WebTest):
+    fixtures = FIXTURES
+
+    def test_projects_json(self):
+        res = self.app.get(reverse('ProjectInstanceView', kwargs={'pk': '29'}))
+        self.assertEqual(res.json['name'], "Consulting - Agile BPA")
+
 class UsersAPITests(TestCase):
     fixtures = FIXTURES
 

--- a/tock/api/urls.py
+++ b/tock/api/urls.py
@@ -9,6 +9,7 @@ from api import views
 
 urlpatterns = patterns('',
     url(r'^projects.(?P<format>csv|json)$', views.ProjectList.as_view(), name='ProjectList'),
+    url(r'^projects/(?P<pk>\d+).json$',view=views.ProjectInstanceView.as_view(),name='ProjectInstanceView'),
     url(r'^users.(?P<format>csv|json)$', views.UserList.as_view(), name='UserList'),
     url(r'^timecards.(?P<format>csv|json)$', views.TimecardList.as_view(), name='TimecardList'),
     url(r'^project_timeline.csv$', views.project_timeline_view, name='ProjectTimelineView'),

--- a/tock/api/views.py
+++ b/tock/api/views.py
@@ -78,6 +78,13 @@ class ProjectList(generics.ListAPIView):
     serializer_class = ProjectSerializer
     pagination_class = StandardResultsSetPagination
 
+class ProjectInstanceView(generics.RetrieveAPIView):
+    """ Return the details of a specific project """
+    queryset =  Project.objects.all()
+    model = Project
+    serializer_class = ProjectSerializer
+
+
 class UserList(generics.ListAPIView):
     queryset = User.objects.all()
     serializer_class = UserSerializer


### PR DESCRIPTION
One of the features that I'm hoping to eventually use is the ability
to connect Tock data with other data. Given that Tock stores some
descriptive metadata, I wanted to be able to access that data at the project
level. In other words, this PR would expose the following endpoint:

`/api/projects/:number.json`