### PR TITLE
Add docker compose setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.4
+MAINTAINER Mila Frerichs mila@civicvision.de
+
+RUN mkdir /tock
+WORKDIR /tock
+
+COPY requirements.txt /tock
+COPY requirements-dev.txt /tock
+
+RUN pip install -r requirements.txt
+RUN pip install -r requirements-dev.txt
+
+COPY tock /tock
+
+EXPOSE 4001
+
+CMD ["waitress-serve", "--port=4001", "tock.wsgi:application"]

--- a/README.md
+++ b/README.md
@@ -41,6 +41,41 @@ $ python manage.py runserver
 
 From your host computer, going to http://192.168.33.10 will enable you to view Tock. You're automatically logged in as `testuser@gsa.gov`, the nginx proxy in production will pull the logged in user from Google Auth proxy. You can access the admin panel at http://192.168.33.10/admin
 
+### Using Docker
+
+To use Tock with docker make sure you have the latest version fo docker installed.
+To build a new image run:
+```shell
+$ docker-compose build tock
+```
+After the initial build you should run:
+```shell
+$ scripts/docker-migrate.sh
+```
+This will run all the migrations.
+
+If you want to include test data run
+```shell
+$ scripts/docker-seed.sh
+```
+
+To run tests with docker simply run
+```shell
+$ scripts/docker-test.sh
+```
+
+To create a running instance use
+```shell
+$ docker-compose up
+```
+
+or
+```shell
+$ docker-compose up -d
+```
+to run it in the background.
+Now you can visit your browser and go to http://192.168.100.99/employees or another IP depending on your docker setup.
+
 ### Making SASS changes
 
 In order to make official changes to the styling of the website, you'll need to compile locally and submit the files accordingly. All of the files you should be editing are located in `tock/tock/static/sass/` and are labeled according to their purpose, e.g. `base/_typography.scss` focuses on website type stylings.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '2'
+services:
+  tock:
+    build: .
+    command: python manage.py runserver 0.0.0.0:4001
+    env_file: .env
+    ports:
+      - 80:4001
+    links:
+      - db:db
+
+  db:
+    image: postgres
+    environment:
+      - POSTGRES_USER=tock
+      - POSTGRES_PASSWORD=tock
+      - POSTGRES_DB=tock
+      - PGPASSWORD=tock
+      - PGPUSER=tock

--- a/scripts/docker-migrate.sh
+++ b/scripts/docker-migrate.sh
@@ -1,0 +1,1 @@
+docker-compose run tock python manage.py migrate --settings=tock.settings.dev --noinput

--- a/scripts/docker-seed.sh
+++ b/scripts/docker-seed.sh
@@ -1,0 +1,1 @@
+docker-compose run tock python manage.py loaddata test_data/data-update.json

--- a/scripts/docker-test.sh
+++ b/scripts/docker-test.sh
@@ -1,0 +1,3 @@
+docker-compose run db psql -h db -U tock -c 'CREATE DATABASE IF NOT EXISTS "tock-test"'
+docker-compose run tock python manage.py syncdb --noinput --settings=tock.settings.test
+docker-compose run tock python manage.py test --noinput --settings=tock.settings.test

--- a/tock/tock/settings/dev.py
+++ b/tock/tock/settings/dev.py
@@ -1,4 +1,5 @@
 from .base import *  # noqa
+import os
 
 DEBUG = True
 TEMPLATE_DEBUG = True
@@ -12,7 +13,7 @@ DATABASES = {
         # The following settings are not used with sqlite3:
         'USER': 'tock',
         'PASSWORD': 'tock',
-        'HOST': 'localhost',                      # Empty for localhost through domain sockets or           '127.0.0.1' for localhost through TCP.
+        'HOST': os.environ.get('DATABASE_HOST'),
         'PORT': '',                      # Set to empty string for default.
     }
 }

--- a/tock/tock/settings/test.py
+++ b/tock/tock/settings/test.py
@@ -1,4 +1,5 @@
 from .base import *  # noqa
+import os
 
 from django.utils.crypto import get_random_string
 
@@ -8,7 +9,9 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
         'NAME': 'tock-test',
-        'HOST': 'localhost',
+        'HOST': os.environ.get('DATABASE_HOST'),
+        'USER': 'tock',
+        'PASSWORD': 'tock',
     }
 }
 


### PR DESCRIPTION
## What does this PR do?

It adds docker-compose version 2 setup to create a local environment for tock. 
Make sure to have the latest version of Docker and docker-compose installed.

All commands are explained in the Readme.
This is part of the Micropurchase Experiment from 18f.

### A few comments
I opted to use shell scripts to run specific commands. Almost everything can be used in a production environment. 
