### PR TITLE
Allow more than 40

### DIFF
--- a/tock/hours/migrations/0011_auto_20151203_1532.py
+++ b/tock/hours/migrations/0011_auto_20151203_1532.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.core.validators
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('hours', '0010_auto_20150519_1436'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='reportingperiod',
+            name='working_hours',
+            field=models.PositiveSmallIntegerField(validators=[django.core.validators.MaxValueValidator(60)], default=40),
+        ),
+    ]

--- a/tock/hours/models.py
+++ b/tock/hours/models.py
@@ -10,7 +10,7 @@ class ReportingPeriod(ValidateOnSaveMixin, models.Model):
     end_date = models.DateField()
     working_hours = models.PositiveSmallIntegerField(
         default=40,
-        validators=[MaxValueValidator(40)])
+        validators=[MaxValueValidator(60)])
     message = models.TextField(
         help_text='A message to provide at the top of the reporting period.',
         blank=True)

--- a/tock/hours/models.py
+++ b/tock/hours/models.py
@@ -10,7 +10,7 @@ class ReportingPeriod(ValidateOnSaveMixin, models.Model):
     end_date = models.DateField()
     working_hours = models.PositiveSmallIntegerField(
         default=40,
-        validators=[MaxValueValidator(60)])
+        validators=[MaxValueValidator(80)])
     message = models.TextField(
         help_text='A message to provide at the top of the reporting period.',
         blank=True)

--- a/tock/hours/tests/test_models.py
+++ b/tock/hours/tests/test_models.py
@@ -28,12 +28,12 @@ class ReportingPeriodTests(TestCase):
         self.assertEqual('This is not a vacation', reporting_period.message)
 
     def test_max_reporting_period_length(self):
-        """Check to ensure a reporting period cannot be longer than 40 hours"""
+        """Check to ensure a reporting period cannot be longer than 80 hours"""
         with self.assertRaises(ValidationError):
             hours.models.ReportingPeriod(
                 start_date=datetime.date(2015, 1, 7),
                 end_date=datetime.date(2015, 1, 14),
-                working_hours=45).save()
+                working_hours=85).save()
 
     def test_unique_constraint(self):
         """ Check that unique constrains work for reporting period """


### PR DESCRIPTION
in response to #262.  this allows an administrator to create reporting periods that are longer than 40 hours.  the only use case for this at present is, via admin privileges, modifying prior reporting periods to increase the hours ceiling and then modifying applicable time cards to include extra hours.  after modifications to individual timecards are made, the ceiling should be lowered back to 40 hours.

@geramirez mind taking a look?

cc @HuixianXu