### PR TITLE
Tune Up Accounting Code Logic

### DIFF
--- a/tock/employees/admin.py
+++ b/tock/employees/admin.py
@@ -25,18 +25,6 @@ class UserDataForm(forms.ModelForm):
                 )
 
             if pl_info and \
-            (pl_info.as_start_date > self.cleaned_data['start_date']):
-                raise forms.ValidationError('The profit/loss accounting '\
-                    'information you have selected, {}, has a start date that '\
-                    'is after the start date of {}. Please select profit/loss '\
-                    'accounting information with a start date that occurs on '\
-                    'or before {}.'.format(
-                        pl_info,
-                        self.cleaned_data['user'],
-                        self.cleaned_data['start_date']
-                    )
-                )
-            if pl_info and \
             (pl_info.as_end_date < self.cleaned_data['start_date']):
                 raise forms.ValidationError('The profit/loss accounting' \
                     'information you have selected, {}, has an end date that '\

--- a/tock/employees/tests/test_admin.py
+++ b/tock/employees/tests/test_admin.py
@@ -16,7 +16,7 @@ class TestUserDataForm(TestCase):
         """Tests custom admin form validation."""
 
         # Checks that a ProfitLossAccount object with a start date that is
-        # after the employee's start date is rejected.
+        # after the employee's start date is accepted.
         ProfitLossAccount.objects.create(
             name='PL',
             accounting_string='1234',
@@ -37,18 +37,18 @@ class TestUserDataForm(TestCase):
             'profit_loss_account': ProfitLossAccount.objects.first().id
         }
         form = UserDataForm(data=form_data)
-        self.assertFalse(form.is_valid())
+        self.assertTrue(form.is_valid())
 
-        # Checks that correcting the previous start date issue results in
-        # the ProfitLossAccount object being successfully associated with the
-        # UserData object.
+        # Checks that changing the start date to a date that is after the
+        # end date of the ProfitLossAccount object results in a rejection.
         form_data.update(
             {
-                'start_date': ProfitLossAccount.objects.first().as_start_date
+                'start_date': ProfitLossAccount.objects.first().as_end_date \
+                    + datetime.timedelta(days=1)
             }
         )
         form = UserDataForm(data=form_data)
-        self.assertTrue(form.is_valid())
+        self.assertFalse(form.is_valid())
 
         # Checks that a ProfitLossAccount object with the wrong account type is
         # rejected.


### PR DESCRIPTION
## Description

When loading in accounting code info into the production instance, I noticed an issue with the logic from #562 (Extend Profit/Loss Accounting Info): the logic unnecessarily restricts the association of accounting codes with employees based on the start date of the user and the start date of the accounting code. For instance, if I started on 12/01/2014, only accounting codes with start dates on or before that date could be associated with my UserData object. This doesn't make sense because generally accounting codes are refreshed / recreated every fiscal year.

This change backs out the overly-restrictive logic and updates tests to comply. _Note_ that this change does not impact the model-level logic for the application of revenue and expense codes to TimecardObjects: these still check to see what accounting code is "in force" during the associated reporting period and, if one is available, associates the accounting code with the TimecardObject.
