### PR TITLE
add user_data.csv | json endpoint

### DIFF
--- a/tock/api/urls.py
+++ b/tock/api/urls.py
@@ -21,5 +21,7 @@ urlpatterns = patterns('',
     url(r'^timecards_bulk.csv$', views.bulk_timecard_list, name='BulkTimecardList'),
     url(r'^hours/by_quarter.json$', views.hours_by_quarter, name='HoursByQuarter'),
     url(r'^hours/by_quarter_by_user.json$', views.hours_by_quarter_by_user, name='HoursByQuarterByUser'),
-    url(r'^slim_timecard_bulk.csv$', views.slim_bulk_timecard_list, name='SlimBulkTimecardList')
+    url(r'^slim_timecard_bulk.csv$', views.slim_bulk_timecard_list, name='SlimBulkTimecardList'),
+    url(r'^user_data.(?P<format>csv|json)$', views.UserDataView.as_view(), name='UserDataView'),
+
 )

--- a/tock/api/views.py
+++ b/tock/api/views.py
@@ -10,6 +10,7 @@ from django.contrib.auth import get_user_model
 
 from projects.models import Project
 from hours.models import TimecardObject, Timecard, ReportingPeriod
+from employees.models import UserData
 
 from rest_framework import serializers, generics, pagination
 
@@ -61,6 +62,20 @@ class UserSerializer(serializers.ModelSerializer):
             'email'
         )
 
+class UserDataSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = UserData
+        fields = (
+            'user',
+            'start_date',
+            'end_date',
+            'current_employee',
+            'is_18f_employee',
+            'is_billable',
+            'unit',
+        )
+
+
 class ReportingPeriodSerializer(serializers.ModelSerializer):
     class Meta:
         model = ReportingPeriod
@@ -107,6 +122,11 @@ class SlimBulkTimecardSerializer(serializers.Serializer):
     mbnumber = serializers.CharField(source='project.mbnumber')
 
 # API Views
+
+class UserDataView(generics.ListAPIView):
+    queryset = UserData.objects.all()
+    serializer_class = UserDataSerializer
+    pagination_class = JumboResultsSetPagination
 
 class ProjectList(generics.ListAPIView):
     queryset = Project.objects.all()


### PR DESCRIPTION
accessible at /api/user_data.csv or /api/user_data.json. includes `id`, `start_date`, `end_date`, `current_employee`, `is_18f_employee`, `is_billable`, and `unit` fields