### PR TITLE
CSV download issue

### DIFF
--- a/tock/api/tests.py
+++ b/tock/api/tests.py
@@ -24,7 +24,6 @@ from django.test.client import Client
 from rest_framework.test import APIClient
 
 # common client for all API tests
-
 def client(self):
     self.request_user = User.objects.get_or_create(username='aaron.snow')[0]
     self.token = Token.objects.get_or_create(user=self.request_user)[0].key
@@ -39,16 +38,11 @@ FIXTURES = [
     'hours/fixtures/timecards.json'
 ]
 
-
 class ProjectsAPITests(TestCase):
     fixtures = FIXTURES
 
     def test_projects_json(self):
         pass
-
-    def test_projects_csv(self):
-        pass
-
 
 class ProjectInstanceAPITests(WebTest):
     fixtures = FIXTURES
@@ -68,22 +62,14 @@ class UsersAPITests(TestCase):
     def test_users_csv(self):
         pass
 
-
 class TimecardsAPITests(WebTest):
     fixtures = FIXTURES
 
     def test_timecards_json(self):
         """ Check that the timecards are rendered in json format correctly """
-        res = client(self).get(reverse('TimecardList', kwargs={'format': 'json'})).content
+        res = client(self).get(reverse('TimecardList')).content
         clean_res = json.loads(res.decode())
         self.assertEqual(clean_res['count'], 2)
-
-    def test_timecards_csv(self):
-        """ Check that the timecards are rendered in csv format correctly """
-        res = client(self).get(reverse('TimecardList', kwargs={'format': 'csv'})).content
-        target_fields = len(TimecardSerializer.__dict__['_declared_fields'])
-        output_fields = len(str(res).split('\\r')[0].split(','))
-        self.assertEqual(target_fields, output_fields)
 
     # TODO: test with more diverse data
     def test_get_timecards(self):
@@ -138,72 +124,6 @@ class TimecardsAPITests(WebTest):
             params={'submitted': 'foo'}
         )
         self.assertEqual(len(queryset), 2)
-
-
-class ProjectTimelineTests(WebTest):
-    fixtures = FIXTURES
-
-    def test_project_timeline(self):
-        res = client(self).get(reverse('UserTimelineView'))
-        self.assertIn(
-            'aaron.snow,2015-06-01,2015-06-08,False,20.00', str(res.content))
-
-
-class BulkTimecardsTests(TestCase):
-    fixtures = FIXTURES
-
-    def test_bulk_timecards(self):
-        response = client(self).get(reverse('BulkTimecardList'))
-        rows = decode_streaming_csv(response)
-        expected_fields = set((
-            'project_name',
-            'project_id',
-            'billable',
-            'employee',
-            'start_date',
-            'end_date',
-            'hours_spent',
-            'agency',
-            'flat_rate',
-            'active',
-            'mbnumber',
-            'notes',
-        ))
-        rows_read = 0
-        for row in rows:
-            self.assertEqual(set(row.keys()), expected_fields)
-            self.assertEqual(row['project_id'], '1')
-            rows_read += 1
-        self.assertNotEqual(rows_read, 0, 'no rows read, expecting 1 or more')
-
-class BulkTimecardsTests(TestCase):
-    fixtures = FIXTURES
-
-    def test_slim_bulk_timecards(self):
-        response = client(self).get(reverse('SlimBulkTimecardList'))
-        rows = decode_streaming_csv(response)
-        expected_fields = set((
-            'project_name',
-            'billable',
-            'employee',
-            'start_date',
-            'end_date',
-            'hours_spent',
-            'mbnumber',
-        ))
-        rows_read = 0
-        for row in rows:
-            self.assertEqual(set(row.keys()), expected_fields)
-            self.assertEqual(row['project_name'], 'Out Of Office')
-            self.assertEqual(row['billable'], 'False')
-            rows_read += 1
-        self.assertNotEqual(rows_read, 0, 'no rows read, expecting 1 or more')
-
-
-def decode_streaming_csv(response, **reader_options):
-    lines = [line.decode('utf-8') for line in response.streaming_content]
-    return csv.DictReader(lines, **reader_options)
-
 
 class TestAggregates(WebTest):
 
