### PR TITLE
update b/g deployment scripts for new cloud.gov env

### DIFF
--- a/staging-deploy.sh
+++ b/staging-deploy.sh
@@ -17,11 +17,11 @@ deploy()
 	cf push $next_deployment --no-start -n $app_name-$timestamp
 	cf push $next_deployment -n $app_name-$timestamp
 	echo "Mapping $next_deployment to the Main Domain"
-	cf map-route $next_deployment 18f.gov -n $app_name
- 	cf map-route $next_deployment 18f.gov -n $app_name --path api
+	cf map-route $next_deployment fr.cloud.gov -n $app_name-staging
+ 	cf map-route $next_deployment fr.cloud.gov -n $app_name-staging --path api
 	echo "Removing $current_deployment From the Main Domain"
-	cf unmap-route $current_deployment 18f.gov -n $app_name
-  cf unmap-route $current_deployment 18f.gov -n $app_name --path api
+	cf unmap-route $current_deployment fr.cloud.gov -n $app_name-staging
+  cf unmap-route $current_deployment fr.cloud.gov -n $app_name-staging --path api
 	read -p "Check your app. Is it functioning properly? (y/n)" -n 1 -r
 	echo    # (optional) move to a new line
 	if [[ $REPLY =~ ^[Yy]$ ]]; then


### PR DESCRIPTION
This change updates script to new DB service (as opposed to a hardcoded DB address and key) and creates a nearly identical `staging-deploy.sh` script for zero downtime staging deploys. The staging script **must** be run in the cloud.gov staging space to avoid conflicts with the production app.