### PR TITLE
match search text within dropdown options text

### DIFF
--- a/tock/tock/templates/hours/timecard_form.html
+++ b/tock/tock/templates/hours/timecard_form.html
@@ -164,6 +164,10 @@
 
 
 $( document ).ready(function() {
+    var chosenOptions = {
+      search_contains: true
+    };
+
     $("#save-timecard").on("click", function() {
       var form = $('form'),
           save_input = '<input type="hidden" name="save_only" value="1"/>';
@@ -205,26 +209,27 @@ $( document ).ready(function() {
           });
 
         }).appendTo('.entries');
-        $(".entry-project select").chosen();
+        
+        $(".entry-project select")
+          .chosen(chosenOptions)
+          .on('change', function(e) {
+              toggleNotesField(this);
+              displayAlerts(this);
+          });
 
         // Increment the TOTAL_FORMS
         $('#id_timecardobject_set-TOTAL_FORMS').val(parseInt($('#id_timecardobject_set-TOTAL_FORMS').val()) + 1);
-
-        // Rebind events.
-        $('.entry-project select').chosen().on('change', function(e) {
-            toggleNotesField(this);
-            displayAlerts(this);
-        });
-    });
-
-    $('.entry-project select').chosen().on('change', function(e) {
-        toggleNotesField(this);
-        displayAlerts(this);
     });
 
     // Run on initial load
     populateHourTotals();
-    $('.entry-project select').chosen();
+
+    $('.entry-project select')
+      .chosen(chosenOptions)
+      .on('change', function(e) {
+          toggleNotesField(this);
+          displayAlerts(this);
+      });
 
     // Force an update to each project selection menu in case a notes field
     // needs to be re-displayed.


### PR DESCRIPTION
- add `search_within: true` to chosen() instantiations
- simplify calls to chosen() instantiation and event hookups

Noticed today that I was unable to just type "holiday" to find the "Administrative/Holiday Leave" project in tock. Enabling the `search_within` option in chosen selects enables searching to work within full strings instead of on space-delimited tokens.

<img width="325" alt="screen shot 2016-07-11 at 8 39 12 am" src="https://cloud.githubusercontent.com/assets/697848/16732768/567cd7c8-4744-11e6-93cf-cb919d0f793c.png">
