### PR TITLE
0-60 hours for superusers

### DIFF
--- a/tock/hours/admin.py
+++ b/tock/hours/admin.py
@@ -33,26 +33,26 @@ class TimecardObjectFormset(BaseInlineFormSet):
 
         hours = Decimal(0.0)
         superuser_hours = Decimal(60.0)
-        more_than_60 = False
+        zero_to_60 = False
         working_hours = self.instance.reporting_period.working_hours
         for unit in self.cleaned_data:
             try:
                 hours = hours + unit['hours_spent']
-                more_than_60 = unit['timecard'].more_than_60
+                zero_to_60 = unit['timecard'].zero_to_60
             except KeyError:
                 pass
 
-        if hours > working_hours and not more_than_60:
+        if hours > working_hours and not zero_to_60:
             raise ValidationError(
                 'You have entered more than %s hours' % working_hours
             )
 
-        if hours > superuser_hours and more_than_60:
+        if hours > superuser_hours and zero_to_60:
             raise ValidationError(
                 'You have entered more than %s hours' % superuser_hours
             )
 
-        if hours < working_hours:
+        if hours < working_hours and not zero_to_60:
             raise ValidationError(
                 'You have entered fewer than %s hours' % working_hours
             )

--- a/tock/hours/admin.py
+++ b/tock/hours/admin.py
@@ -32,17 +32,24 @@ class TimecardObjectFormset(BaseInlineFormSet):
             return
 
         hours = Decimal(0.0)
+        superuser_hours = Decimal(60.0)
+        more_than_60 = False
         working_hours = self.instance.reporting_period.working_hours
-
         for unit in self.cleaned_data:
             try:
                 hours = hours + unit['hours_spent']
+                more_than_60 = unit['timecard'].more_than_60
             except KeyError:
                 pass
 
-        if hours > working_hours:
+        if hours > working_hours and not more_than_60:
             raise ValidationError(
                 'You have entered more than %s hours' % working_hours
+            )
+
+        if hours > superuser_hours and more_than_60:
+            raise ValidationError(
+                'You have entered more than %s hours' % superuser_hours
             )
 
         if hours < working_hours:

--- a/tock/hours/admin.py
+++ b/tock/hours/admin.py
@@ -20,6 +20,7 @@ class ReportingPeriodListFilter(admin.SimpleListFilter):
         return queryset
 
 