@@ -273,9 +193,7 @@ class TestAggregates(WebTest):
 
     def test_hours_by_quarter_by_user_with_unsubmitted_timecards(self):
         """ Check that unsubmitted timecards are not counted  """
-
         # add one unsubmitted timecard + one additional submitted one
-
         timecard_unsubmit = TimecardFactory(
             user=self.user,
             reporting_period=ReportingPeriodFactory(
@@ -311,7 +229,6 @@ class TestAggregates(WebTest):
 
         self.assertEqual(len(self.timecard_objects), 4)
         self.assertEqual(row['total'], 60)
-
 
 class ReportingPeriodList(WebTest):
     fixtures = FIXTURES
@@ -350,7 +267,6 @@ class ReportingPeriodList(WebTest):
             )
         ).data
         self.assertEqual(res['count'], 1)
-
 
     def test_ReportingPeriodList_json_no_longer_employed(self):
         """ Check that the ReportingPeriodList shows users that have missing

--- a/tock/api/urls.py
+++ b/tock/api/urls.py
@@ -8,20 +8,16 @@ from api import views
 # admin.autodiscover()
 
 urlpatterns = [
-    url(r'^projects.(?P<format>csv|json)$', views.ProjectList.as_view(), name='ProjectList'),
+    url(r'^projects.json$', views.ProjectList.as_view(), name='ProjectList'),
     url(r'^projects/(?P<pk>\d+).json$',view=views.ProjectInstanceView.as_view(),name='ProjectInstanceView'),
-    url(r'^users.(?P<format>csv|json)$', views.UserList.as_view(), name='UserList'),
-    url(r'^reporting_period_audit/$', view=views.ReportingPeriodList.as_view(), name='ReportingPeriodList'),
-    url(r'^reporting_period_audit/(?P<reporting_period_start_date>[0-9]{4}-[0-9]{2}-[0-9]{2})/$',
+    url(r'^users.json$', views.UserList.as_view(), name='UserList'),
+    url(r'^reporting_period_audit.json$', view=views.ReportingPeriodList.as_view(), name='ReportingPeriodList'),
+    url(r'^reporting_period_audit/(?P<reporting_period_start_date>[0-9]{4}-[0-9]{2}-[0-9]{2}).json$',
         view=views.ReportingPeriodAudit.as_view(), name='ReportingPeriodAudit'
     ),
-    url(r'^timecards.(?P<format>csv|json)$', views.TimecardList.as_view(), name='TimecardList'),
-    url(r'^project_timeline.csv$', views.project_timeline_view, name='ProjectTimelineView'),
-    url(r'^user_timeline.csv$', views.user_timeline_view, name='UserTimelineView'),
-    url(r'^timecards_bulk.csv$', views.bulk_timecard_list, name='BulkTimecardList'),
+    url(r'^timecards.json$', views.TimecardList.as_view(), name='TimecardList'),
     url(r'^hours/by_quarter.json$', views.hours_by_quarter, name='HoursByQuarter'),
     url(r'^hours/by_quarter_by_user.json$', views.hours_by_quarter_by_user, name='HoursByQuarterByUser'),
-    url(r'^slim_timecard_bulk.csv$', views.slim_bulk_timecard_list, name='SlimBulkTimecardList'),
-    url(r'^user_data.(?P<format>csv|json)$', views.UserDataView.as_view(), name='UserDataView'),
+    url(r'^user_data.json$', views.UserDataView.as_view(), name='UserDataView'),
 
 ]

--- a/tock/api/views.py
+++ b/tock/api/views.py
@@ -96,30 +96,6 @@ class TimecardSerializer(serializers.Serializer):
     flat_rate = serializers.BooleanField(source='project.accounting_code.flat_rate')
     notes = serializers.CharField()
 
-
-class BulkTimecardSerializer(serializers.Serializer):
-    project_name = serializers.CharField(source='project.name')
-    project_id = serializers.CharField(source='project.id')
-    employee = serializers.StringRelatedField(source='timecard.user')
-    start_date = serializers.DateField(source='timecard.reporting_period.start_date')
-    end_date = serializers.DateField(source='timecard.reporting_period.end_date')
-    hours_spent = serializers.DecimalField(max_digits=5, decimal_places=2)
-    billable = serializers.BooleanField(source='project.accounting_code.billable')
-    agency = serializers.CharField(source='project.accounting_code.agency.name')
-    flat_rate = serializers.BooleanField(source='project.accounting_code.flat_rate')
-    active = serializers.BooleanField(source='project.active')
-    mbnumber = serializers.CharField(source='project.mbnumber')
-    notes = serializers.CharField()
-
-class SlimBulkTimecardSerializer(serializers.Serializer):
-    project_name = serializers.CharField(source='project.name')
-    employee = serializers.StringRelatedField(source='timecard.user')
-    start_date = serializers.DateField(source='timecard.reporting_period.start_date')
-    end_date = serializers.DateField(source='timecard.reporting_period.end_date')
-    hours_spent = serializers.DecimalField(max_digits=5, decimal_places=2)
-    billable = serializers.BooleanField(source='project.accounting_code.billable')
-    mbnumber = serializers.CharField(source='project.mbnumber')
-
 # API Views
 
 class UserDataView(generics.ListAPIView):
@@ -192,59 +168,6 @@ class TimecardList(generics.ListAPIView):
     def get_queryset(self):
         return get_timecards(self.queryset, self.request.query_params)
 
-def timeline_view(request, value_fields=(), **field_alias):
-    """ CSV endpoint for the project timeline viz """
-    queryset = get_timecards(TimecardList.queryset, request.GET)
-
-    fields = list(value_fields) + [
-        'timecard__reporting_period__start_date',
-        'timecard__reporting_period__end_date',
-        'project__accounting_code__billable'
-    ]
-
-    field_map = {
-        'timecard__reporting_period__start_date': 'start_date',
-        'timecard__reporting_period__end_date': 'end_date',
-        'project__accounting_code__billable': 'billable',
-    }
-    field_map.update(field_alias)
-
-    data = queryset.values(*fields).annotate(hours_spent=Sum('hours_spent'))
-
-    fields.append('hours_spent')
-
-    data = [
-        {
-            field_map.get(field, field): row.get(field)
-            for field in fields
-        }
-        for row in data
-    ]
-
-    response = HttpResponse(content_type='text/csv')
-
-    fieldnames = [field_map.get(field, field) for field in fields]
-    writer = csv.DictWriter(response, fieldnames=fieldnames)
-    writer.writeheader()
-    for row in data:
-        writer.writerow(row)
-    return response
-
-def project_timeline_view(request):
-    return timeline_view(
-        request,
-        value_fields=['project__id', 'project__name'],
-        project__id='project_id',
-        project__name='project_name',
-    )
-
-def user_timeline_view(request):
-    return timeline_view(
-        request,
-        value_fields=['timecard__user__username'],
-        timecard__user__username='user',
-    )
-
 def get_timecards(queryset, params=None):
     """
     Filter a TimecardObject queryset according to the provided GET
