### PR TITLE
add hours to utilization view and template, link to latest timecard

### DIFF
--- a/tock/tock/static/sass/base/_tables.scss
+++ b/tock/tock/static/sass/base/_tables.scss
@@ -23,3 +23,10 @@ td,
 th {
   vertical-align: middle;
 }
+
+// Custom table styles
+.table-subtext {
+  color: $color-gray;
+  font-size: $h6-font-size;
+  font-style: italic;
+}

--- a/tock/tock/templates/utilization/group_utilization.html
+++ b/tock/tock/templates/utilization/group_utilization.html
@@ -4,7 +4,6 @@
 
 <h2>Utilization by Unit</h2>
 {% if request.user.is_staff %}
-<br />
 <h3>Notes:</h3>
 <p>
 The following report contains users who are marked as billable in Tock,
@@ -22,26 +21,24 @@ Utilization is calculated by dividing the total number of hours submitted on
 projects that are marked "billable" in Tock, divided by the total number of
 hours submitted on all projects for the given period.
 </p>
-<br />
 <h3>Jump to:</h3>
 <ul>
 {% for i in unit_choices%}
   <li><a href="#{{i.1}}">{{i.1}}</a></li>
 {% endfor %}
 </ul>
-<br />
-<br />
+<br>
 
  {% for i in unit_choices %}
 
-<h3><a name="{{i.1}}">{{i.1}}</a></h3>
+<h3 id="{{i.1}}">{{i.1}}</h3>
 
 <table class="table-minimal report_table">
     <tr class="report_table__header-row">
         <th>Name</th>
-        <th>Last Week <br /> (Ending {{ through_date }})</th>
-        <th>Last Four Weeks <br /> ({{ recent_start_date }} - {{ through_date }})</th>
-    <th>Fiscal Year to Date <br /> (Ending {{ through_date }})</th>
+        <th>Last Week <br> (Ending {{ through_date }}) <br><span class="table-subtext">% billable (billable hrs / total hrs)</span></th>
+        <th>Last Four Weeks <br> ({{ recent_start_date }} - {{ through_date }}) <br><span class="table-subtext">% billable (billable hrs / total hrs)</span></th>
+    <th>Fiscal Year to Date <br> (Ending {{ through_date }}) <br><span class="table-subtext">% billable (billable hrs / total hrs)</span></th>
     </tr>
 
     {% for userdata in object_list %}
@@ -53,7 +50,7 @@ hours submitted on all projects for the given period.
         </td>
         <td>
           {% if userdata.last_all_hours_total %}
-              <a href='{{ userdata.last_url }}'>
+              <a href='{{ userdata.last_url }}' title="Percent billable (billable hours / total hours)">
                 {{ userdata.last }}
                 ({{ userdata.last_billable_hours_total }} /
                 {{ userdata.last_all_hours_total }})
@@ -85,7 +82,7 @@ hours submitted on all projects for the given period.
       {% endif %}
     {% endfor %}
 </table>
-<br />
+<br>
 
 {% endfor %}
 

--- a/tock/tock/templates/utilization/group_utilization.html
+++ b/tock/tock/templates/utilization/group_utilization.html
@@ -46,16 +46,43 @@ hours submitted on all projects for the given period.
 
     {% for userdata in object_list %}
 
-    {% if userdata.unit is i.0 %}
-    <tr class="report_table__row">
-      <td>
-        {{ userdata.user_data }}
-      </td>
-      <td>{{ userdata.last }}</td>
-      <td>{{ userdata.recent }}</td>
-      <td>{{ userdata.fytd }}</td>
-    </tr>
-    {% endif %}
+      {% if userdata.unit is i.0 %}
+      <tr class="report_table__row">
+        <td>
+          {{ userdata.user_data }}
+        </td>
+        <td>
+          {% if userdata.last_all_hours_total %}
+              <a href='{{ userdata.last_url }}'>
+                {{ userdata.last }}
+                ({{ userdata.last_billable_hours_total }} /
+                {{ userdata.last_all_hours_total }})
+              </a>
+          {% else %}
+              --
+          {% endif %}
+        </td>
+        <td>
+          {% if userdata.recent_all_hours_total %}
+            {{ userdata.recent }}
+            ({{ userdata.recent_billable_hours_total }} /
+            {{ userdata.recent_all_hours_total }})
+          {% else %}
+            --
+          {% endif %}
+          </td>
+
+        <td>
+          {% if userdata.fytd_all_hours_total %}
+            {{ userdata.fytd }}
+            ({{ userdata.fytd_billable_hours_total }} /
+            {{ userdata.fytd_all_hours_total }})
+          {% else %}
+            --
+          {% endif %}
+        </td>
+      </tr>
+      {% endif %}
     {% endfor %}
 </table>
 <br />

