### PR TITLE
Add a default timezone to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ addons:
 before_script:
   - psql -c 'create database "tock-test";' -U postgres
 
+before_install:
+  - export TZ=America/New_York
+
 install:
   - travis_retry pip install codecov
   - travis_retry pip install -r requirements.txt


### PR DESCRIPTION
## Description

This PR adds a default timezone to .travis.yml
This prevents datetime drift related errors when running CI.
See https://github.com/18F/tock/pull/583#issuecomment-263477596
for an example of tests that can fail due to that drift.