### PR TITLE
add billable indicator to employee model

### DIFF
--- a/tock/employees/migrations/0008_userdata_is_billable.py
+++ b/tock/employees/migrations/0008_userdata_is_billable.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('employees', '0007_auto_20160428_0105'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='userdata',
+            name='is_billable',
+            field=models.BooleanField(verbose_name='Billable Employee', default=True),
+        ),
+    ]

--- a/tock/employees/models.py
+++ b/tock/employees/models.py
@@ -26,9 +26,11 @@ class UserData(models.Model):
     user = models.OneToOneField(User, related_name='user_data', verbose_name='Tock username')
     start_date = models.DateField(blank=True, null=True, verbose_name='Employee start date')
     end_date = models.DateField(blank=True, null=True, verbose_name='Employee end date')
-    current_employee = models.BooleanField(default=True, verbose_name='Current Employee')
-    is_18f_employee = models.BooleanField(default=True, verbose_name='18F Employee')
-    unit = models.IntegerField(null=True, choices=UNIT_CHOICES, verbose_name="Select unit", blank=True)
+    current_employee = models.BooleanField(default=True, verbose_name='Is Current Employee')
+    is_18f_employee = models.BooleanField(default=True, verbose_name='Is 18F Employee')
+    is_billable = models.BooleanField(default=True, verbose_name="Is 18F Billable Employee")
+    unit = models.IntegerField(null=True, choices=UNIT_CHOICES, verbose_name="Select 18F unit", blank=True)
+
 
     class Meta:
         verbose_name='Employee'


### PR DESCRIPTION
- add "is_billable" to employee model to indicate whether the employee is primarily "billable" (as opposed to primarily admin / support / mgmt / non-billable)

- other minor text tweaks to employee model