### PR TITLE
clear checkbox when new line item added to page

### DIFF
--- a/tock/tock/templates/hours/timecard_form.html
+++ b/tock/tock/templates/hours/timecard_form.html
@@ -153,6 +153,7 @@ $( document ).ready(function() {
           entry.find('#entry-notes .invalid').remove();
           entry.find('select').show();
           entry.find('input, select, textarea').val('');
+          entry.find(':checkbox').prop('checked', false);
 
           // Remove any existing values
           entry.val('');


### PR DESCRIPTION
This PR addresses feedback by Jay Huie in Slack: "1) I think there’s a small “tock bug” - where I had one item (the last in the list) to be deleted then did “add new item” and it seemed to inherit that checkbox status."