### PR TITLE
Allow autocomplete by project number.

### DIFF
--- a/tock/hours/forms.py
+++ b/tock/hours/forms.py
@@ -88,7 +88,7 @@ def projects_as_choices():
             projects.append([
                 project.id,
                 {
-                    'label': project.name,
+                    'label': '%d - %s' % (project.id, project.name),
                     'billable': code.billable,
                     'notes_displayed': project.notes_displayed,
                     'notes_required': project.notes_required,

--- a/tock/hours/forms.py
+++ b/tock/hours/forms.py
@@ -74,6 +74,15 @@ class SelectWithData(forms.widgets.Select):
             conditional_escape(force_text(option_label)))
 
 
+def choice_label_for_project(project):
+    """
+    Returns the label for a project as it should appear in an
+    auto-completable list of choices.
+    """
+
+    return '%s - %s' % (project.id, project.name)
+
+
 def projects_as_choices():
     """ Adds all of the projects in database to the TimeCardObjectForm project
     ChoiceField """
@@ -88,7 +97,7 @@ def projects_as_choices():
             projects.append([
                 project.id,
                 {
-                    'label': '%d - %s' % (project.id, project.name),
+                    'label': choice_label_for_project(project),
                     'billable': code.billable,
                     'notes_displayed': project.notes_displayed,
                     'notes_required': project.notes_required,

--- a/tock/hours/tests/test_forms.py
+++ b/tock/hours/tests/test_forms.py
@@ -8,7 +8,8 @@ import projects.models
 
 from hours.forms import (
     TimecardForm, TimecardObjectForm,
-    TimecardFormSet, projects_as_choices
+    TimecardFormSet, projects_as_choices,
+    choice_label_for_project
 )
 
 
@@ -31,6 +32,10 @@ class TimecardFormTests(TestCase):
             'user': self.user, 'reporting_period': self.reporting_period}
         form = TimecardForm(form_data)
         self.assertTrue(form.is_valid())
+
+    def test_choice_label_for_project(self):
+        self.assertEqual(choice_label_for_project(self.project_1),
+                         '32 - openFEC')
 
     def test_projects_as_choices(self):
         """tests projects_as_choices only returns projects marked active:

--- a/tock/hours/tests/test_integration.py
+++ b/tock/hours/tests/test_integration.py
@@ -5,6 +5,7 @@ from django.contrib.auth import get_user_model
 
 from django_webtest import WebTest
 
+from hours.forms import choice_label_for_project
 import hours.models
 import projects.models
 
@@ -53,12 +54,16 @@ class TestOptions(WebTest):
             self.assertNotIn(each, options)
 
     def test_project_select(self):
-        self._assert_project_options([each.name for each in self.projects])
+        self._assert_project_options([
+            choice_label_for_project(each) for each in self.projects
+        ])
 
     def test_project_select_dynamic(self):
         self.projects[1].delete()
         self._assert_project_options(
-            [self.projects[0].name], [self.projects[1].name])
+            [choice_label_for_project(self.projects[0])],
+            [choice_label_for_project(self.projects[1])]
+        )
 
     def test_admin_page_reportingperiod(self):
         """ Check that admin page reportingperiod works"""

--- a/tock/hours/tests/test_views.py
+++ b/tock/hours/tests/test_views.py
@@ -8,6 +8,7 @@ from django_webtest import WebTest
 from hours.utils import number_of_hours
 
 from employees.models import UserData
+from hours.forms import choice_label_for_project
 import hours.models
 import projects.models
 import hours.views
@@ -134,7 +135,7 @@ class ReportTests(WebTest):
 
         # projects based on last submitted timecard
         last_timecard_projects = set(
-            tco.project.name for tco
+            choice_label_for_project(tco.project) for tco
             in self.timecard.timecardobject_set.all()
         )
 


### PR DESCRIPTION
This fixes #353. As specified in that issue, the project labels are now prefixed with their project ID, followed by a dash:

![2016-06-03_6-54-34](https://cloud.githubusercontent.com/assets/124687/15776766/42ffd51a-2958-11e6-938a-cd3e291b286c.png)

In the above screenshot, typing `99` into the text field would cause **99 - 38r3aG Project** to be chosen. Alternatively, `38r3aG` could also be typed, and the widget would still work as it previously had (i.e., there's no regressions in the UI).

**Note:** I'm assuming here that all users have JS enabled. If they don't, and if the Chosen widget actually appears as a standard `<select>`, then some user habituation could be broken.
