### PR TITLE
[WIP] 511 addhours endpoint

### DIFF
--- a/tock/hours/tests/test_views.py
+++ b/tock/hours/tests/test_views.py
@@ -181,6 +181,52 @@ class UtilTests(TestCase):
         """Ensure the number of hours returns a correct value"""
         self.assertEqual(20, number_of_hours(50, 40))
 
+class UserReportsTest(TestCase):
+    fixtures = [
+        'tock/fixtures/prod_user.json',
+        'projects/fixtures/projects.json',
+        'employees/fixtures/user_data.json'
+    ]
+    def setUp(self):
+        self.user = User.objects.first()
+        user_data = UserData.objects.first()
+        user_data.user = self.user
+        user_data.save()
+
+        self.reporting_period = hours.models.ReportingPeriod.objects.create(
+            start_date=datetime.date(1999, 12, 31),
+            end_date=datetime.date(2000, 1, 1)
+        )
+        self.timecard = hours.models.Timecard.objects.create(
+            user=self.user,
+            reporting_period=self.reporting_period
+        )
+        self.nonbillable_project = hours.models.Project.objects.filter(
+            accounting_code__billable=False
+        )[0]
+        self.billable_project = projects.models.Project.objects.filter(
+            accounting_code__billable=True
+        )[0]
+        self.timecard_obj_0 = hours.models.TimecardObject.objects.create(
+            timecard=self.timecard,
+            project=self.nonbillable_project,
+            hours_spent=13
+        )
+        self.timecard_obj_1 = hours.models.TimecardObject.objects.create(
+            timecard=self.timecard,
+            project=self.billable_project,
+            hours_spent=27
+        )
+
+    def test_user_reporting_period_report(self):
+        response = client(self).get(reverse(
+            'reports:ReportingPeriodUserDetailView',
+            kwargs={'reporting_period':'1999-12-31', 'username':'aaron.snow'}
+        ))
+        self.assertEqual(response.context['user_utilization'], '67.5%')
+        self.assertEqual(response.context['user_all_hours'], 40.00)
+        self.assertEqual(response.context['user_billable_hours'], 27)
+        self.assertContains(response, '67.5%')
 
 class ReportTests(WebTest):
     fixtures = [

--- a/tock/hours/views.py
+++ b/tock/hours/views.py
@@ -1,6 +1,7 @@
 import csv
 import datetime
 import io
+from decimal import Decimal
 from itertools import chain
 from operator import attrgetter
 
@@ -10,11 +11,12 @@ from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError, ObjectDoesNotExist
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse
-from django.shortcuts import get_object_or_404
+from django.shortcuts import get_object_or_404, redirect
 from django.views.generic import ListView, DetailView
 from django.views.generic.edit import CreateView, UpdateView, FormView
 from django.db.models import Prefetch, Q, Sum
 from django.contrib.auth.decorators import user_passes_test
+from django.template.defaultfilters import pluralize
 
 from rest_framework.permissions import IsAuthenticated
 from rest_framework import serializers
@@ -313,6 +315,58 @@ class ReportingPeriodBulkImportView(PermissionMixin, FormView):
     def get_success_url(self):
         return reverse("ListReportingPeriods")
 
+def add_hours_view(request):
+    project_id = request.GET['project']
+    hours = Decimal(request.GET['hours'])
+    r = ReportingPeriod.objects.latest()
+
+    try:
+        proj = Project.objects.get(id=project_id)
+    except Project.DoesNotExist:
+        msg = "Hours not updated. Project with ID %s does Not Exist" % (project_id)
+        messages.add_message(
+            request,
+            messages.ERROR,
+            msg
+        )
+        return redirect(reverse('reportingperiod:UpdateTimesheet', args=[r]))
+
+    tc, created = Timecard.objects.get_or_create(
+        reporting_period_id=r.id,
+        user_id=request.user.id)
+
+    if created:
+        tc.save()
+
+    tco, created = TimecardObject.objects.get_or_create(
+        timecard_id=tc.id,
+        project_id=proj.id)
+
+    if tco.hours_spent is None:
+        tco.hours_spent = 0
+
+    updated_hours = tco.hours_spent + hours
+    updated_hours = max(0, updated_hours)
+
+    tco.hours_spent = updated_hours
+    tco.save()
+
+    if hours > 0:
+        plural_hours = pluralize(hours, 'hour,hours')
+        has = pluralize(hours, 'has,have')
+        undo_query = "?hours=-%s&project=%s" % (hours, proj.id)
+        undo_url = reverse('AddHours') + undo_query
+        undo_tag = "<a href=\"%s\">Undo</a>" % (undo_url)
+        msg = "%s %s %s been added to %s. %s" % (hours, plural_hours, has,
+                proj.name, undo_tag)
+    else:
+        plural_hours = pluralize(-hours, 'hour,hours')
+        has = pluralize(-hours, 'has,have')
+        msg = "%s %s %s been removed from %s." % (-hours, plural_hours, has,
+                proj.name)
+
+    messages.add_message(request, messages.INFO, msg)
+    return redirect(reverse('reportingperiod:UpdateTimesheet', args=[r]))
 
 class TimecardView(UpdateView):
     form_class = TimecardForm

--- a/tock/hours/views.py
+++ b/tock/hours/views.py
@@ -529,11 +529,14 @@ class ReportingPeriodUserDetailView(DetailView):
     template_name = "hours/reporting_period_user_detail.html"
 
     def get_object(self):
-        return get_object_or_404(
-            Timecard,
+        obj = Timecard.objects.prefetch_related(
+            'timecardobjects__project',
+            'timecardobjects__project__accounting_code'
+        ).get(
             reporting_period__start_date=self.kwargs['reporting_period'],
             user__username=self.kwargs['username']
         )
+        return obj
 
     def get_context_data(self, **kwargs):
         user_billable_hours = TimecardObject.objects.filter(

--- a/tock/tock/templates/hours/reporting_period_user_detail.html
+++ b/tock/tock/templates/hours/reporting_period_user_detail.html
@@ -37,7 +37,21 @@
     {% endif %}
 	{% endfor %}
 </table>
-
 <div>First Submitted: {{ object.created }}</div>
 Last Changed: {{ object.modified }}
+
+<h3> Reporting Period Summary </h3>
+<table class="table-minimal report_table">
+	<tr class="report_table__header-row">
+		<th>Billable Hours</th>
+		<th>Total Hours</th>
+		<th>Billable %</th>
+	</tr>
+	<tr class="report_table__header-row">
+		<td> {{ user_billable_hours }} </td>
+		<td> {{ user_all_hours }} </td>
+		<td> {{ user_utilization }} </td>
+	</tr>
+</table>
+
 {% endblock %}

--- a/tock/tock/templates/hours/timecard_form.html
+++ b/tock/tock/templates/hours/timecard_form.html
@@ -61,7 +61,7 @@
   {% if messages %}
   <ul class="messages">
     {% for message in messages %}
-      <b><li{% if message.tags %} class="alert-{{ message.tags }}"{% endif %}>{{ message }}</li></b>
+      <b><li{% if message.tags %} class="alert-{{ message.tags }}"{% endif %}>{{ message | safe }}</li></b>
     {% endfor %}
   </ul>
   {% endif %}

--- a/tock/tock/templates/utilization/group_utilization.html
+++ b/tock/tock/templates/utilization/group_utilization.html
@@ -29,7 +29,11 @@ hours submitted on all projects for the given period.
 </ul>
 <br>
 
+
+
  {% for i in unit_choices %}
+
+
 
 <h3 id="{{i.1}}">{{i.1}}</h3>
 
@@ -81,6 +85,33 @@ hours submitted on all projects for the given period.
       </tr>
       {% endif %}
     {% endfor %}
+    <tr>
+      <td><b>Totals:</b></td>
+        <td><b>
+    {% for ut in unit_totals %}
+      {% if i.1 is ut.last.unit_name %}
+          {{ ut.last.utilization }}<br />
+          ({{ ut.last.billable_hours }}/{{ ut.last.total_hours }})
+        {% endif %}
+      {% endfor %}
+      </b></td>
+      <td><b>
+  {% for ut in unit_totals %}
+    {% if i.1 is ut.last.unit_name %}
+        {{ ut.recent.utilization }}<br />
+        ({{ ut.recent.billable_hours }}/{{ ut.recent.total_hours }})
+      {% endif %}
+    {% endfor %}
+    </b></td>
+    <td><b>
+{% for ut in unit_totals %}
+  {% if i.1 is ut.last.unit_name %}
+      {{ ut.fytd.utilization }}<br />
+      ({{ ut.fytd.billable_hours }}/{{ ut.fytd.total_hours }})
+    {% endif %}
+  {% endfor %}
+  </b></td>
+  </tr>
 </table>
 <br>
 

--- a/tock/tock/urls.py
+++ b/tock/tock/urls.py
@@ -14,6 +14,10 @@ urlpatterns = [
         hours.views.ReportingPeriodListView.as_view(),
         name='ListReportingPeriods'
     ),
+    url(r'^addHours/',
+        hours.views.add_hours_view,
+        name='AddHours'
+    ),
     url(r'^reporting_period/', include(
         'hours.urls.timesheets',
         namespace='reportingperiod'

--- a/tock/utilization/tests/test_views.py
+++ b/tock/utilization/tests/test_views.py
@@ -123,4 +123,3 @@ class TestGroupUtilizationView(WebTest):
         )
         self.assertEqual(
             response.context['user_list'][0].__dict__['_user_data_cache'].__dict__['unit'], 0)
-        #print(response.content)

--- a/tock/utilization/tests/test_views.py
+++ b/tock/utilization/tests/test_views.py
@@ -122,4 +122,27 @@ class TestGroupUtilizationView(WebTest):
             response.context['user_list'][0].__dict__['_user_data_cache']
         )
         self.assertEqual(
-            response.context['user_list'][0].__dict__['_user_data_cache'].__dict__['unit'], 0)
+            response.context['user_list'][0].__dict__['_user_data_cache'].\
+            __dict__['unit'], 0)
+
+    def test_summary_rows(self):
+        response = self.app.get(
+            url=reverse('utilization:GroupUtilizationView'),
+            headers={'X_AUTH_USER': 'aaron.snow@gsa.gov'}
+        )
+        self.assertEqual(
+            response.context['unit_totals'][0]['recent']['total_hours'],
+            (self.b_timecard_object.hours_spent + \
+            self.nb_timecard_object.hours_spent)
+        )
+        # Update hours spent.
+        self.b_timecard_object.hours_spent = 33.33
+        self.b_timecard_object.save()
+        response = self.app.get(
+            url=reverse('utilization:GroupUtilizationView'),
+            headers={'X_AUTH_USER': 'aaron.snow@gsa.gov'}
+        )
+        self.assertContains(response,int(
+            self.b_timecard_object.hours_spent + \
+            self.nb_timecard_object.hours_spent)
+        )

--- a/tock/utilization/views.py
+++ b/tock/utilization/views.py
@@ -153,9 +153,6 @@ class GroupUtilizationView(ListView):
             else:
                 staffer.last_billable_hours_total = 0.0
 
-
-
-            print()
             staffer.last_url = reverse(
                 'reports:ReportingPeriodUserDetailView',
                 kwargs={

--- a/tock/utilization/views.py
+++ b/tock/utilization/views.py
@@ -63,14 +63,12 @@ class GroupUtilizationView(ListView):
                 Sum('hours_spent'
                 )
             )
-            #print('ytd bill  {}'.format(fytd_billable_hours))
 
             """Calcuates the all hours decimal value in the queryset."""
             fytd_all_hours = fytd_tos.aggregate(
                 Sum('hours_spent'
                 )
             )
-            #print('ytd all  {}'.format(fytd_all_hours))
 
             """Filters the fytd_tos queryset to only look for TimecardObjects
             that are related to reporting periods within the last n reporting
@@ -88,14 +86,12 @@ class GroupUtilizationView(ListView):
                 Sum('hours_spent'
                 )
             )
-            #print('recent bill  {}'.format(recent_billable_hours))
 
             """Calcuates the all hours decimal value in the queryset."""
             recent_all_hours = recent_tos.aggregate(
                 Sum('hours_spent'
                 )
             )
-            #print('recent all  {}'.format(recent_all_hours))
 
             """Filters the recent_tos queryset to only look for TimecardObjects
             that are related to reporting periods within the last 1 reporting
@@ -112,14 +108,12 @@ class GroupUtilizationView(ListView):
                 Sum('hours_spent'
                 )
             )
-            #print('last bill  {}'.format(last_billable_hours))
 
             """Calcuates the all hours decimal value in the queryset."""
             last_all_hours = last_tos.aggregate(
                 Sum('hours_spent'
                 )
             )
-            #print('last all  {}'.format(last_all_hours))
 
 
             staffer.fytd = calculate_utilization(


### PR DESCRIPTION
## Description
This PR implements #511: an AddHours endpoint that allows a user to add hours for a specific line item to the current time card so that it's easier to contemporaneously track time in Tock.