### PR TITLE
allow for saving/submitting 0 hour entries

### DIFF
--- a/tock/hours/forms.py
+++ b/tock/hours/forms.py
@@ -180,7 +180,7 @@ class TimecardInlineFormSet(BaseInlineFormSet):
             if form.cleaned_data:
                 if form.cleaned_data.get('DELETE'):
                     continue
-                if not form.cleaned_data.get('hours_spent'):
+                if form.cleaned_data.get('hours_spent') is None:
                     raise forms.ValidationError(
                         'If you have a project listed, the number of hours '
                         'cannot be blank'

--- a/tock/hours/tests/test_forms.py
+++ b/tock/hours/tests/test_forms.py
@@ -176,7 +176,7 @@ class TimecardInlineFormSetTests(TestCase):
         form_data['timecardobject_set-2-hours_spent'] = 0
         form_data['timecardobject_set-TOTAL_FORMS'] = '3'
         formset = TimecardFormSet(form_data)
-        self.assertFalse(formset.is_valid())
+        self.assertTrue(formset.is_valid())
 
     def test_reporting_period_with_less_than_40_hours_success(self):
         """ Test the timecard form when the reporting period is less than


### PR DESCRIPTION
This PR allows you to save / submit entries with 0 hours. If the hours input is left blank, you will still get the usual validation error ("the number of hours cannot be blank").

This addresses https://github.com/18F/tock/issues/339 and https://github.com/18F/tock/issues/338