### PR TITLE
make csv views available w/o token to auth'd user

### DIFF
--- a/tock/api/views.py
+++ b/tock/api/views.py
@@ -1,6 +1,8 @@
 import collections
 import datetime
 
+
+from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse
 from django.db import connection
 from django.db.models import Sum
@@ -295,6 +297,7 @@ def get_timecards(queryset, params=None):
 
     return queryset
 
+@login_required
 def bulk_timecard_list(request):
     """
     Stream all the timecards as CSV.
@@ -303,6 +306,7 @@ def bulk_timecard_list(request):
     serializer = BulkTimecardSerializer()
     return stream_csv(queryset, serializer)
 
+@login_required
 def slim_bulk_timecard_list(request):
     """
     Stream a slimmed down version of all the timecards as CSV.

--- a/tock/hours/urls/reports.py
+++ b/tock/hours/urls/reports.py
@@ -2,7 +2,11 @@ from django.conf.urls import url
 
 from .. import views
 
+from api.views import bulk_timecard_list, slim_bulk_timecard_list
+
 urlpatterns = [
+    url(r'^timecards_bulk.csv$', bulk_timecard_list, name='BulkTimecardList'),
+    url(r'^slim_timecard_bulk.csv$', slim_bulk_timecard_list, name='SlimBulkTimecardList'),
     url(regex=r'^$', view=views.ReportsList.as_view(), name='ListReports'),
     url(regex=r'^(?P<reporting_period>[0-9]{4}-[0-9]{2}-[0-9]{2})/$',
         view=views.ReportingPeriodDetailView.as_view(), name='ReportingPeriodDetailView'),

--- a/tock/tock/templates/base.html
+++ b/tock/tock/templates/base.html
@@ -49,7 +49,7 @@
         <li><b>Admin:</b></li>
         <li><a href="{% url 'reportingperiod:ReportingPeriodCreateView' %}">Add reporting period</a></li>
         <li><a href="/admin">Admin panel</a>
-        <li><a href="/api/timecards_bulk.csv">Bulk timecard CSV</a>
+        <li><a href="{% url 'reports:BulkTimecardList' %}">Bulk timecard CSV</a>
         {% endif %}
         <hr>
       </ul>

--- a/tock/tock/templates/hours/reports_list.html
+++ b/tock/tock/templates/hours/reports_list.html
@@ -7,8 +7,8 @@
 
 <h3> Raw data in .csv </h3>
 <ul>
-	<li><a href="http://tock.18f.gov/api/timecards_bulk.csv">Complete timecard data</a></li>
-	<li><a href="http://tock.18f.gov/api/slim_timecard_bulk.csv">Complete timecard data with fewer fields</a></li>
+	<li><a href="{% url 'reports:BulkTimecardList' %}">Complete timecard data</a></li>
+	<li><a href="{% url 'reports:SlimBulkTimecardList' %}">Complete timecard data with fewer fields</a></li>
 
 <div class="reporting-periods">
 	<h3>Reports by weekly reporting period</h3>


### PR DESCRIPTION
This change is a complement to the new token-based authentication in #465. It provides logged in (via the UAA proxy) users with access to two common CSV reports w/o requiring a token. h/t to @annalee for working through it with me!