### PR TITLE
provide user with more reporting options

### DIFF
--- a/tock/tock/templates/hours/reports_list.html
+++ b/tock/tock/templates/hours/reports_list.html
@@ -9,17 +9,36 @@
 <ul>
 	{% if user.is_superuser %}
 	<i>Superuser Reports</i>
-	<li><a href="{% url 'reports:AdminBulkTimecardList' %}">Complete timecard data with grade info</a></li>
+	<li>Complete timecard data with grade info:
+			<a href="{% url 'reports:AdminBulkTimecardList' %}">All</a>
+			<a href="{% url 'reports:AdminBulkTimecardList' %}?after=2016-10-01">FY2017</a>
+	</li>
 	<br />
 	<i>Regular Reports</i>
 	{% endif %}
-	<li><a href="{% url 'reports:BulkTimecardList' %}">Complete timecard data</a></li>
-	<li><a href="{% url 'reports:SlimBulkTimecardList' %}">Complete timecard data with fewer fields</a></li>
-	<li><a href="{% url 'reports:ProjectTimelineView' %}">Aggregate hourly data by project and reporting period</a></li>
-	<li><a href="{% url 'reports:UserTimelineView' %}">Aggregate hourly data by user, reporting period, and project billable status</a></li>
+	<li>Complete timecard data:
+		<a href="{% url 'reports:BulkTimecardList' %}">All</a>
+		<a href="{% url 'reports:BulkTimecardList' %}?after=2016-10-01">FY2017</a>
+	</li>
+	<li>Complete timecard data with fewer fields:
+		<a href="{% url 'reports:SlimBulkTimecardList' %}">All</a>
+		<a href="{% url 'reports:SlimBulkTimecardList' %}?after=2016-10-01">FY2017</a>
+	</li>
+	<li>Complete snippet data for 'General':
+			<a href="{% url 'reports:GeneralSnippetsView' %}">All</a>
+			<a href="{% url 'reports:GeneralSnippetsView' %}?after=2016-10-01">FY2017</a>
+	</li>
+	<li>Aggregate hourly data by project and reporting period:
+		<a href="{% url 'reports:ProjectTimelineView' %}">All</a>
+		<a href="{% url 'reports:ProjectTimelineView' %}?after=2016-10-01">FY2017</a>
+	</li>
+	<li>Aggregate hourly data by user, reporting period, and project billable status:
+		<a href="{% url 'reports:UserTimelineView' %}">All</a>
+		<a href="{% url 'reports:UserTimelineView' %}?after=2016-10-01">FY2017</a>
+	</li>
 	<li><a href="{% url 'reports:ProjectList' %}">List of all projects</a></li>
 	<li><a href="{% url 'reports:UserDataView' %}">List of all users</a></li>
-	<li><a href="{% url 'reports:GeneralSnippetsView' %}">Complete snippet data for 'General'</a></li>
+
 
 <div class="reporting-periods">
 	<h3>Reports by weekly reporting period</h3>


### PR DESCRIPTION
## Description

This change to the reports template makes use of the `?after=` parameter available via Tock's RESTful framework to give the user the option to download a CSV containing either all the data or just a single fiscal year (in this case, FY17).

## Additional information

Screenshot of changes:

----
<img width="737" alt="screen shot 2016-11-23 at 2 03 27 pm" src="https://cloud.githubusercontent.com/assets/7645362/20575060/a5f25cf0-b185-11e6-8f63-c904d43bbf00.png">

