### PR TITLE
Adds add'l text to table header and title text to link

### DIFF
--- a/tock/tock/static/sass/base/_tables.scss
+++ b/tock/tock/static/sass/base/_tables.scss
@@ -23,3 +23,10 @@ td,
 th {
   vertical-align: middle;
 }
+
+// Custom table styles
+.table-subtext {
+  color: $color-gray;
+  font-size: $h6-font-size;
+  font-style: italic;
+}

--- a/tock/tock/templates/utilization/group_utilization.html
+++ b/tock/tock/templates/utilization/group_utilization.html
@@ -4,7 +4,6 @@
 
 <h2>Utilization by Unit</h2>
 {% if request.user.is_staff %}
-<br>
 <h3>Notes:</h3>
 <p>
 The following report contains users who are marked as billable in Tock,
@@ -22,15 +21,12 @@ Utilization is calculated by dividing the total number of hours submitted on
 projects that are marked "billable" in Tock, divided by the total number of
 hours submitted on all projects for the given period.
 </p>
-<br>
 <h3>Jump to:</h3>
 <ul>
 {% for i in unit_choices%}
   <li><a href="#{{i.1}}">{{i.1}}</a></li>
 {% endfor %}
 </ul>
-<br>
-<br>
 
  {% for i in unit_choices %}
 

--- a/tock/tock/templates/utilization/group_utilization.html
+++ b/tock/tock/templates/utilization/group_utilization.html
@@ -27,10 +27,11 @@ hours submitted on all projects for the given period.
   <li><a href="#{{i.1}}">{{i.1}}</a></li>
 {% endfor %}
 </ul>
+<br>
 
  {% for i in unit_choices %}
 
-<h3><a name="{{i.1}}">{{i.1}}</a></h3>
+<h3 id="{{i.1}}">{{i.1}}</h3>
 
 <table class="table-minimal report_table">
     <tr class="report_table__header-row">

--- a/tock/tock/templates/utilization/group_utilization.html
+++ b/tock/tock/templates/utilization/group_utilization.html
@@ -53,7 +53,7 @@ hours submitted on all projects for the given period.
         </td>
         <td>
           {% if userdata.last_all_hours_total %}
-              <a href='{{ userdata.last_url }}'>
+              <a href='{{ userdata.last_url }}' title="Percent billable (billable hours / total hours)">
                 {{ userdata.last }}
                 ({{ userdata.last_billable_hours_total }} /
                 {{ userdata.last_all_hours_total }})

--- a/tock/tock/templates/utilization/group_utilization.html
+++ b/tock/tock/templates/utilization/group_utilization.html
@@ -39,9 +39,9 @@ hours submitted on all projects for the given period.
 <table class="table-minimal report_table">
     <tr class="report_table__header-row">
         <th>Name</th>
-        <th>Last Week <br> (Ending {{ through_date }})</th>
-        <th>Last Four Weeks <br> ({{ recent_start_date }} - {{ through_date }})</th>
-    <th>Fiscal Year to Date <br> (Ending {{ through_date }})</th>
+        <th>Last Week <br> (Ending {{ through_date }}) <br><span class="table-subtext">% billable (billable hrs / total hrs)</span></th>
+        <th>Last Four Weeks <br> ({{ recent_start_date }} - {{ through_date }}) <br><span class="table-subtext">% billable (billable hrs / total hrs)</span></th>
+    <th>Fiscal Year to Date <br> (Ending {{ through_date }}) <br><span class="table-subtext">% billable (billable hrs / total hrs)</span></th>
     </tr>
 
     {% for userdata in object_list %}

--- a/tock/tock/templates/utilization/group_utilization.html
+++ b/tock/tock/templates/utilization/group_utilization.html
@@ -4,7 +4,7 @@
 
 <h2>Utilization by Unit</h2>
 {% if request.user.is_staff %}
-<br />
+<br>
 <h3>Notes:</h3>
 <p>
 The following report contains users who are marked as billable in Tock,
@@ -22,15 +22,15 @@ Utilization is calculated by dividing the total number of hours submitted on
 projects that are marked "billable" in Tock, divided by the total number of
 hours submitted on all projects for the given period.
 </p>
-<br />
+<br>
 <h3>Jump to:</h3>
 <ul>
 {% for i in unit_choices%}
   <li><a href="#{{i.1}}">{{i.1}}</a></li>
 {% endfor %}
 </ul>
-<br />
-<br />
+<br>
+<br>
 
  {% for i in unit_choices %}
 
@@ -39,9 +39,9 @@ hours submitted on all projects for the given period.
 <table class="table-minimal report_table">
     <tr class="report_table__header-row">
         <th>Name</th>
-        <th>Last Week <br /> (Ending {{ through_date }})</th>
-        <th>Last Four Weeks <br /> ({{ recent_start_date }} - {{ through_date }})</th>
-    <th>Fiscal Year to Date <br /> (Ending {{ through_date }})</th>
+        <th>Last Week <br> (Ending {{ through_date }})</th>
+        <th>Last Four Weeks <br> ({{ recent_start_date }} - {{ through_date }})</th>
+    <th>Fiscal Year to Date <br> (Ending {{ through_date }})</th>
     </tr>
 
     {% for userdata in object_list %}
@@ -85,7 +85,7 @@ hours submitted on all projects for the given period.
       {% endif %}
     {% endfor %}
 </table>
-<br />
+<br>
 
 {% endfor %}
 


### PR DESCRIPTION
## Description

Adds add'l text to the table header and adds title text to the link to describe you're looking at `Percent billable (billable hours / total hours)`. Cleans up some line breaks and removes anchor link from headers.

## Additional information

### This is what the add'l table header text looks like:
<img width="934" alt="screen shot 2016-11-21 at 11 52 52 am" src="https://cloud.githubusercontent.com/assets/5249443/20498250/42c08256-afe1-11e6-8895-f67a108eb567.png">

### This is what the title text looks like:
<img width="933" alt="screen shot 2016-11-21 at 11 53 38 am" src="https://cloud.githubusercontent.com/assets/5249443/20498254/458a35a4-afe1-11e6-8373-f21524a21215.png">

*Note: this is fake data for demonstration purposes.
