### PR TITLE
add org data to employee model

### DIFF
--- a/tock/employees/admin.py
+++ b/tock/employees/admin.py
@@ -1,0 +1,9 @@
+from django.contrib import admin
+from django.forms.models import BaseInlineFormSet
+
+from .models import UserData
+
+class EmployeeDataAdmin(admin.ModelAdmin):
+    list_display = ('user',)
+
+admin.site.register(UserData)

--- a/tock/employees/migrations/0007_auto_20160428_0105.py
+++ b/tock/employees/migrations/0007_auto_20160428_0105.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('employees', '0006_userdata_current_employee'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='userdata',
+            options={'verbose_name_plural': 'Employees', 'verbose_name': 'Employee'},
+        ),
+        migrations.AddField(
+            model_name='userdata',
+            name='is_18f_employee',
+            field=models.BooleanField(verbose_name='18F Employee', default=True),
+        ),
+        migrations.AddField(
+            model_name='userdata',
+            name='unit',
+            field=models.IntegerField(verbose_name='Select unit', choices=[(0, 'Operations-Team Operations'), (1, 'Operations-Talent'), (2, 'Operations-Infrastructure'), (3, 'Operations-Front Office'), (4, 'Chapters-Acquisition Managers'), (5, 'Chapters-Engineering'), (6, 'Chapters-Experience Design'), (7, 'Chapters-Product'), (8, 'Chapters-Strategists'), (9, 'Business-Acquisition Services'), (10, 'Business-Custom Partner Solutions'), (11, 'Business-Learn'), (12, 'Business-Products & Platforms'), (13, 'Business-Transformation Services'), (14, 'PIF-Fellows'), (15, 'PIF-Operations'), (16, 'Unknown / N/A')], blank=True, null=True),
+        ),
+        migrations.AlterField(
+            model_name='userdata',
+            name='current_employee',
+            field=models.BooleanField(verbose_name='Current Employee', default=True),
+        ),
+        migrations.AlterField(
+            model_name='userdata',
+            name='end_date',
+            field=models.DateField(verbose_name='Employee end date', null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='userdata',
+            name='start_date',
+            field=models.DateField(verbose_name='Employee start date', null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='userdata',
+            name='user',
+            field=models.OneToOneField(verbose_name='Tock username', to=settings.AUTH_USER_MODEL, related_name='user_data'),
+        ),
+    ]

--- a/tock/employees/models.py
+++ b/tock/employees/models.py
@@ -1,9 +1,38 @@
 from django.db import models
 from django.contrib.auth.models import User
 
-
 class UserData(models.Model):
-    user = models.OneToOneField(User, related_name='user_data')
-    start_date = models.DateField(blank=True, null=True)
-    end_date = models.DateField(blank=True, null=True)
-    current_employee = models.BooleanField(default=True)
+
+    UNIT_CHOICES = (
+        (0, 'Operations-Team Operations'),
+        (1, 'Operations-Talent'),
+        (2, 'Operations-Infrastructure'),
+        (3, 'Operations-Front Office'),
+        (4, 'Chapters-Acquisition Managers'),
+        (5, 'Chapters-Engineering'),
+        (6, 'Chapters-Experience Design'),
+        (7, 'Chapters-Product'),
+        (8, 'Chapters-Strategists'),
+        (9, 'Business-Acquisition Services'),
+        (10, 'Business-Custom Partner Solutions'),
+        (11, 'Business-Learn'),
+        (12, 'Business-Products & Platforms'),
+        (13, 'Business-Transformation Services'),
+        (14, 'PIF-Fellows'),
+        (15, 'PIF-Operations'),
+        (16, 'Unknown / N/A')
+    )
+
+    user = models.OneToOneField(User, related_name='user_data', verbose_name='Tock username')
+    start_date = models.DateField(blank=True, null=True, verbose_name='Employee start date')
+    end_date = models.DateField(blank=True, null=True, verbose_name='Employee end date')
+    current_employee = models.BooleanField(default=True, verbose_name='Current Employee')
+    is_18f_employee = models.BooleanField(default=True, verbose_name='18F Employee')
+    unit = models.IntegerField(null=True, choices=UNIT_CHOICES, verbose_name="Select unit", blank=True)
+
+    class Meta:
+        verbose_name='Employee'
+        verbose_name_plural='Employees'
+
+    def __str__(self):
+        return '%s' % (self.user)

--- a/tock/employees/tests/test_models.py
+++ b/tock/employees/tests/test_models.py
@@ -13,6 +13,8 @@ class UserDataTests(TestCase):
         userdata = UserData(user=self.regular_user)
         userdata.start_date = datetime.date(2014, 1, 1)
         userdata.end_date = datetime.date(2016, 1, 1)
+        userdata.unit = 1
+        userdata.is_18f_employee = True
         userdata.save()
 
     def test_user_data_is_stored(self):
@@ -24,6 +26,7 @@ class UserDataTests(TestCase):
         self.assertEqual(
             userdata.end_date,
             datetime.date(2016, 1, 1))
+        self.assertEqual(userdata.unit, 1)
 
     def test_check_user_data_connected_to_user_model(self):
         """ Check that user data can be retrieved from User Model """
@@ -33,7 +36,11 @@ class UserDataTests(TestCase):
         self.assertEqual(
             self.regular_user.user_data.end_date,
             datetime.date(2016, 1, 1))
-    
+        self.assertEqual(
+            self.regular_user.user_data.unit, 1)
+        self.assertTrue(
+            self.regular_user.user_data.is_18f_employee)
+
     def test_user_data_current_employee_default_is_true(self):
         """ Check that the user data is initalized with the current
         employee value being true """


### PR DESCRIPTION
** replaces #348 which included unnecessary squashing of migration files **

- add employee unit field to employee model
- add choices for employee unit field
- update tests for employee model

purpose of this PR is to append more detailed employee information to tock data for: (1) business analytics; (2) billing information; and (3) end reliance on lower quality spreadsheet based roster information for the prior to items.