### PR TITLE
adds a slimmer bulk timecard endpoint

### DIFF
--- a/tock/api/tests.py
+++ b/tock/api/tests.py
@@ -159,6 +159,29 @@ class BulkTimecardsTests(TestCase):
             rows_read += 1
         self.assertNotEqual(rows_read, 0, 'no rows read, expecting 1 or more')
 
+class BulkTimecardsTests(TestCase):
+    fixtures = FIXTURES
+
+    def test_slim_bulk_timecards(self):
+        response = self.client.get(reverse('SlimBulkTimecardList'))
+        rows = decode_streaming_csv(response)
+        expected_fields = set((
+            'project_name',
+            'billable',
+            'employee',
+            'start_date',
+            'end_date',
+            'hours_spent',
+            'mbnumber',
+        ))
+        rows_read = 0
+        for row in rows:
+            self.assertEqual(set(row.keys()), expected_fields)
+            self.assertEqual(row['project_name'], 'Out Of Office')
+            self.assertEqual(row['billable'], 'False')
+            rows_read += 1
+        self.assertNotEqual(rows_read, 0, 'no rows read, expecting 1 or more')
+
 
 def decode_streaming_csv(response, **reader_options):
     lines = [line.decode('utf-8') for line in response.streaming_content]

--- a/tock/api/urls.py
+++ b/tock/api/urls.py
@@ -21,4 +21,5 @@ urlpatterns = patterns('',
     url(r'^timecards_bulk.csv$', views.bulk_timecard_list, name='BulkTimecardList'),
     url(r'^hours/by_quarter.json$', views.hours_by_quarter, name='HoursByQuarter'),
     url(r'^hours/by_quarter_by_user.json$', views.hours_by_quarter_by_user, name='HoursByQuarterByUser'),
+    url(r'^slim_timecard_bulk.csv$', views.slim_bulk_timecard_list, name='SlimBulkTimecardList')
 )

--- a/tock/api/views.py
+++ b/tock/api/views.py
@@ -97,6 +97,15 @@ class BulkTimecardSerializer(serializers.Serializer):
     mbnumber = serializers.CharField(source='project.mbnumber')
     notes = serializers.CharField()
 
+class SlimBulkTimecardSerializer(serializers.Serializer):
+    project_name = serializers.CharField(source='project.name')
+    employee = serializers.StringRelatedField(source='timecard.user')
+    start_date = serializers.DateField(source='timecard.reporting_period.start_date')
+    end_date = serializers.DateField(source='timecard.reporting_period.end_date')
+    hours_spent = serializers.DecimalField(max_digits=5, decimal_places=2)
+    billable = serializers.BooleanField(source='project.accounting_code.billable')
+    mbnumber = serializers.CharField(source='project.mbnumber')
+
 # API Views
 
 class ProjectList(generics.ListAPIView):
@@ -267,7 +276,6 @@ def get_timecards(queryset, params=None):
 
     return queryset
 
-
 def bulk_timecard_list(request):
     """
     Stream all the timecards as CSV.
@@ -275,6 +283,15 @@ def bulk_timecard_list(request):
     queryset = get_timecards(TimecardList.queryset, request.GET)
     serializer = BulkTimecardSerializer()
     return stream_csv(queryset, serializer)
+
+def slim_bulk_timecard_list(request):
+    """
+    Stream a slimmed down version of all the timecards as CSV.
+    """
+    queryset = get_timecards(TimecardList.queryset, request.GET)
+    serializer = SlimBulkTimecardSerializer()
+    return stream_csv(queryset, serializer)
+
 
 
 from rest_framework.response import Response


### PR DESCRIPTION
adds a more svelte option for pull bulk tock data. ran into issues pulling the live data into google sheets off the bulk_timecards.csv endpoint. reduced the number of fields to make the load more economical. if @toolness or @ccostino have a minute or two to take a look, would much appreciate!

test coverage added, as well.