### PR TITLE
notes validation + meaningful error message

### DIFF
--- a/tock/hours/forms.py
+++ b/tock/hours/forms.py
@@ -184,21 +184,25 @@ class TimecardObjectForm(forms.ModelForm):
 
     def clean(self):
         super(TimecardObjectForm, self).clean()
-
         if 'notes' in self.cleaned_data and 'project' in self.cleaned_data:
             self.cleaned_data['notes'] = bleach.clean(
                 self.cleaned_data['notes'],
                 tags=[],
                 strip=True
             )
-
-            if self.cleaned_data['project'].notes_required and self.cleaned_data['notes'] == '':
-                self.add_error(
-                    'notes',
-                    forms.ValidationError('Please enter a snippet for this item.')
-                )
-            elif not self.cleaned_data['project'].notes_displayed:
-                del self.cleaned_data['notes']
+            if 'save_only' in self.data.keys():
+                pass
+            else:
+                if self.cleaned_data['project'].notes_required and \
+                    self.cleaned_data['notes'] == '':
+                    self.add_error(
+                        'notes',
+                        forms.ValidationError(
+                            'Please enter a snippet for this item.'
+                        )
+                    )
+                elif not self.cleaned_data['project'].notes_displayed:
+                    del self.cleaned_data['notes']
 
         return self.cleaned_data
 
@@ -240,7 +244,6 @@ class TimecardInlineFormSet(BaseInlineFormSet):
 
     def clean(self):
         super(TimecardInlineFormSet, self).clean()
-
         total_hrs = 0
         for form in self.forms:
             if form.cleaned_data:
@@ -252,9 +255,12 @@ class TimecardInlineFormSet(BaseInlineFormSet):
                         'cannot be blank.'
                     )
                 total_hrs += form.cleaned_data.get('hours_spent')
-
         if not self.save_only:
-
+            if self._errors:
+                raise forms.ValidationError(
+                    'Timecard not submitted because one or more of your '\
+                    'entries has an error!'
+                )
             if total_hrs > self.get_max_working_hours():
                 raise forms.ValidationError('You may not submit more than %s '
                     'hours for this period. To report additional hours'

--- a/tock/hours/forms.py
+++ b/tock/hours/forms.py
@@ -256,7 +256,7 @@ class TimecardInlineFormSet(BaseInlineFormSet):
                     )
                 total_hrs += form.cleaned_data.get('hours_spent')
         if not self.save_only:
-            if self._errors:
+            if len(self._errors[0].keys()) > 0:
                 raise forms.ValidationError(
                     'Timecard not submitted because one or more of your '\
                     'entries has an error!'


### PR DESCRIPTION
## Description

User could not save a timecard that contained a notes-required entry. This changeset addresses this by:

1. Only applying notes-required validation to cases where the user is attempting to submit the form, as opposed to all postings of the form;

2. Checking to see if there are any TimecardObject errors upon submission (non-save) and, if so, notifying the user that there is an error that needs to be corrected.

## Additional information

Include any of the following (as necessary):

Successful save with no notes:

<img width="814" alt="screen shot 2016-11-15 at 3 00 02 pm" src="https://cloud.githubusercontent.com/assets/7645362/20321673/46a34c06-ab44-11e6-9cd7-32b6c2553254.png">


Error message when a TimecardObject submission has an issue:

<img width="808" alt="screen shot 2016-11-15 at 3 01 09 pm" src="https://cloud.githubusercontent.com/assets/7645362/20321710/63d100e8-ab44-11e6-8593-70b76e48ac5e.png">

