### PR TITLE
Allow access to user detail

### DIFF
--- a/tock/employees/tests/test_models.py
+++ b/tock/employees/tests/test_models.py
@@ -20,6 +20,12 @@ class UserDataTests(TestCase):
         userdata.save()
         self.token = Token.objects.create(user=self.regular_user)
 
+    def test_string_method(self):
+        """Check that string method override works correctly."""
+        userdata = UserData.objects.get(user=self.regular_user)
+        expected_string = str(userdata.user.username)
+        self.assertEqual(expected_string, str(userdata))
+
     def test_user_data_is_stored(self):
         """ Check that user data was stored correctly """
         userdata = UserData.objects.first()

--- a/tock/employees/tests/test_views.py
+++ b/tock/employees/tests/test_views.py
@@ -40,6 +40,22 @@ class UserViewTests(WebTest):
             status_code=200
         )
 
+    def test_access_to_user_form_for_self(self):
+        response = self.app.get(
+            reverse('employees:UserListView'),
+            headers={'X_AUTH_USER': 'aaron.snow@gsa.gov'},
+        )
+        self.assertContains(
+            response,
+            '<a href="/employees/e/aaron.snow">aaron.snow</a>',
+            status_code=200
+        )
+        self.assertNotContains(
+            response,
+            '<a href="/employees/aaron.snow">aaron.snow</a>',
+            status_code=200
+        )
+
     def test_parse_date(self):
         """ Test that the parse date function returns datetime obj when
         input is not NA """

--- a/tock/employees/tests/test_views.py
+++ b/tock/employees/tests/test_views.py
@@ -23,6 +23,23 @@ class UserViewTests(WebTest):
             end_date=datetime.datetime(2016, 1, 1)
         ).save()
 
+    def test_access_to_employee_static_view(self):
+        response = self.app.get(
+            reverse('employees:UserDetailView', args=["regular.user"]),
+            headers={'X_AUTH_USER': 'aaron.snow@gsa.gov'},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            'First Name:',
+            status_code=200
+        )
+        self.assertNotContains(
+            response,
+            '<form action="" method="post">',
+            status_code=200
+        )
+
     def test_parse_date(self):
         """ Test that the parse date function returns datetime obj when
         input is not NA """

--- a/tock/employees/urls.py
+++ b/tock/employees/urls.py
@@ -5,5 +5,7 @@ from . import views
 urlpatterns = [
     url(regex=r'^$', view=views.UserListView.as_view(), name='UserListView'),
     url(regex=r'^(?P<username>[A-Za-z0-9._%+-]*)/$',
+        view=views.UserDetailView.as_view(), name='UserDetailView'),
+    url(regex=r'^e/(?P<username>[A-Za-z0-9._%+-]*)/$',
         view=views.UserFormView.as_view(), name='UserFormView'),
 ]

--- a/tock/employees/views.py
+++ b/tock/employees/views.py
@@ -2,8 +2,10 @@ import datetime
 
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
-from django.views.generic import ListView
+from django.views.generic import ListView, DetailView
 from django.views.generic.edit import FormView
+from django.shortcuts import get_object_or_404
+
 
 from tock.utils import PermissionMixin, IsSuperUserOrSelf
 
@@ -28,6 +30,14 @@ class UserListView(ListView):
         context = super(UserListView, self).get_context_data(**kwargs)
         return context
 
+class UserDetailView(DetailView):
+    template_name = 'employees/user_detail.html'
+
+    def get_object(self, **kwargs):
+        kwargs['username'] = self.kwargs['username']
+        target_user = UserData.objects.get(
+            user__username=self.kwargs['username'])
+        return target_user
 
 class UserFormView(PermissionMixin, FormView):
     template_name = 'employees/user_form.html'

