### PR TITLE
Less --> Fewer

### DIFF
--- a/tock/tock/templates/hours/reports_list.html
+++ b/tock/tock/templates/hours/reports_list.html
@@ -8,7 +8,7 @@
 <h3> Raw data in .csv </h3>
 <ul>
 	<li><a href="http://tock.18f.gov/api/timecards_bulk.csv">Complete timecard data</a></li>
-	<li><a href="http://tock.18f.gov/api/slim_timecard_bulk.csv">Complete timecard data with less fields</a></li>
+	<li><a href="http://tock.18f.gov/api/slim_timecard_bulk.csv">Complete timecard data with fewer fields</a></li>
 
 <div class="reporting-periods">
 	<h3>Reports by weekly reporting period</h3>


### PR DESCRIPTION
Change language from "less fields" to "fewer fields".

Currently, the reports interface at https://tock.18f.gov/reports/ says "Complete timecard data with less fields".

<img width="413" alt="screen shot 2016-09-17 at 8 02 18 am" src="https://cloud.githubusercontent.com/assets/4153048/18608084/272f031c-7cad-11e6-90a4-1f186de31f9d.png">

Grammatically, this should be "Complete timecard data with fewer fields".