### PR TITLE
Bump Django Version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.8.9
+Django==1.8.13
 dj-database-url==0.3.0
 psycopg2==2.6
 model-mommy==1.2.3


### PR DESCRIPTION
Two CVE's [pop up](https://gemnasium.com/github.com/18F/tock/alerts) in Gemnasium for this version of Django, so let's bump up the
patch version (should be 100% compatible). CVEs:

* CVE-2016-2512 - MALICIOUS REDIRECT AND POSSIBLE XSS ATTACK VIA USER-SUPPLIED
  REDIRECT URLS: Unsure if Tock uses redirects anywhere. Best to update to be
  safe.
* CVE-2016-2513 - USER ENUMERATION THROUGH TIMING DIFFERENCE ON PASSWORD
  HASHER WORK FACTOR UPGRADE: Should be a non-issue given that Tock doesn't
  have local users