### PR TITLE
Improve Django Debug Toolbar integration with Docker

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -63,4 +63,7 @@ local_settings.py
 
 .DS_Store
 
-.vagrant
+# Docker
+.env
+docker-compose.yml
+Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,8 @@ app:
     - PYTHONUNBUFFERED=yup
     - DATABASE_URL=postgres://tock_user@db/tock
     - RUNNING_IN_DOCKER=yup
-  command: python manage.py runserver 0.0.0.0:8000
+    - DJANGO_SETTINGS_MODULE=tock.settings.dev
+  command: "python manage.py runserver 0.0.0.0:${EXTERNAL_PORT}"
 db:
   image: postgres:9.4
   environment:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ whitenoise==1.0.6
 djangorestframework==3.1.2
 djangorestframework-csv==1.3.3
 bleach==1.4.2
-django-debug-toolbar

--- a/tock/manage.py
+++ b/tock/manage.py
@@ -69,7 +69,10 @@ def wait_for_db(max_attempts=15, seconds_between_attempts=1):
     print("Connection to database established.")
 
 if __name__ == '__main__':
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'tock.settings.dev')
+    os.environ.setdefault(
+        'DJANGO_SETTINGS_MODULE',
+        'tock.settings.production'
+    )
 
     if os.environ.get('RUNNING_IN_DOCKER') == 'yup':
         setup_docker_sigterm_handler()

--- a/tock/tock/settings/base.py
+++ b/tock/tock/settings/base.py
@@ -10,34 +10,40 @@ https://docs.djangoproject.com/en/1.7/ref/settings/
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
+
 from django.utils.crypto import get_random_string
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
-
 DATABASES = {}
-# ALLOWED_HOSTS = []
-# Application definition
-
-INSTALLED_APPS = ('django.contrib.contenttypes',  # may be okay to remove
-                  'django.contrib.staticfiles', 'django.contrib.admin',
-                  'django.contrib.auth', 'django.contrib.sessions',
-                  'django.contrib.messages',
-                  'tock', 'projects', 'hours', 'employees', 'api')
-
 ROOT_URLCONF = 'tock.urls'
 WSGI_APPLICATION = 'tock.wsgi.application'
-
 SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY', get_random_string(50))
+
+INSTALLED_APPS = (
+    'django.contrib.contenttypes',  # may be okay to remove
+    'django.contrib.staticfiles',
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'tock',
+    'projects',
+    'hours',
+    'employees',
+    'api',
+)
 
 # Default + request
 TEMPLATE_CONTEXT_PROCESSORS = (
-    "django.contrib.auth.context_processors.auth",
-    "django.core.context_processors.debug",
-    "django.core.context_processors.i18n",
-    "django.core.context_processors.media",
-    "django.core.context_processors.static", "django.core.context_processors.tz",
-    "django.contrib.messages.context_processors.messages",
-    "django.core.context_processors.request")
+    'django.contrib.auth.context_processors.auth',
+    'django.core.context_processors.debug',
+    'django.core.context_processors.i18n',
+    'django.core.context_processors.media',
+    'django.core.context_processors.static',
+    'django.core.context_processors.tz',
+    'django.contrib.messages.context_processors.messages',
+    'django.core.context_processors.request',
+)
 
 MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -51,10 +57,9 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )
 
-AUTHENTICATION_BACKENDS = ('tock.remote_user_auth.TockUserBackend',)
-
-# Internationalization
-# https://docs.djangoproject.com/en/1.7/topics/i18n/
+AUTHENTICATION_BACKENDS = (
+    'tock.remote_user_auth.TockUserBackend',
+)
 
 LANGUAGE_CODE = 'en-us'
 TIME_ZONE = 'UTC'
@@ -62,11 +67,11 @@ USE_I18N = True
 USE_L10N = True
 USE_TZ = True
 
-TEMPLATE_DIRS = ('/templates/',)
+TEMPLATE_DIRS = (
+    '/templates/',
+)
 
