### PR TITLE
Clarify Tock Projects == Billable

### DIFF
--- a/tock/tock/templates/projects/project_detail.html
+++ b/tock/tock/templates/projects/project_detail.html
@@ -2,7 +2,7 @@
 {% load project_tags %}
 
 {% block content %}
-<h2><a href="{% url 'ProjectListView' %}">Tock Projects</a> / {{ object.name }}</h2>
+<h2><a href="{% url 'ProjectListView' %}">Tock Billable Projects</a> / {{ object.name }}</h2>
 
 <p class="project__description">{{ object.description|default:'(no description)' }}</p>
 


### PR DESCRIPTION
It seemed from the slack discussion project == billable, so I thought
it worth making explicit and obvious.