+
 class TimecardObjectFormset(BaseInlineFormSet):
     def clean(self):
         """
@@ -35,6 +36,7 @@ class TimecardObjectFormset(BaseInlineFormSet):
         superuser_hours = Decimal(60.0)
         zero_to_60 = False
         working_hours = self.instance.reporting_period.working_hours
+
         for unit in self.cleaned_data:
             try:
                 hours = hours + unit['hours_spent']
@@ -60,6 +62,7 @@ class TimecardObjectFormset(BaseInlineFormSet):
 
 class ReportingPeriodAdmin(admin.ModelAdmin):
     list_display = ('start_date', 'end_date',)
+    filter_horizontal = ('users',)
 
 
 class TimecardObjectInline(admin.TabularInline):

--- a/tock/hours/migrations/0015_timecard_more_than_60.py
+++ b/tock/hours/migrations/0015_timecard_more_than_60.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('hours', '0014_timecard_submitted'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='timecard',
+            name='more_than_60',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/tock/hours/migrations/0016_auto_20160303_0516.py
+++ b/tock/hours/migrations/0016_auto_20160303_0516.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('hours', '0015_timecard_more_than_60'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='timecard',
+            old_name='more_than_60',
+            new_name='zero_to_60',
+        ),
+    ]

--- a/tock/hours/migrations/0017_remove_timecard_zero_to_60.py
+++ b/tock/hours/migrations/0017_remove_timecard_zero_to_60.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('hours', '0016_auto_20160303_0516'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='timecard',
+            name='zero_to_60',
+        ),
+    ]

--- a/tock/hours/migrations/0018_timecard_zero_to_60.py
+++ b/tock/hours/migrations/0018_timecard_zero_to_60.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('hours', '0017_remove_timecard_zero_to_60'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='timecard',
+            name='zero_to_60',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/tock/hours/migrations/0019_auto_20160304_0135.py
+++ b/tock/hours/migrations/0019_auto_20160304_0135.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('hours', '0018_timecard_zero_to_60'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='reportingperiod',
+            old_name='working_hours',
+            new_name='foo_bar',
+        ),
+    ]

--- a/tock/hours/migrations/0020_auto_20160304_0137.py
+++ b/tock/hours/migrations/0020_auto_20160304_0137.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('hours', '0019_auto_20160304_0135'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='reportingperiod',
+            old_name='foo_bar',
+            new_name='working_hours',
+        ),
+    ]

--- a/tock/hours/migrations/0021_reportingperiod_users.py
+++ b/tock/hours/migrations/0021_reportingperiod_users.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('hours', '0020_auto_20160304_0137'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='reportingperiod',
+            name='users',
+            field=models.ManyToManyField(blank=True, verbose_name='Zero to 60 users', to=settings.AUTH_USER_MODEL),
+        ),
+    ]

--- a/tock/hours/models.py
+++ b/tock/hours/models.py
@@ -43,7 +43,7 @@ class Timecard(models.Model):
     reporting_period = models.ForeignKey(ReportingPeriod)
     time_spent = models.ManyToManyField(Project, through='TimecardObject')
     submitted = models.BooleanField(default=False)
-    more_than_60 = models.BooleanField(default=False)
+    zero_to_60 = models.BooleanField(default=False)
     created = models.DateTimeField(auto_now_add=True)
     modified = models.DateTimeField(auto_now=True)
 

--- a/tock/hours/models.py
+++ b/tock/hours/models.py
@@ -43,6 +43,7 @@ class Timecard(models.Model):
     reporting_period = models.ForeignKey(ReportingPeriod)
     time_spent = models.ManyToManyField(Project, through='TimecardObject')
     submitted = models.BooleanField(default=False)
+    more_than_60 = models.BooleanField(default=False)
     created = models.DateTimeField(auto_now_add=True)
     modified = models.DateTimeField(auto_now=True)
 

--- a/tock/hours/models.py
+++ b/tock/hours/models.py
@@ -15,6 +15,7 @@ class ReportingPeriod(ValidateOnSaveMixin, models.Model):
     message = models.TextField(
         help_text='A message to provide at the top of the reporting period.',
         blank=True)
+    users = models.ManyToManyField(User, verbose_name='Zero to 60 users',  blank=True)
 
     def __str__(self):
         return str(self.start_date)

--- a/tock/hours/tests/test_forms.py
+++ b/tock/hours/tests/test_forms.py
@@ -184,7 +184,7 @@ class TimecardInlineFormSetTests(TestCase):
         form_data['timecardobject_set-1-hours_spent'] = '80'
         self.timecard.zero_to_60 = True
         formset = self.TimecardObjectFormset(form_data, instance=self.timecard)
-        self.assertEqual(formset.is_valid(), True)
+        self.assertEqual(formset.is_valid(), False)
 
     def test_timecard_inline_formset_valid(self):
         """ Test valid timecard data """

--- a/tock/hours/tests/test_forms.py
+++ b/tock/hours/tests/test_forms.py
@@ -178,6 +178,14 @@ class TimecardInlineFormSetTests(TestCase):
         formset = self.TimecardObjectFormset(form_data, instance=self.timecard)
         self.assertEqual(formset.is_valid(), False)
 
+    def test_card_greater_than_superuserworking_hours_w_0_60(self):
+        """ Test hours spent can't be greater than working hours when 0_60 is False"""
+        form_data = self.form_data()
+        form_data['timecardobject_set-1-hours_spent'] = '80'
+        self.timecard.zero_to_60 = True
+        formset = self.TimecardObjectFormset(form_data, instance=self.timecard)
+        self.assertEqual(formset.is_valid(), True)
+
     def test_timecard_inline_formset_valid(self):
         """ Test valid timecard data """
         form_data = self.form_data()

--- a/tock/hours/tests/test_forms.py
+++ b/tock/hours/tests/test_forms.py
@@ -1,7 +1,11 @@
 import datetime
 
+from django import forms
 from django.test import TestCase
 from django.contrib.auth import get_user_model
+from django.forms.models import inlineformset_factory
+
+from hours.models import Timecard, TimecardObject, ReportingPeriod
 
 import hours.models
 import projects.models
