### PR TITLE
Closes #236:  Update README with missing setup step

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This will provision an entire setup for you pretty quickly (see `provision/dev/b
 $ vagrant ssh
 $ cd /vagrant/tock
 $ pyenv activate tock
+$ python manage.py loaddata prod_user projects
 $ python manage.py runserver
 ```
 


### PR DESCRIPTION
This changeset addresses a missing step in the README when setting up Tock locally.  The fixture data for a user and for the projects needs to be loaded in order to access the admin site and see any project information.