### PR TITLE
Save timecard functionality (micro-purchase auction)

### DIFF
--- a/tock/api/views.py
+++ b/tock/api/views.py
@@ -129,7 +129,7 @@ class ReportingPeriodAudit(generics.ListAPIView):
         filed_users = list(
             Timecard.objects.filter(
                 reporting_period=reporting_period,
-                time_spent__isnull=False
+                submitted=True
             ).distinct().all().values_list('user__id', flat=True))
         return get_user_model().objects \
             .exclude(user_data__start_date__gte=reporting_period.end_date) \

--- a/tock/api/views.py
+++ b/tock/api/views.py
@@ -223,6 +223,13 @@ def get_timecards(queryset, params=None):
     * if `project` is provided as a numeric id or name, get rows for
       that project.
     """
+
+    # include only submitted timecards unless submitted=no in params
+    submitted = True
+    if params and 'submitted' in params:
+        submitted = params['submitted'] != 'no'
+    queryset = queryset.filter(timecard__submitted=submitted)
+
     if not params:
         return queryset
 
@@ -278,6 +285,7 @@ with agg as (
     join hours_reportingperiod rp on tc.reporting_period_id = rp.id
     join projects_project pr on tco.project_id = pr.id
     join projects_accountingcode ac on pr.accounting_code_id = ac.id
+    where tc.submitted = True
     group by
         year,
         quarter,
@@ -332,6 +340,7 @@ with agg as (
     join auth_user usr on tc.user_id = usr.id
     join projects_project pr on tco.project_id = pr.id
     join projects_accountingcode ac on pr.accounting_code_id = ac.id
+    where tc.submitted = True
     group by
         year,
         quarter,

--- a/tock/hours/factories.py
+++ b/tock/hours/factories.py
@@ -29,6 +29,7 @@ class TimecardFactory(DjangoModelFactory):
         model = models.Timecard
     user = factory.SubFactory(UserFactory)
     reporting_period = factory.SubFactory(ReportingPeriodFactory)
+    submitted = True
 
 
 class TimecardObjectFactory(DjangoModelFactory):

--- a/tock/hours/fixtures/timecards.json
+++ b/tock/hours/fixtures/timecards.json
@@ -12,6 +12,7 @@
     "fields": {
       "user": 1,
       "reporting_period": 1,
+      "submitted": true,
       "created": "2015-06-08T12:00:00.000Z",
       "modified": "2015-06-08T12:00:00.000Z"
     },
@@ -27,5 +28,70 @@
       "modified": "2015-06-08T12:00:00.000Z"
     },
     "pk": 1
+  },
+
+
+  {
+    "model": "hours.reportingperiod",
+    "fields": {
+      "start_date": "2016-06-01",
+      "end_date": "2016-06-08"
+    },
+    "pk": 2
+  },
+  {
+    "model": "hours.timecard",
+    "fields": {
+      "user": 1,
+      "reporting_period": 2,
+      "submitted": true,
+      "created": "2016-06-08T12:00:00.000Z",
+      "modified": "2016-06-08T12:00:00.000Z"
+    },
+    "pk": 2
+  },
+  {
+    "model": "hours.timecardobject",
+    "fields": {
+      "timecard": 2,
+      "project": 1,
+      "hours_spent": 20,
+      "created": "2016-06-08T12:00:00.000Z",
+      "modified": "2016-06-08T12:00:00.000Z"
+    },
+    "pk": 2
+  },
+
+
+  {
+    "model": "hours.reportingperiod",
+    "fields": {
+      "start_date": "2017-06-01",
+      "end_date": "2017-06-08"
+    },
+    "pk": 3
+  },
+  {
+    "model": "hours.timecard",
+    "fields": {
+      "user": 1,
+      "reporting_period": 3,
+      "submitted": false,
+      "created": "2017-06-08T12:00:00.000Z",
+      "modified": "2017-06-08T12:00:00.000Z"
+    },
+    "pk": 3
+  },
+  {
+    "model": "hours.timecardobject",
+    "fields": {
+      "timecard": 3,
+      "project": 1,
+      "hours_spent": 20,
+      "created": "2017-06-08T12:00:00.000Z",
+      "modified": "2017-06-08T12:00:00.000Z"
+    },
+    "pk": 3
   }
+
 ]

--- a/tock/hours/forms.py
+++ b/tock/hours/forms.py
@@ -158,8 +158,11 @@ class TimecardObjectForm(forms.ModelForm):
 
 
 class TimecardInlineFormSet(BaseInlineFormSet):
-    """This FormSet is used for submissions of timecard entries. Right now,
-      it only works for initial entries and not for updates :/"""
+    """This FormSet is used for submissions of timecard entries."""
+
+    def __init__(self, *args, **kwargs):
+        super(TimecardInlineFormSet, self).__init__(*args, **kwargs)
+        self.save_only = False
 
     def set_working_hours(self, working_hours):
         """ Set the number of hours employees should work """
@@ -171,7 +174,8 @@ class TimecardInlineFormSet(BaseInlineFormSet):
 
     def clean(self):
         super(TimecardInlineFormSet, self).clean()
-        total_number_of_hours = 0
+
+        total_hrs = 0
         for form in self.forms:
             if form.cleaned_data:
                 if not form.cleaned_data.get('hours_spent'):
@@ -179,10 +183,12 @@ class TimecardInlineFormSet(BaseInlineFormSet):
                         'If you have a project listed, the number of hours '
                         'cannot be blank'
                     )
-                total_number_of_hours += form.cleaned_data.get('hours_spent')
-        if total_number_of_hours != self.get_working_hours():
+                total_hrs += form.cleaned_data.get('hours_spent')
+
+        if not self.save_only and total_hrs != self.get_working_hours():
             raise forms.ValidationError(
                 'You must report exactly %s hours.' % self.get_working_hours())
+
         return getattr(self, 'cleaned_data', None)
 
 

--- a/tock/hours/migrations/0014_timecard_submitted.py
+++ b/tock/hours/migrations/0014_timecard_submitted.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+def backfill(apps, schema_editor):
+    timecard_model = apps.get_model("hours", "Timecard")
+    to_submit = timecard_model.objects.filter(time_spent__isnull=False)
+    to_submit.update(submitted=True)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('hours', '0013_timecardobject_notes'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='timecard',
+            name='submitted',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.RunPython(backfill),
+    ]

--- a/tock/hours/models.py
+++ b/tock/hours/models.py
@@ -42,6 +42,7 @@ class Timecard(models.Model):
     user = models.ForeignKey(User)
     reporting_period = models.ForeignKey(ReportingPeriod)
     time_spent = models.ManyToManyField(Project, through='TimecardObject')
+    submitted = models.BooleanField(default=False)
     created = models.DateTimeField(auto_now_add=True)
     modified = models.DateTimeField(auto_now=True)
 

--- a/tock/hours/templatetags/has_submitted_timesheet.py
+++ b/tock/hours/templatetags/has_submitted_timesheet.py
@@ -8,6 +8,6 @@ register = template.Library()
 def has_submitted_timesheet(user, reporting_period):
     return Timecard.objects.filter(
         reporting_period=reporting_period,
-        time_spent__isnull=False,
+        submitted=True,
         user=user
     ).exists()

--- a/tock/hours/tests/test_forms.py
+++ b/tock/hours/tests/test_forms.py
@@ -6,7 +6,10 @@ from django.contrib.auth import get_user_model
 import hours.models
 import projects.models
 
-from hours.forms import TimecardForm, TimecardObjectForm, TimecardFormSet, projects_as_choices
+from hours.forms import (
+    TimecardForm, TimecardObjectForm,
+    TimecardFormSet, projects_as_choices
+)
 
 
 class TimecardFormTests(TestCase):
@@ -137,6 +140,14 @@ class TimecardInlineFormSetTests(TestCase):
         formset = TimecardFormSet(form_data)
         self.assertTrue(formset.is_valid())
 
+    def test_timecard_inline_formset_save_only(self):
+        """ Test formset's save_only field """
+        form_data = self.form_data()
+        formset = TimecardFormSet(form_data)
+        self.assertFalse(formset.save_only)  # default
+        formset.save_only = True
+        self.assertTrue(formset.save_only)
+
     def test_timecard_is_not_100(self):
         """ Test timecard form data that doesn't total the set working
         hours """
