### PR TITLE
Use escape sequences for unicode JSON chars in API output

### DIFF
--- a/tock/tock/settings/base.py
+++ b/tock/tock/settings/base.py
@@ -74,6 +74,7 @@ ALLOWED_EMAIL_DOMAINS = {
 }
 
 REST_FRAMEWORK = {
+    'UNICODE_JSON': False,
     'DEFAULT_RENDERER_CLASSES': (
         'rest_framework.renderers.JSONRenderer',
         # use our CSV renderer instead of rest_framework_csv's


### PR DESCRIPTION
I *think* this fixes #371.  I haven't actually tried it out though, as I've just used GitHub's in-browser text editor to make the change.