--- a/tock/utilization/tests/test_views.py
+++ b/tock/utilization/tests/test_views.py
@@ -33,7 +33,7 @@ class TestUtils(TestCase):
     def test_get_dates(self):
         periods = ReportingPeriod.objects.count() -1
         result = get_dates(periods)
-        self.assertEqual(len(result), 4)
+        self.assertEqual(len(result), 5)
         self.assertTrue(result[1] <= result[2])
         self.assertFalse(result[2] == result[3])
 

--- a/tock/utilization/utils.py
+++ b/tock/utilization/utils.py
@@ -34,8 +34,10 @@ def get_dates(periods):
     else:
         earliest_date = fy_first_day
 
+    latest_start_date = reportingperiods[0].start_date
+
     return reportingperiods_end_date, reportingperiods_start_date, \
-        fy_first_day, earliest_date
+        fy_first_day, earliest_date, latest_start_date
 
 """Calculates utilization as hours billed divided by hours worked."""
 def calculate_utilization(billable_hours, all_hours):

--- a/tock/utilization/views.py
+++ b/tock/utilization/views.py
@@ -3,6 +3,7 @@ import datetime
 from django.db.models import Sum, Prefetch
 from django.views.generic import ListView
 from django.contrib.auth.models import User
+from django.core.urlresolvers import reverse
 
 from hours.models import Timecard, TimecardObject, ReportingPeriod
 from employees.models import UserData
@@ -125,15 +126,42 @@ class GroupUtilizationView(ListView):
                 fytd_billable_hours['hours_spent__sum'],
                 fytd_all_hours['hours_spent__sum']
             )
+            staffer.fytd_all_hours_total = fytd_all_hours['hours_spent__sum']
+            if fytd_billable_hours['hours_spent__sum']:
+                staffer.fytd_billable_hours_total = fytd_billable_hours['hours_spent__sum']
+            else:
+                staffer.fytd_billable_hours_total = 0.0
 
             staffer.recent = calculate_utilization(
                 recent_billable_hours['hours_spent__sum'],
                 recent_all_hours['hours_spent__sum']
             )
+            staffer.recent_all_hours_total = recent_all_hours['hours_spent__sum']
+            if recent_billable_hours['hours_spent__sum']:
+                staffer.recent_billable_hours_total = recent_billable_hours['hours_spent__sum']
+            else:
+                staffer.recent_billable_hours_total = 0.0
+
 
             staffer.last = calculate_utilization(
                 last_billable_hours['hours_spent__sum'],
                 last_all_hours['hours_spent__sum']
+            )
+            staffer.last_all_hours_total = last_all_hours['hours_spent__sum']
+            if last_billable_hours['hours_spent__sum']:
+                staffer.last_billable_hours_total = last_billable_hours['hours_spent__sum']
+            else:
+                staffer.last_billable_hours_total = 0.0
+
+
+
+            print()
+            staffer.last_url = reverse(
+                'reports:ReportingPeriodUserDetailView',
+                kwargs={
+                        'username':staffer,
+                        'reporting_period': recent_rps[4]
+                }
             )
 
         return billable_staff


### PR DESCRIPTION
## Description

First PR in a series designed to address #561 (Team Reporting Improvements). This PR updates the utilization page and corresponding GroupUtilization view by:

- adding hourly numerator and denominator information; and
- generating a link to the latest timecard for each user.

This enhancement serves as the "starting point" described by a [user](https://github.com/18F/tock/issues/561#issuecomment-261322088).

## Additional information

For those with staff-level access to our staging site, the proposed enhancements are viewable [here](tock.app.cloud.gov/utilization/).