### PR TITLE
Revert all custom checkboxes to browser defaults

### DIFF
--- a/tock/tock/static/sass/_checkbox.scss
+++ b/tock/tock/static/sass/_checkbox.scss
@@ -1,0 +1,12 @@
+// Reverts to browser default checkboxes bc problems with USWDS custom checkboxes
+input[type="checkbox"] {
+  height: initial;
+  margin-left: 0;
+  opacity: 1;
+  position: relative;
+  width: auto;
+
+  &:focus {
+    box-shadow: none;
+  }
+}

--- a/tock/tock/static/sass/_entries.scss
+++ b/tock/tock/static/sass/_entries.scss
@@ -157,17 +157,6 @@
 
 .entry-delete {
 	@include span-columns(1);
-
-  input {
-    height: initial;
-    margin-left: 0;
-    opacity: 1;
-    width: auto;
-
-    &:focus {
-      box-shadow: none;
-    }
-  }
 }
 
 .entry-hidden {

--- a/tock/tock/static/sass/core.scss
+++ b/tock/tock/static/sass/core.scss
@@ -7,6 +7,7 @@
 @import "entries";
 @import "utils";
 @import "alert";
+@import "checkbox";
 
 // generic web component styles
 @import "components";


### PR DESCRIPTION
## Description

Reverts all checkboxes to use browser defaults bc of issues with USWDS checkboxes. Previously, browser default checkbox was set just on the timesheet page.

Fixes #556.

## This is what it looks like

<img width="390" alt="screen shot 2016-11-14 at 11 11 49 am" src="https://cloud.githubusercontent.com/assets/5249443/20278997/ae0d3990-aa5b-11e6-9d36-03eb3394eff8.png">