@@ -186,6 +197,17 @@ class TimecardInlineFormSetTests(TestCase):
         formset = TimecardFormSet(form_data)
         formset.set_working_hours(16)
         self.assertFalse(formset.is_valid())
+
+    def test_reporting_period_with_less_than_40_hours_success_save_mode(self):
+        """ Test the timecard form when the reporting period is less than
+        40 hours a week and you save (not submit) """
+        form_data = self.form_data()
+        form_data['timecardobject_set-0-hours_spent'] = '5'
+        form_data['timecardobject_set-1-hours_spent'] = '5'
+        formset = TimecardFormSet(form_data)
+        formset.set_working_hours(16)
+        formset.save_only = True
+        self.assertTrue(formset.is_valid())
 
     def test_one_project_with_notes_and_one_without_notes_is_invalid(self):
         """ Test the timecard form when one entry requires notes and another

--- a/tock/hours/tests/test_templatetags.py
+++ b/tock/hours/tests/test_templatetags.py
@@ -21,6 +21,7 @@ class TemplateTagTests(TestCase):
         self.user = get_user_model().objects.get(id=1)
         self.timecard = hours.models.Timecard.objects.create(
             user=self.user,
+            submitted=True,
             reporting_period=self.reporting_period)
         self.project_1 = projects.models.Project.objects.get(name="openFEC")
         self.project_2 = projects.models.Project.objects.get(

--- a/tock/hours/tests/test_views.py
+++ b/tock/hours/tests/test_views.py
@@ -230,21 +230,65 @@ class ReportTests(WebTest):
             len(response.html.find_all('tr', {'class': 'user'})), 2
         )
 
-    def test_ReportingPeriodDetailView_unsubmitted_time(self):
+    def test_ReportingPeriodDetailView_add_submitted_time(self):
         """