@@ -294,24 +217,6 @@ def get_timecards(queryset, params=None):
             queryset = queryset.filter(project__name=project)
 
     return queryset
-
-def bulk_timecard_list(request):
-    """
-    Stream all the timecards as CSV.
-    """
-    queryset = get_timecards(TimecardList.queryset, request.GET)
-    serializer = BulkTimecardSerializer()
-    return stream_csv(queryset, serializer)
-
-def slim_bulk_timecard_list(request):
-    """
-    Stream a slimmed down version of all the timecards as CSV.
-    """
-    queryset = get_timecards(TimecardList.queryset, request.GET)
-    serializer = SlimBulkTimecardSerializer()
-    return stream_csv(queryset, serializer)
-
-
 
 from rest_framework.response import Response
 from rest_framework.decorators import api_view

--- a/tock/hours/tests/test_views.py
+++ b/tock/hours/tests/test_views.py
@@ -1,10 +1,12 @@
 import datetime
+import csv
 
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.contrib.auth import get_user_model
 
 from django_webtest import WebTest
+
 from hours.utils import number_of_hours
 
 from employees.models import UserData
@@ -12,7 +14,74 @@ from hours.forms import choice_label_for_project
 import hours.models
 import projects.models
 import hours.views
+from api.tests import client
 
