### PR TITLE
add description to project list

### DIFF
--- a/tock/tock/templates/projects/project_list.html
+++ b/tock/tock/templates/projects/project_list.html
@@ -27,7 +27,9 @@
       <a href="/projects/{{ project.id }}">{{ project.name }}</a>
     </td>
     <td>{{ project.id }}</td>
+    <td>{{ project.description}}</td>
   </tr>
+
   {% endfor %}
 </table>
 


### PR DESCRIPTION
adds a description to the /projects/ page, along side the name and ID of the project  cc @lanebecker 