-        Check that the ReportingPeriodDetailView only shows users
-        with submitted timecards
+        Check that ReportingPeriodDetailView properly allocates
+        those who filled out (submitted) time vs. not
         """
-        self.timecard.submitted = False
-        self.timecard.save()
+
+        self.timecard = hours.models.Timecard.objects.create(
+            user=self.regular_user,
+            submitted=True,
+            reporting_period=self.reporting_period
+        )
+
         response = self.app.get(
             reverse(
                 'reports:ReportingPeriodDetailView',
                 kwargs={'reporting_period': '2015-01-01'},
             )
         )
+
+        tables = response.html.find_all('table')
+        not_filed_time = tables[0]
+        filed_time = tables[1]
+
         self.assertEqual(
-            len(response.html.find_all('tr', {'class': 'user'})), 1
+            len(not_filed_time.find_all('tr', {'class': 'user'})), 0
+        )
+        self.assertEqual(
+            len(filed_time.find_all('tr', {'class': 'user'})), 2
+        )
+
+
+    def test_ReportingPeriodDetailView_add_unsubmitted_time(self):
+        """
+        Check that ReportingPeriodDetailView properly allocates
+        those who filled out (submitted) time vs. not, another example
+        """
+
+        self.timecard = hours.models.Timecard.objects.create(
+            user=self.regular_user,
+            submitted=False,
+            reporting_period=self.reporting_period
+        )
+
+        response = self.app.get(
+            reverse(
+                'reports:ReportingPeriodDetailView',
+                kwargs={'reporting_period': '2015-01-01'},
+            )
+        )
+
+        tables = response.html.find_all('table')
+        not_filed_time = tables[0]
+        filed_time = tables[1]
+
+        self.assertEqual(
+            len(not_filed_time.find_all('tr', {'class': 'user'})), 1
+        )
+        self.assertEqual(
+            len(filed_time.find_all('tr', {'class': 'user'})), 1
         )
 
     def test_ReportingPeriodDetailView_current_employee_toggle(self):

--- a/tock/hours/views.py
+++ b/tock/hours/views.py
@@ -35,7 +35,7 @@ class ReportingPeriodListView(PermissionMixin, ListView):
         context = super(
             ReportingPeriodListView, self).get_context_data(**kwargs)
         context['completed_reporting_periods'] = self.queryset.filter(
-            timecard__time_spent__isnull=False,
+            timecard__submitted=True,
             timecard__user=self.request.user.id
         ).distinct().order_by('-start_date')[:5]
 
@@ -44,14 +44,14 @@ class ReportingPeriodListView(PermissionMixin, ListView):
                 timecard__user=self.request.user.id).exclude(
                 end_date__lte=self.request.user.user_data.start_date)
             unfinished_reporting_periods = self.queryset.filter(
-                timecard__time_spent__isnull=True,
+                timecard__submitted=False,
                 timecard__user=self.request.user.id).exclude(
                 end_date__lte=self.request.user.user_data.start_date)
         except ValueError:
             unstarted_reporting_periods = self.queryset.exclude(
                 timecard__user=self.request.user)
             unfinished_reporting_periods = self.queryset.filter(
-                timecard__time_spent__isnull=True,
+                timecard__submitted=False,
                 timecard__user=self.request.user)
 
         context['uncompleted_reporting_periods'] = sorted(list(chain(

--- a/tock/projects/tests.py
+++ b/tock/projects/tests.py
@@ -107,6 +107,7 @@ class TestProjectTimeline(WebTest):
             TimecardObject.objects.create(
                 timecard=Timecard.objects.create(
                     user=self.user,
+                    submitted=True,
                     reporting_period=ReportingPeriod.objects.create(
                         start_date=date,
                         end_date=date + datetime.timedelta(days=6),

--- a/tock/projects/views.py
+++ b/tock/projects/views.py
@@ -51,6 +51,10 @@ def project_timeline(project, period_limit=5):
         tc = t.timecard
         report_date = tc.reporting_period.start_date
 
+        # skip if timecard not submitted yet
+        if not tc.submitted:
+            continue
+
         # add report date to period array if not present
         # if period limit set, stop after limit reached
         if report_date not in periods:

--- a/tock/tock/templates/hours/timecard_form.html
+++ b/tock/tock/templates/hours/timecard_form.html
@@ -69,7 +69,8 @@
       <div class="entries-total-reported-wrapper">
         Total: <span class="entries-total-reported-amount">0</span> hours
       </div>
-      <button type="submit" class="btn btn-primary">Submit Timecard</button>
+      <button type="button" class="btn btn-primary" id="save-timecard">Save</button>
+      <button type="submit" class="btn btn-primary">Submit</button>
     </div>
   </div>
  </form>
@@ -128,6 +129,14 @@
 
 
 $( document ).ready(function() {
+    $("#save-timecard").on("click", function() {
+      var form = $('form'),
+          save_input = '<input type="hidden" name="save_only" value="1"/>';
+
+      form.append(save_input);
+      form.submit();
+    });
+
     $(".add-timecard-entry").on( "click", function() {
         $('div.entry:last').clone().each(function(i) {
           var entry = $(this);


### PR DESCRIPTION
This PR addresses [issue #288](https://github.com/18F/tock/issues/288). This code adds functionality to save hours throughout the week (without submitting).

A summary of the additions & changes:

#### New `submitted` field in `Timecard` model

This is a boolean field and defaulted to `False`. All existing timecards where `time_spent__isnull=False` are backfilled to `submitted=True` in the migration script (see `hours/migrations/0014_timecard_submitted.py`)

#### Save button added

On the timesheet form page, there is now a "Save" button alongside the "Submit" button. 

If a user clicks "Save", the `timecard` and `timecard_objects` are added / updated in the database but the `submitted` field on the `timecard` object remains / is set to `False`. After a successful "Save", the user remains on the same page (vs. after a "Submit" which redirects the user to the homepage).

#### API tweaks

Saved but not submitted timecards are excluded by default in the relevant endpoints.

To see the saved but not submitted timecard data, one can add `submitted=no` as a URL parameter, for example, `/api/timecards.json?submitted=no`

I believe all other references to submitted timecards throughout the codebase have been updated.

#### Tests

New unit tests have been added (and existing ones adjusted) to reflect the changes to `hours.forms`, `hours.views`, and `api.views` 

All new code is [PEP 8](https://www.python.org/dev/peps/pep-0008/) compliant.  