+
+FIXTURES = [
+    'tock/fixtures/prod_user.json',
+    'projects/fixtures/projects.json',
+    'hours/fixtures/timecards.json',
+]
+
+class BulkTimecardsTests(TestCase):
+    fixtures = FIXTURES
+
+    def test_bulk_timecards(self):
+        response = client(self).get(reverse('reports:BulkTimecardList'))
+        rows = decode_streaming_csv(response)
+        expected_fields = set((
+            'project_name',
+            'project_id',
+            'billable',
+            'employee',
+            'start_date',
+            'end_date',
+            'hours_spent',
+            'agency',
+            'flat_rate',
+            'active',
+            'mbnumber',
+            'notes',
+        ))
+        rows_read = 0
+        for row in rows:
+            self.assertEqual(set(row.keys()), expected_fields)
+            self.assertEqual(row['project_id'], '1')
+            rows_read += 1
+        self.assertNotEqual(rows_read, 0, 'no rows read, expecting 1 or more')
+
+    def test_slim_bulk_timecards(self):
+        response = client(self).get(reverse('reports:SlimBulkTimecardList'))
+        rows = decode_streaming_csv(response)
+        expected_fields = set((
+            'project_name',
+            'billable',
+            'employee',
+            'start_date',
+            'end_date',
+            'hours_spent',
+            'mbnumber',
+        ))
+        rows_read = 0
+        for row in rows:
+            self.assertEqual(set(row.keys()), expected_fields)
+            self.assertEqual(row['project_name'], 'Out Of Office')
+            self.assertEqual(row['billable'], 'False')
+            rows_read += 1
+        self.assertNotEqual(rows_read, 0, 'no rows read, expecting 1 or more')
+
+
+def decode_streaming_csv(response, **reader_options):
+    lines = [line.decode('utf-8') for line in response.streaming_content]
+    return csv.DictReader(lines, **reader_options)
+
+class ProjectTimelineTests(WebTest):
+    fixtures = FIXTURES
+
+    def test_project_timeline(self):
+        res = client(self).get(reverse('reports:UserTimelineView'))
+        self.assertIn(
+            'aaron.snow,2015-06-01,2015-06-08,False,20.00', str(res.content))
 
 class UtilTests(TestCase):
 

--- a/tock/hours/urls/reports.py
+++ b/tock/hours/urls/reports.py
@@ -1,8 +1,11 @@
 from django.conf.urls import url
 
 from .. import views