-# Static files (CSS, JavaScript, Images)
-# https://docs.djangoproject.com/en/1.7/howto/static-files/
-STATIC_ROOT = os.path.join(BASE_DIR, "static")
+STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 STATIC_URL = '/static/'
 
 ALLOWED_EMAIL_DOMAINS = {

--- a/tock/tock/settings/dev.py
+++ b/tock/tock/settings/dev.py
@@ -1,24 +1,28 @@
-from .base import *  # noqa
-
 import dj_database_url
 
+from .base import *  # noqa
+
 DEBUG = True
-TEMPLATE_DEBUG = True
+TEMPLATE_DEBUG = DEBUG
+DEBUG_TOOLBAR_PATCH_SETTINGS = False
 
-INTERNAL_IPS = ('127.0.0.1',)
-
-DATABASES = {}
 DATABASES['default'] = dj_database_url.config(
     default='postgres://tock:tock@localhost/tock'
 )
 
-INSTALLED_APPS += ('debug_toolbar',)
+INSTALLED_APPS += (
+    'debug_toolbar',
+)
 
-DEBUG_TOOLBAR_PATCH_SETTINGS = False
+MIDDLEWARE_CLASSES += (
+    'debug_toolbar.middleware.DebugToolbarMiddleware',
+)
 
-MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
-
-INTERNAL_IPS = ['127.0.0.1', '::1', '192.168.33.10']
+INTERNAL_IPS = [
+    '127.0.0.1',
+    '::1',
+    '192.168.33.10',
+]
 
 MEDIA_ROOT = './media/'
 MEDIA_URL = '/media/'

--- a/tock/tock/settings/dev.py
+++ b/tock/tock/settings/dev.py
@@ -6,6 +6,11 @@ DEBUG = True
 TEMPLATE_DEBUG = DEBUG
 DEBUG_TOOLBAR_PATCH_SETTINGS = False
 
+INTERNAL_IPS = [
+    '127.0.0.1',
+    '::1',
+]
+
 DATABASES['default'] = dj_database_url.config(
     default='postgres://tock:tock@localhost/tock'
 )
@@ -18,14 +23,26 @@ MIDDLEWARE_CLASSES += (
     'debug_toolbar.middleware.DebugToolbarMiddleware',
 )
 
-INTERNAL_IPS = [
-    '127.0.0.1',
-    '::1',
-    '192.168.33.10',
-]
-
 MEDIA_ROOT = './media/'
 MEDIA_URL = '/media/'
+
+# Due to the Docker configuration and Django Debug Toolbar's need to account
+# for the local machine's IP address in INTERNAL_IPS to display itself, opt
+# to show the debug toolbar with a custom callback instead. For more
+# information on this setup please take a look at these resources:
+# https://django-debug-toolbar.readthedocs.io/en/1.4/installation.html#internal-ips
+# https://django-debug-toolbar.readthedocs.io/en/1.4/configuration.html#toolbar-options (SHOW_TOOLBAR_CALLBACK)
+# http://stackoverflow.com/questions/10517765/django-debug-toolbar-not-showing-up
+# https://gist.github.com/douglasmiranda/9de51aaba14543851ca3 (code taken from here)
+def show_django_debug_toolbar(request):
+    if request.is_ajax():
+        return False
+
+    return True
+
+DEBUG_TOOLBAR_CONFIG = {
+    'SHOW_TOOLBAR_CALLBACK': 'tock.settings.dev.show_django_debug_toolbar',
+}
 
 try:
   from .local_settings import *

--- a/tock/tock/settings/production.py
+++ b/tock/tock/settings/production.py
@@ -2,9 +2,10 @@ import os
 
 import dj_database_url
 
-from .base import *
+from .base import *  # noqa
 
 DEBUG = False
+TEMPLATE_DEBUG = DEBUG
 
 USE_X_FORWARDED_HOST = True
 
@@ -15,9 +16,7 @@ ALLOWED_HOSTS = ['*']  # proxied
 STATIC_ROOT = '/app/tock/tock/static/'
 STATIC_URL = '/tock/static/'
 
-DATABASES = {}
 DATABASES['default'] = dj_database_url.config()
-
 
 LOGGING = {
     'version': 1,

--- a/tock/tock/settings/test.py
+++ b/tock/tock/settings/test.py
@@ -1,6 +1,6 @@
-from .base import *  # noqa
-
 from django.utils.crypto import get_random_string
+
+from .base import *  # noqa
 
 SECRET_KEY = get_random_string(50)
 

--- a/tock/tock/urls.py
+++ b/tock/tock/urls.py
@@ -1,9 +1,7 @@
-from django.conf.urls import patterns, include, url
-# from django.conf.urls.static import static
 from django.conf import settings
-# from django.views.generic import TemplateView
+from django.conf.urls import patterns, include, url
 
-# Uncomment the next two lines to enable the admin:
+# Enable the Django admin.
 from django.contrib import admin
 admin.autodiscover()
 
@@ -13,28 +11,40 @@ import projects.urls
 
 urlpatterns = patterns(
     '',
-    url(r'^$', hours.views.ReportingPeriodListView.as_view(),
-        name='ListReportingPeriods'),
-    url(r'^reporting_period/', include("hours.urls.timesheets",
-        namespace="reportingperiod")),
-    url(r'^reports/', include("hours.urls.reports", namespace="reports")),
-    url(r'^employees/', include("employees.urls", namespace="employees")),
+    url(r'^$',
+        hours.views.ReportingPeriodListView.as_view(),
+        name='ListReportingPeriods'
+    ),
+    url(r'^reporting_period/', include(
+        'hours.urls.timesheets',
+        namespace='reportingperiod'
+    )),
+    url(r'^reports/', include(
+        'hours.urls.reports',
+        namespace='reports'
+    )),
+    url(r'^employees/', include(
+        'employees.urls',
+        namespace='employees'
+    )),
+    url(r'^projects/', include(projects.urls)),
 
     # TODO: version the API?
     url(r'^api/', include(api.urls)),
 
-    # project views
-    url(r'^projects/', include(projects.urls)),
-
-    # Uncomment the next line to enable the admin:
+    # Enable the Django admin.
     url(r'^admin/', include(admin.site.urls)),
 )
 
 
+# Enable Django Debug Toolbar only if in DEBUG mode.
 if settings.DEBUG:
     import debug_toolbar
+
     urlpatterns += patterns(
-        '', url(r'^__debug__/', include(debug_toolbar.urls)),)
+        '', url(r'^__debug__/', include(debug_toolbar.urls)),
+    )
+
 
 # Uncomment the next line to serve media files in dev.
 # urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/tock/tock/wsgi.py
+++ b/tock/tock/wsgi.py
@@ -8,7 +8,8 @@ https://docs.djangoproject.com/en/1.7/howto/deployment/wsgi/
 """
 
 import os
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tock.settings.production")
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'tock.settings.production')
 
 from django.core.wsgi import get_wsgi_application
 # important that the whitenoise import is after the line above


### PR DESCRIPTION
This changeset improves the integration of `django-debug-toolbar` with the recent support added for running Tock in a Docker container.  It also addresses an underlying issue that was present where the incorrect settings file was being used for running the `manage.py collectstatic` command and when running the app in staging or production.

The following list is a brief summary of all of the changes I made:

* Remove reference to Vagrant files and add Docker files to `.cfignore`.
* Add the `DJANGO_SETTINGS_MODULE` environment variable to `docker-compose.yml`.
* Always reference the `EXTERNAL_PORT` environment variable in `docker-compose.yml`.
* Remove `django-debug-toolbar` from `requirements.txt`.
* Default to running with `tock.settings.production` in cases where `DJANGO_SETTINGS_MODULE` is not set for consistency (this also prevents debug information and the debug toolbar from loading in places it shouldn't).
* Make use of the `DEBUG_TOOLBAR_CONFIG['SHOW_TOOLBAR_CALLBACK']` dict setting for Django Debug Toolbar to account for differing container IPs on everyone's machines.
* A bunch of general cleanup and consolidation of settings and project config related files.

I believe I have accounted for everything but please let me know if anything is out of place, missing, or still not configured correctly.

One last thing I'm still not sure about here too is running the tests (typically run via `manage.py test` or `manage.py test --settings=tock.settings.test`).  As you can see, Travis ran them just fine but that's because they're not being setup and run in with the Docker container.  When trying to run them locally, the only way I was able to get them to work is to still setup a virtualenv for the Tock project and run them in that (not the Docker container); this also requires specifying that `--settings` argument.

Is there a better way of setting up and running tests when using Docker?  Regardless, the README should probably have a bit of info around this as well, so whatever the accepted solution is I'm happy to update it with instructions as a part of this.

/cc @batemapf, @toolness, @jcscottiii 