### PR TITLE
add service info for staging instance

### DIFF
--- a/staging-manifest.yml
+++ b/staging-manifest.yml
@@ -7,3 +7,5 @@ applications:
   path: .
   stack: cflinuxfs2
   timeout: 180
+  services:
+    - tock-staging-2


### PR DESCRIPTION
ensures that the tock-staging app automatically binds to staging DB