### PR TITLE
addresses #558

### DIFF
--- a/tock/tock/templates/projects/project_detail.html
+++ b/tock/tock/templates/projects/project_detail.html
@@ -24,6 +24,7 @@
       Non-Billable
     {% endif %}
   </li>
+  <li>
     <b> Agreement URL: </b>
 {% if project.agreement_URL %}
   <a href="{{ object.agreement_URL }}"> Google Drive folder </a>
@@ -46,7 +47,12 @@
 {% endif %}
   </li>
   <li>
-    <b> Description: </b> {{ object.description|default:'(no description provided)' }}
+    <b>Accounting Code:</b>
+      {{ object.profit_loss_account.accounting_string|default:'No accouting string available' }}
+  </li>
+  <li>
+    <b> Description: </b>
+      {{ object.description|default:'No description available' }}
   </li>
 
 </ul>


### PR DESCRIPTION
## Description

Addresses #558 by displaying the Project__profit_loss_account__accounting_string value if available. If not, states that the value is not available.

## Additional information

<img width="678" alt="screen shot 2016-11-14 at 4 58 40 pm" src="https://cloud.githubusercontent.com/assets/7645362/20284559/a54b2800-aa8b-11e6-91b7-6392ef0a749e.png">


