### PR TITLE
Don't load debug toolbar during unit tests.

### DIFF
--- a/tock/tock/settings/dev.py
+++ b/tock/tock/settings/dev.py
@@ -1,3 +1,5 @@
+import os
+import sys
 import dj_database_url
 
 from .base import *  # noqa
@@ -15,13 +17,17 @@ DATABASES['default'] = dj_database_url.config(
     default='postgres://tock:tock@localhost/tock'
 )
 
-INSTALLED_APPS += (
-    'debug_toolbar',
-)
+IS_RUNNING_TEST_SUITE = (os.path.basename(sys.argv[0]) == 'manage.py' and
+                         len(sys.argv) > 1 and sys.argv[1] == 'test')
 
-MIDDLEWARE_CLASSES += (
-    'debug_toolbar.middleware.DebugToolbarMiddleware',
-)
+if not IS_RUNNING_TEST_SUITE:
+    INSTALLED_APPS += (
+        'debug_toolbar',
+    )
+
+    MIDDLEWARE_CLASSES += (
+        'debug_toolbar.middleware.DebugToolbarMiddleware',
+    )
 
 MEDIA_ROOT = './media/'
 MEDIA_URL = '/media/'


### PR DESCRIPTION
This is actually a PR for #370 and makes `manage.py test` work without needing to explicitly pass-in a different settings configuration.