@@ -9,6 +13,10 @@ import projects.models
 from hours.forms import (
     TimecardForm, TimecardObjectForm,
     TimecardFormSet, projects_as_choices
+)
+
+from hours.admin import (
+    TimecardObjectFormset
 )
 
 
@@ -104,6 +112,9 @@ class TimecardInlineFormSetTests(TestCase):
             start_date=datetime.date(2015, 1, 1),
             end_date=datetime.date(2015, 1, 7),
             working_hours=40)
+        self.TimecardObjectFormset = inlineformset_factory(Timecard, TimecardObject,
+                                                        extra=1,form=TimecardObjectForm,
+                                                        formset=TimecardObjectFormset)
         self.user = get_user_model().objects.get(id=1)
         self.project_1 = projects.models.Project.objects.get(name="openFEC")
         self.project_2 = projects.models.Project.objects.get(
@@ -114,7 +125,8 @@ class TimecardInlineFormSetTests(TestCase):
         self.project_3.save()
         self.timecard = hours.models.Timecard.objects.create(
             reporting_period=self.reporting_period,
-            user=self.user)
+            user=self.user,
+            zero_to_60 = True)
 
     def form_data(self, clear=[], **kwargs):
         """ Method that auto generates form data for tests """
@@ -133,6 +145,38 @@ class TimecardInlineFormSetTests(TestCase):
         for key, value in kwargs.items():
             form_data[key] = value
         return form_data
+
+    def test_card_less_than_working_hours_wout_0_60(self):
+        """ Test hours spent can't be less than working hours when 0_60 is False"""
+        form_data = self.form_data()
+        form_data['timecardobject_set-1-hours_spent'] = '1'
+        self.timecard.zero_to_60 = False
+        formset = self.TimecardObjectFormset(form_data, instance=self.timecard)
+        self.assertEqual(formset.is_valid(), False)
+
+    def test_card_less_than_working_hours_w_0_60(self):
+        """ Test hours spent can be less than working hours when 0_60 is True"""
+        form_data = self.form_data()
+        form_data['timecardobject_set-1-hours_spent'] = '1'
+        self.timecard.zero_to_60 = True
+        formset = self.TimecardObjectFormset(form_data, instance=self.timecard)
+        self.assertEqual(formset.is_valid(), True)
+
+    def test_card_greater_than_working_hours_w_0_60(self):
+        """ Test hours spent can be greater than working hours when 0_60 is True"""
+        form_data = self.form_data()
+        form_data['timecardobject_set-1-hours_spent'] = '21'
+        self.timecard.zero_to_60 = True
+        formset = self.TimecardObjectFormset(form_data, instance=self.timecard)
+        self.assertEqual(formset.is_valid(), True)
+
+    def test_card_greater_than_working_hours_wout_0_60(self):
+        """ Test hours spent can't be greater than working hours when 0_60 is False"""
+        form_data = self.form_data()
+        form_data['timecardobject_set-1-hours_spent'] = '21'
+        self.timecard.zero_to_60 = False
+        formset = self.TimecardObjectFormset(form_data, instance=self.timecard)
+        self.assertEqual(formset.is_valid(), False)
 
     def test_timecard_inline_formset_valid(self):
         """ Test valid timecard data """

--- a/tock/projects/migrations/0007_auto_20160303_0402.py
+++ b/tock/projects/migrations/0007_auto_20160303_0402.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('projects', '0006_auto_20151229_1618'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='project',
+            options={'verbose_name': 'Project', 'verbose_name_plural': 'Projects', 'ordering': ('name',)},
+        ),
+    ]


### PR DESCRIPTION
This addresses #287 

I am beginning to work on https://micropurchase.18f.gov/auctions/12 and have a few questions. 
- I've got the development environment running, however, there are intermittent 502 errors. Has this been experienced before? Are there solutions to fix this? Below is an example

![Image of Yaktocat](http://i.imgur.com/ucnmIc4.png)
- The Readme.md mentions that by default the logged in user will be testuser@gsa.gov. Is this an admin user that is supposed to be able to enter > 40 hours?
- Is this the screen there the change needs to happen? If so, where should the checkmark go? The screenshot below shows an error when hours more than 40 hours were entered. 
  ![Image of Yaktocat](http://i.imgur.com/GIRrCEl.png)
