### PR TITLE
Fix autocomplete by id.

### DIFF
--- a/tock/hours/forms.py
+++ b/tock/hours/forms.py
@@ -90,12 +90,16 @@ def choice_label_for_project(project):
     return '%s - %s' % (project.id, project.name)
 
 
-def projects_as_choices():
+def projects_as_choices(queryset=None):
     """ Adds all of the projects in database to the TimeCardObjectForm project
     ChoiceField """
 
     accounting_codes = []
-    prefetch_queryset = Project.objects.filter(active=True).prefetch_related('alerts')
+
+    if queryset is None:
+        queryset = Project.objects.filter(active=True)
+
+    prefetch_queryset = queryset.prefetch_related('alerts')
     prefetch = Prefetch('project_set', queryset=prefetch_queryset)
 
     for code in AccountingCode.objects.all().prefetch_related(prefetch, 'agency'):

--- a/tock/hours/tests/test_integration.py
+++ b/tock/hours/tests/test_integration.py
@@ -49,10 +49,8 @@ class TestOptions(WebTest):
         select = res.forms[0].fields['timecardobject_set-0-project'][0]
         options = [each[-1] for each in select.options]
         for each in (positive or []):
-            each = each.split(' - ')[1] if ' - ' in each else each
             self.assertIn(each, options)
         for each in (negative or []):
-            each = each.split(' - ')[1] if ' - ' in each else each
             self.assertNotIn(each, options)
 
     def test_project_select(self):

--- a/tock/tock/templates/hours/timecard_form.html
+++ b/tock/tock/templates/hours/timecard_form.html
@@ -16,6 +16,9 @@
   <div class="alert-red">
     <p class="alert-body">
       <b> Another new feature added! </b> As many of you know, we have recently tackled discrepancies between hours recorded as <b>Out of Office</b> here in Tock and those recorded as <b>Leave</b> in <a href="https://aloha.gsa.gov/"> ALOHA </a> (GSA's official leave processing system). To help reduce the frequency of discrepancies going forward, we have added an alert feature that reminds users to <i> also </i> file an ALOHA leave request when logging time in one of the various Out of Office categories in Tock. Alerts may be added to any project, so if you have an idea for an alert beyond the Out of Office categories, please let us know in <b>#Tock</b>!
+      <br>
+      <br>
+      <b> New feature added! </b> Ever have trouble finding a commonly named project? Now you now have the option to autocomplete your Tock entries below using a Tock ID number! For a listing of Tock ID numbers, please head over to the <b><a href="https://tock.18f.gov/projects/">Projects</a></b> page. Want to suggest a new feature? Please file an issue at the <b><a href="https://www.github.com/18f/tock/issues">Tock repo</a></b> or head over <b>#tock</b> on Slack.
     </p>
   </div>
 </div>


### PR DESCRIPTION
This fixes #380.

The regression was caused by #374, which overwrote the id-prefixed choices introduced by #360. This PR refactors some of #374 while fixing the regression.

(FYI, #374 caused another regression which prompted #378; this PR also obviates the need for that fix, due to the way it refactors and throws out duplicate code.)