### PR TITLE
on submit, removes any TimecardObjects that have zero hours

### DIFF
--- a/tock/hours/forms.py
+++ b/tock/hours/forms.py
@@ -256,6 +256,9 @@ class TimecardInlineFormSet(BaseInlineFormSet):
                     )
                 total_hrs += form.cleaned_data.get('hours_spent')
         if not self.save_only:
+            for form in self.forms:
+                if form.cleaned_data['hours_spent'] == 0:
+                    form.cleaned_data.update({'DELETE': True})
             if len(self._errors[0].keys()) > 0:
                 raise forms.ValidationError(
                     'Timecard not submitted because one or more of your '\

--- a/tock/hours/tests/test_forms.py
+++ b/tock/hours/tests/test_forms.py
@@ -211,6 +211,21 @@ class TimecardInlineFormSetTests(TestCase):
         formset = TimecardFormSet(form_data)
         self.assertTrue(formset.is_valid())
 
+    def test_no_zero_hours_saved(self):
+        """Tests that TimecardObject's with None or 0 hours are not entered
+        into the database on form submission."""
+        form_data = {
+            'timecardobjects-TOTAL_FORMS': '1',
+            'timecardobjects-INITIAL_FORMS': '0',
+            'timecardobjects-MIN_NUM_FORMS': '',
+            'timecardobjects-MAX_NUM_FORMS': '',
+            'timecardobjects-0-project': '4',
+            'timecardobjects-0-hours_spent': ''
+        }
+        formset = TimecardFormSet(form_data)
+        formset.is_valid()
+        self.assertTrue(formset[0].cleaned_data['DELETE'])
+
     def test_reporting_period_with_less_than_min_hours_success(self):
         """ Test the timecard form when the reporting period requires at least
         16 hours to be reported and the hours entered are less than 16"""


### PR DESCRIPTION
## Description

Addresses #552 by marking TimecardObject's to be DELETE'ed if they have a zero value for hours_spent. Upon merge and deployment, this will eliminate the existence of all future timecards having entries with 0 hours spent.  cc @HuixianXu and @MKathrynC who will also probably be happy to eliminate this issue.

## Additional information

Here is a screenshot of the problem:

<img width="813" alt="screen shot 2016-11-18 at 11 19 29 am" src="https://cloud.githubusercontent.com/assets/7645362/20437174/f57be5a6-ad80-11e6-8bd9-822500a3889e.png">

After merge and deploy of this change, I also recommend we clear out all existing TimecardObjects with zero hours spent from the production database.