--- a/tock/tock/templates/employees/user_detail.html
+++ b/tock/tock/templates/employees/user_detail.html
@@ -1,0 +1,47 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h2>Let's Tock about {{ object.user.first_name }} {{ object.user.last_name }}!</h2>
+
+<figure class="chart chart--utilization">
+  <h3 class="chart__title">Project Hours Over Time</h3>
+  <utilization-chart
+    class="timeline timeline--project"
+    data-url="/reports/project_timeline.csv?user={{ username }}"
+    href="/projects/{% verbatim %}{{ project_id }}{% endverbatim %}"
+    layer="project_name"
+    color="project"
+    x="start_date"
+    y="hours_spent">
+  </utilization-chart>
+</figure>
+
+<table id="dataTable" class="striped">
+  <tr>
+    <td><b>First Name:</b></td>
+    <td>{{ object.user.first_name }}</td>
+  </tr>
+  <tr>
+    <td><b>Last Name:</b></td>
+    <td>{{ object.user.last_name }}</td>
+  </tr>
+  <tr>
+    <td><b>Employment Start Date:</b></td>
+    <td>{{ object.start_date }}</td>
+  </tr>
+  {% if object.end_date %}
+  <tr>
+    <td><b>Employment End Date:</b></td>
+    <td>{{ object.start_date }}</td>
+  </tr>
+  {% endif %}
+</table>
+{% endblock %}
+
+{% block js %}
+<script>
+$(function() {
+	$( ".datepicker" ).datepicker();
+});
+</script>
+{% endblock %}

--- a/tock/tock/templates/employees/user_detail.html
+++ b/tock/tock/templates/employees/user_detail.html
@@ -7,7 +7,7 @@
   <h3 class="chart__title">Project Hours Over Time</h3>
   <utilization-chart
     class="timeline timeline--project"
-    data-url="/reports/project_timeline.csv?user={{ username }}"
+    data-url="/reports/project_timeline.csv?user={{ object.user.username }}"
     href="/projects/{% verbatim %}{{ project_id }}{% endverbatim %}"
     layer="project_name"
     color="project"

--- a/tock/tock/templates/employees/user_list.html
+++ b/tock/tock/templates/employees/user_list.html
@@ -16,6 +16,8 @@
 		<td>
 			{% if request.user.is_superuser %}
 		 		<a href="/employees/e/{{ user.username }}">{{ user.username }}</a>
+			{% elif request.user.username == user.username %}
+				<a href="/employees/e/{{ user.username }}">{{ user.username }}</a>
 			{% else %}
 				<a href="/employees/{{ user.username }}">{{ user.username }}</a>
 			{% endif %}

--- a/tock/tock/templates/employees/user_list.html
+++ b/tock/tock/templates/employees/user_list.html
@@ -14,7 +14,11 @@
 	{% for user in object_list %}
 	<tr class="report_table__row">
 		<td>
-			<a href="/employees/{{ user.username }}">{{ user.username }}</a>
+			{% if request.user.is_superuser %}
+		 		<a href="/employees/e/{{ user.username }}">{{ user.username }}</a>
+			{% else %}
+				<a href="/employees/{{ user.username }}">{{ user.username }}</a>
+			{% endif %}
 		</td>
 		<td>{{ user.first_name }}</td>
 		<td>{{ user.last_name }}</td>


### PR DESCRIPTION
To address #218 and #486. 

Earlier resolution of #218 failed due to the retention of view-level permission (requiring either the requesting user be a superuser or requesting their own information). This PR addresses this issue as follows:

1. Creates a new employee detail view from the generic DetailView class that is accessible to all authenticated users;
2. Delivers this view via a new template, user_detail.html, which contains the same information from user_form.html (via UserFormView), but in static / non-editable form. [1]
3. The pre-existing UserFormView retains its permission requirement (superuser or self).
4. Testing added for new view.
5. Added new URL conf for user_detail.html and related view.
6. Updated logic on user_list.html to display one set of URLs (`/employees/f_name.last_name` for regular users; `/employees/e/f_name.last_name` for self or superusers).

_[1] The new template only displays the `end_date` attribute (employment end date) if one exists._