### PR TITLE
Fix Reporting Period CSV Report

### DIFF
--- a/tock/hours/tests/test_views.py
+++ b/tock/hours/tests/test_views.py
@@ -435,7 +435,7 @@ class ReportTests(WebTest):
         )
         lines = response.content.decode('utf-8').splitlines()
         self.assertEqual(len(lines), 3)
-        result = '2015-01-01 - 2015-01-07,{0},aaron.snow@gsa.gov,Peace Corps,28.00'
+        result = '2015-01-01 - 2015-01-07,{0},aaron.snow,Peace Corps,28.00'
         self.assertEqual(
             result.format(
                 self.timecard.modified.strftime('%Y-%m-%d %H:%M:%S')

--- a/tock/hours/views.py
+++ b/tock/hours/views.py
@@ -490,7 +490,7 @@ def ReportingPeriodCSVView(request, reporting_period):
                 timecard_object.timecard.reporting_period.start_date,
                 timecard_object.timecard.reporting_period.end_date),
              timecard_object.timecard.modified.strftime("%Y-%m-%d %H:%M:%S"),
-             timecard_object.timecard.user.email, timecard_object.project,
+             timecard_object.timecard.user.username, timecard_object.project,
              timecard_object.hours_spent])
 
     return response


### PR DESCRIPTION
## Description

Addresses issues raised in Slack on 11/18 re: missing names in the reports/[YYYY-MM-DD].csv file. The CSV writer relied on email address data for the "User" column of the CSV. If the user did not have an email address in the app, a blank was written in its place. This created the appearance of missing records in the output CSV.

This changes switches out email address for username, which is more reliable because all users have a username.

cc @GailSwanson @acolter 