### PR TITLE
Patch #564 to handle errors correctly

### DIFF
--- a/tock/hours/forms.py
+++ b/tock/hours/forms.py
@@ -257,8 +257,11 @@ class TimecardInlineFormSet(BaseInlineFormSet):
                 total_hrs += form.cleaned_data.get('hours_spent')
         if not self.save_only:
             for form in self.forms:
-                if form.cleaned_data['hours_spent'] == 0:
-                    form.cleaned_data.update({'DELETE': True})
+                try:
+                    if form.cleaned_data['hours_spent'] == 0:
+                        form.cleaned_data.update({'DELETE': True})
+                except KeyError:
+                    pass
             if len(self._errors[0].keys()) > 0:
                 raise forms.ValidationError(
                     'Timecard not submitted because one or more of your '\


### PR DESCRIPTION
## Description

This PR patches #564 to handle situations where a submitted form within the TimecardInlineFormset is completely empty (i.e. no project, no hours_spent) and a KeyError is thrown.


