### PR TITLE
Include Client Name in Project API Results

### DIFF
--- a/data-reconciliation.md
+++ b/data-reconciliation.md
@@ -1,0 +1,16 @@
+# Data Reconciliation
+
+18F uses Tock to track past staff project allocations and uses
+[Float](https://www.float.com/) to predict future staff project allocations.
+Both systems contain very similar information but with very different temporal
+aspects: Tock contains historical data, while Float contains projected future
+data. However, the data elements are very similar.
+
+Since both applications are used for managing the business of 18F, it is
+critical that the common data elements between the two are regularly
+reconciled. For instance, analysis quickly breaks down if a project in Float
+has a name attribute that varies from the project name attribute in Tock.
+
+To reconcile the names of users, clients, and projects between Tock and Float,
+a command-line tool named [onena](https://github.com/cwarden/onena) can be
+used, which will help identify similar, but not exact matches.

--- a/tock/api/views.py
+++ b/tock/api/views.py
@@ -33,11 +33,13 @@ class ProjectSerializer(serializers.ModelSerializer):
         model = Project
         fields = (
             'id',
+            'client',
             'name',
             'description',
             'billable',
         )
     billable = serializers.BooleanField(source='accounting_code.billable')
+    client = serializers.StringRelatedField(source='accounting_code')
 
 class UserSerializer(serializers.ModelSerializer):
     class Meta:


### PR DESCRIPTION
Include the client name (accounting code and agency) with each project
when retrieving a project list using the Tock API to allow
reconciliation with Float.  See https://micropurchase.18f.gov/auctions/11

*Since the data reconciliation tool is a new application written in a different language than Tock, I put it in a [separate repo](https://github.com/cwarden/onena).  If you would prefer that I include the source within the Tock repo, or pull it in as submodule, let me know.*