+from api.views import bulk_timecard_list, slim_bulk_timecard_list
 
 urlpatterns = [
+    url(r'^timecards_bulk.csv$', bulk_timecard_list, name='BulkTimecardList'),
+    url(r'^slim_timecard_bulk.csv$', slim_bulk_timecard_list, name='SlimBulkTimecardList'),
     url(regex=r'^$', view=views.ReportsList.as_view(), name='ListReports'),
     url(regex=r'^(?P<reporting_period>[0-9]{4}-[0-9]{2}-[0-9]{2})/$',
         view=views.ReportingPeriodDetailView.as_view(), name='ReportingPeriodDetailView'),

--- a/tock/hours/urls/reports.py
+++ b/tock/hours/urls/reports.py
@@ -1,11 +1,11 @@
 from django.conf.urls import url
 
 from .. import views
-from api.views import bulk_timecard_list, slim_bulk_timecard_list
+from api.views import ProjectList
 
 urlpatterns = [
-    url(r'^timecards_bulk.csv$', bulk_timecard_list, name='BulkTimecardList'),
-    url(r'^slim_timecard_bulk.csv$', slim_bulk_timecard_list, name='SlimBulkTimecardList'),
+    url(r'^timecards_bulk.csv$', views.bulk_timecard_list, name='BulkTimecardList'),
+    url(r'^slim_timecard_bulk.csv$', views.slim_bulk_timecard_list, name='SlimBulkTimecardList'),
     url(regex=r'^$', view=views.ReportsList.as_view(), name='ListReports'),
     url(regex=r'^(?P<reporting_period>[0-9]{4}-[0-9]{2}-[0-9]{2})/$',
         view=views.ReportingPeriodDetailView.as_view(), name='ReportingPeriodDetailView'),
@@ -13,4 +13,8 @@ urlpatterns = [
         view=views.ReportingPeriodCSVView, name='ReportingPeriodCSVView'),
     url(regex=r'^(?P<reporting_period>[0-9]{4}-[0-9]{2}-[0-9]{2})/(?P<username>[A-Za-z0-9._%+-]*)/$',
         view=views.ReportingPeriodUserDetailView.as_view(), name='ReportingPeriodUserDetailView'),
+    url(r'^project_timeline.csv$', views.project_timeline_view, name='ProjectTimelineView'),
+    url(r'^user_timeline.csv$', views.user_timeline_view, name='UserTimelineView'),
+#    url(r'^projects.csv$', ProjectList.as_view(), name='ProjectList'),
+
 ]

--- a/tock/hours/views.py
+++ b/tock/hours/views.py
@@ -13,9 +13,10 @@ from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
 from django.views.generic import ListView, DetailView
 from django.views.generic.edit import CreateView, UpdateView, FormView
-from django.db.models import Prefetch, Q
+from django.db.models import Prefetch, Q, Sum
 
 from rest_framework.permissions import IsAuthenticated
+from rest_framework import serializers
 
 from tock.remote_user_auth import email_to_username
 from tock.utils import PermissionMixin, IsSuperUserOrSelf
@@ -25,6 +26,101 @@ from .forms import (
     ReportingPeriodForm, ReportingPeriodImportForm, projects_as_choices,
     TimecardForm, TimecardFormSet, timecard_formset_factory
 )
+from api.views import get_timecards, TimecardList
+from api.renderers import stream_csv
+
+
+class BulkTimecardSerializer(serializers.Serializer):
+    project_name = serializers.CharField(source='project.name')
+    project_id = serializers.CharField(source='project.id')
+    employee = serializers.StringRelatedField(source='timecard.user')
+    start_date = serializers.DateField(source='timecard.reporting_period.start_date')
+    end_date = serializers.DateField(source='timecard.reporting_period.end_date')
+    hours_spent = serializers.DecimalField(max_digits=5, decimal_places=2)
+    billable = serializers.BooleanField(source='project.accounting_code.billable')
+    agency = serializers.CharField(source='project.accounting_code.agency.name')
+    flat_rate = serializers.BooleanField(source='project.accounting_code.flat_rate')
+    active = serializers.BooleanField(source='project.active')
+    mbnumber = serializers.CharField(source='project.mbnumber')
+    notes = serializers.CharField()
+
+class SlimBulkTimecardSerializer(serializers.Serializer):
+    project_name = serializers.CharField(source='project.name')
+    employee = serializers.StringRelatedField(source='timecard.user')
+    start_date = serializers.DateField(source='timecard.reporting_period.start_date')
+    end_date = serializers.DateField(source='timecard.reporting_period.end_date')
+    hours_spent = serializers.DecimalField(max_digits=5, decimal_places=2)
+    billable = serializers.BooleanField(source='project.accounting_code.billable')
+    mbnumber = serializers.CharField(source='project.mbnumber')
+
+def bulk_timecard_list(request):
+    """
+    Stream all the timecards as CSV.
+    """
+    queryset = get_timecards(TimecardList.queryset, request.GET)
+    serializer = BulkTimecardSerializer()
+    return stream_csv(queryset, serializer)
+
+def slim_bulk_timecard_list(request):
+    """
+    Stream a slimmed down version of all the timecards as CSV.
+    """
+    queryset = get_timecards(TimecardList.queryset, request.GET)
+    serializer = SlimBulkTimecardSerializer()
+    return stream_csv(queryset, serializer)
+
+def timeline_view(request, value_fields=(), **field_alias):
+    """ CSV endpoint for the project timeline viz """
+    queryset = get_timecards(TimecardList.queryset, request.GET)
+
+    fields = list(value_fields) + [
+        'timecard__reporting_period__start_date',
+        'timecard__reporting_period__end_date',
+        'project__accounting_code__billable'
+    ]
+
+    field_map = {
+        'timecard__reporting_period__start_date': 'start_date',
+        'timecard__reporting_period__end_date': 'end_date',
+        'project__accounting_code__billable': 'billable',
+    }
+    field_map.update(field_alias)
+
+    data = queryset.values(*fields).annotate(hours_spent=Sum('hours_spent'))
+
+    fields.append('hours_spent')
+
+    data = [
+        {
+            field_map.get(field, field): row.get(field)
+            for field in fields
+        }
+        for row in data
+    ]
+
+    response = HttpResponse(content_type='text/csv')
+
+    fieldnames = [field_map.get(field, field) for field in fields]
+    writer = csv.DictWriter(response, fieldnames=fieldnames)
+    writer.writeheader()
+    for row in data:
+        writer.writerow(row)
+    return response
+
+def project_timeline_view(request):
+    return timeline_view(
+        request,
+        value_fields=['project__id', 'project__name'],
+        project__id='project_id',
+        project__name='project_name',
+    )
+
+def user_timeline_view(request):
+    return timeline_view(
+        request,
+        value_fields=['timecard__user__username'],
+        timecard__user__username='user',
+    )
 
 
 class ReportingPeriodListView(PermissionMixin, ListView):

--- a/tock/tock/templates/base.html
+++ b/tock/tock/templates/base.html
@@ -49,7 +49,7 @@
         <li><b>Admin:</b></li>
         <li><a href="{% url 'reportingperiod:ReportingPeriodCreateView' %}">Add reporting period</a></li>
         <li><a href="/admin">Admin panel</a>
-        <li><a href="/api/timecards_bulk.csv">Bulk timecard CSV</a>
+        <li><a href="{% url 'reports:BulkTimecardList' %}">Bulk timecard CSV</a>
         {% endif %}
         <hr>
       </ul>

--- a/tock/tock/templates/hours/reports_list.html
+++ b/tock/tock/templates/hours/reports_list.html
@@ -7,8 +7,8 @@
 
 <h3> Raw data in .csv </h3>
 <ul>
-	<li><a href="http://tock.18f.gov/api/timecards_bulk.csv">Complete timecard data</a></li>
-	<li><a href="http://tock.18f.gov/api/slim_timecard_bulk.csv">Complete timecard data with fewer fields</a></li>
+	<li><a href="{% url 'reports:BulkTimecardList' %}">Complete timecard data</a></li>
+	<li><a href="{% url 'reports:SlimBulkTimecardList' %}">Complete timecard data with fewer fields</a></li>
 
 <div class="reporting-periods">
 	<h3>Reports by weekly reporting period</h3>

--- a/tock/tock/templates/projects/project_detail.html
+++ b/tock/tock/templates/projects/project_detail.html
@@ -65,7 +65,7 @@ Total hours saved, but not submitted: <span id="totalHoursSaved">{{ total_hours_
 <figure class="chart chart--utilization">
   <utilization-chart
     class="timeline timeline--project"
-    data-url="{% url 'UserTimelineView' %}?project={{ object.id }}"
+    data-url="{% url 'reports:UserTimelineView' %}?project={{ object.id }}"
     href="/employees/{% verbatim %}{{ user }} {% endverbatim %}"
     layer="user"
     color="user"

--- a/tock/tock/templates/projects/project_list.html
+++ b/tock/tock/templates/projects/project_list.html
@@ -7,7 +7,7 @@
   <h3 class="chart__title">Project Hours Over Time</h3>
   <utilization-chart
     class="timeline timeline--projects"
-    data-url="/api/project_timeline.csv"
+    data-url="/reports/project_timeline.csv"
     href="/projects/{% verbatim %}{{ project_id }}{% endverbatim %}"
     layer="project_name"
     color="project"


### PR DESCRIPTION
This change is complementary to #465 and  moves CSV reports (views, serializers, tests, and URL confs) to the /reports/ route which is behind the cloud.gov UAA authentication system. Users who consume these reports can do so after authenticating into Tock as usual.

Users getting JSON data can hit the /api/ route with a token.

Tip of the hat to @annalee for encouraging me to do this the _right_ way :-).