### PR TITLE
User summary row

### DIFF
--- a/tock/hours/tests/test_views.py
+++ b/tock/hours/tests/test_views.py
@@ -181,6 +181,52 @@ class UtilTests(TestCase):
         """Ensure the number of hours returns a correct value"""
         self.assertEqual(20, number_of_hours(50, 40))
 
+class UserReportsTest(TestCase):
+    fixtures = [
+        'tock/fixtures/prod_user.json',
+        'projects/fixtures/projects.json',
+        'employees/fixtures/user_data.json'
+    ]
+    def setUp(self):
+        self.user = User.objects.first()
+        user_data = UserData.objects.first()
+        user_data.user = self.user
+        user_data.save()
+
+        self.reporting_period = hours.models.ReportingPeriod.objects.create(
+            start_date=datetime.date(1999, 12, 31),
+            end_date=datetime.date(2000, 1, 1)
+        )
+        self.timecard = hours.models.Timecard.objects.create(
+            user=self.user,
+            reporting_period=self.reporting_period
+        )
+        self.nonbillable_project = hours.models.Project.objects.filter(
+            accounting_code__billable=False
+        )[0]
+        self.billable_project = projects.models.Project.objects.filter(
+            accounting_code__billable=True
+        )[0]
+        self.timecard_obj_0 = hours.models.TimecardObject.objects.create(
+            timecard=self.timecard,
+            project=self.nonbillable_project,
+            hours_spent=13
+        )
+        self.timecard_obj_1 = hours.models.TimecardObject.objects.create(
+            timecard=self.timecard,
+            project=self.billable_project,
+            hours_spent=27
+        )
+
+    def test_user_reporting_period_report(self):
+        response = client(self).get(reverse(
+            'reports:ReportingPeriodUserDetailView',
+            kwargs={'reporting_period':'1999-12-31', 'username':'aaron.snow'}
+        ))
+        self.assertEqual(response.context['user_utilization'], '67.5%')
+        self.assertEqual(response.context['user_all_hours'], 40.00)
+        self.assertEqual(response.context['user_billable_hours'], 27)
+        self.assertContains(response, '67.5%')
 
 class ReportTests(WebTest):
     fixtures = [

--- a/tock/hours/views.py
+++ b/tock/hours/views.py
@@ -529,11 +529,14 @@ class ReportingPeriodUserDetailView(DetailView):
     template_name = "hours/reporting_period_user_detail.html"
 
     def get_object(self):
-        return get_object_or_404(
-            Timecard,
+        obj = Timecard.objects.prefetch_related(
+            'timecardobjects__project',
+            'timecardobjects__project__accounting_code'
+        ).get(
             reporting_period__start_date=self.kwargs['reporting_period'],
             user__username=self.kwargs['username']
         )
+        return obj
 
     def get_context_data(self, **kwargs):
         user_billable_hours = TimecardObject.objects.filter(

--- a/tock/tock/templates/hours/reporting_period_user_detail.html
+++ b/tock/tock/templates/hours/reporting_period_user_detail.html
@@ -37,7 +37,21 @@
     {% endif %}
 	{% endfor %}
 </table>
-
 <div>First Submitted: {{ object.created }}</div>
 Last Changed: {{ object.modified }}
+
+<h3> Reporting Period Summary </h3>
+<table class="table-minimal report_table">
+	<tr class="report_table__header-row">
+		<th>Billable Hours</th>
+		<th>Total Hours</th>
+		<th>Billable %</th>
+	</tr>
+	<tr class="report_table__header-row">
+		<td> {{ user_billable_hours }} </td>
+		<td> {{ user_all_hours }} </td>
+		<td> {{ user_utilization }} </td>
+	</tr>
+</table>
+
 {% endblock %}


### PR DESCRIPTION
## Description

Adds a new table to the user timecard detail page that summarizes billable hours, all hours, and billable percentage for a user in a specific reporting period. Feature requested in #551.

This change also addresses an existing n+1 query issue by prefetching project and accounting code information along with timecard info for eventual use in the template.

## Additional information

Screenshot of changes:

----

<img width="1016" alt="screen shot 2016-11-25 at 11 29 18 am" src="https://cloud.githubusercontent.com/assets/7645362/20631000/6f4bed78-b302-11e6-89ab-5a21afd7ed88.png">
