### PR TITLE
Add appropriate elements to table markup

### DIFF
--- a/tock/hours/tests/test_views.py
+++ b/tock/hours/tests/test_views.py
@@ -568,7 +568,7 @@ class ReportTests(WebTest):
             )
         )
         self.assertEqual(
-            len(response.html.find_all('tr', {'class': 'user'})), 2
+            len(response.html.find_all('tbody')), 2
         )
 
     def test_ReportingPeriodDetailView_add_submitted_time(self):
@@ -593,12 +593,11 @@ class ReportTests(WebTest):
         tables = response.html.find_all('table')
         not_filed_time = tables[0]
         filed_time = tables[1]
-
         self.assertEqual(
-            len(not_filed_time.find_all('tr', {'class': 'user'})), 0
+            len(not_filed_time.find_all('tbody')), 0
         )
         self.assertEqual(
-            len(filed_time.find_all('tr', {'class': 'user'})), 2
+            len(filed_time.find_all('tbody')), 2
         )
 
 
@@ -626,10 +625,10 @@ class ReportTests(WebTest):
         filed_time = tables[1]
 
         self.assertEqual(
-            len(not_filed_time.find_all('tr', {'class': 'user'})), 1
+            len(not_filed_time.find_all('tbody')), 1
         )
         self.assertEqual(
-            len(filed_time.find_all('tr', {'class': 'user'})), 1
+            len(filed_time.find_all('tbody')), 1
         )
 
     def test_ReportingPeriodDetailView_current_employee_toggle(self):
@@ -644,6 +643,6 @@ class ReportTests(WebTest):
             )
         )
         self.assertEqual(
-            len(response.html.find_all('tr', {'class': 'user'})), 3
+            len(response.html.find_all('tbody')), 3
         )
         self.former_employee

--- a/tock/tock/static/sass/base/_tables.scss
+++ b/tock/tock/static/sass/base/_tables.scss
@@ -24,6 +24,10 @@ th {
   vertical-align: middle;
 }
 
+caption {
+  text-align: left;
+}
+
 // Custom table styles
 .table-subtext {
   color: $color-gray;

--- a/tock/tock/static/sass/base/_tables.scss
+++ b/tock/tock/static/sass/base/_tables.scss
@@ -29,4 +29,5 @@ th {
   color: $color-gray;
   font-size: $h6-font-size;
   font-style: italic;
+  font-weight: $font-normal;
 }

--- a/tock/tock/templates/employees/user_list.html
+++ b/tock/tock/templates/employees/user_list.html
@@ -2,12 +2,12 @@
 
 {% block content %}
 
-<table class="table-minimal report_table">
+<table class="report_table">
   <caption>
     <h2>Tock Users</h2>
   </caption>
   <thead>
-    <tr class="report_table__header-row">
+    <tr>
       <th>Email Address</th>
       <th>First Name</th>
       <th>Last Name</th>
@@ -17,15 +17,15 @@
   </thead>
   {% for user in object_list %}
   <tbody>
-    <tr class="report_table__row">
+    <tr>
       <td>
-        {% if request.user.is_superuser %}
-          <a href="/employees/e/{{ user.username }}">{{ user.username }}</a>
-        {% elif request.user.username == user.username %}
-          <a href="/employees/e/{{ user.username }}">{{ user.username }}</a>
-        {% else %}
-          <a href="/employees/{{ user.username }}">{{ user.username }}</a>
-        {% endif %}
+      {% if request.user.is_superuser %}
+        <a href="/employees/e/{{ user.username }}">{{ user.username }}</a>
+      {% elif request.user.username == user.username %}
+        <a href="/employees/e/{{ user.username }}">{{ user.username }}</a>
+      {% else %}
+        <a href="/employees/{{ user.username }}">{{ user.username }}</a>
+      {% endif %}
       </td>
       <td>{{ user.first_name }}</td>
       <td>{{ user.last_name }}</td>

--- a/tock/tock/templates/employees/user_list.html
+++ b/tock/tock/templates/employees/user_list.html
@@ -4,34 +4,34 @@
 <h2>Tock Users</h2>
 
 <table class="table-minimal report_table">
-	<thead>
-		<tr class="report_table__header-row">
-			<th>Email Address</th>
-			<th>First Name</th>
-			<th>Last Name</th>
-			<th>Start Date</th>
-			<th>End Date</th>
-		</tr>
-	</thead>
-	{% for user in object_list %}
-	<tbody>
-		<tr class="report_table__row">
-			<td>
-				{% if request.user.is_superuser %}
-			 		<a href="/employees/e/{{ user.username }}">{{ user.username }}</a>
-				{% elif request.user.username == user.username %}
-					<a href="/employees/e/{{ user.username }}">{{ user.username }}</a>
-				{% else %}
-					<a href="/employees/{{ user.username }}">{{ user.username }}</a>
-				{% endif %}
-			</td>
-			<td>{{ user.first_name }}</td>
-			<td>{{ user.last_name }}</td>
-			<td>{{ user.user_data.start_date }}</td>
-			<td>{{ user.user_data.end_date }}</td>
-		</tr>
-	</tbody>
-	{% endfor %}
+  <thead>
+    <tr class="report_table__header-row">
+      <th>Email Address</th>
+      <th>First Name</th>
+      <th>Last Name</th>
+      <th>Start Date</th>
+      <th>End Date</th>
+    </tr>
+  </thead>
+  {% for user in object_list %}
+  <tbody>
+    <tr class="report_table__row">
+      <td>
+        {% if request.user.is_superuser %}
+          <a href="/employees/e/{{ user.username }}">{{ user.username }}</a>
+        {% elif request.user.username == user.username %}
+          <a href="/employees/e/{{ user.username }}">{{ user.username }}</a>
+        {% else %}
+          <a href="/employees/{{ user.username }}">{{ user.username }}</a>
+        {% endif %}
+      </td>
+      <td>{{ user.first_name }}</td>
+      <td>{{ user.last_name }}</td>
+      <td>{{ user.user_data.start_date }}</td>
+      <td>{{ user.user_data.end_date }}</td>
+    </tr>
+  </tbody>
+  {% endfor %}
 </table>
 
 {% endblock %}

--- a/tock/tock/templates/employees/user_list.html
+++ b/tock/tock/templates/employees/user_list.html
@@ -4,29 +4,33 @@
 <h2>Tock Users</h2>
 
 <table class="table-minimal report_table">
-	<tr class="report_table__header-row">
-		<th>Email Address</th>
-		<th>First Name</th>
-		<th>Last Name</th>
-		<th>Start Date</th>
-		<th>End Date</th>
-	</tr>
+	<thead>
+		<tr class="report_table__header-row">
+			<th>Email Address</th>
+			<th>First Name</th>
+			<th>Last Name</th>
+			<th>Start Date</th>
+			<th>End Date</th>
+		</tr>
+	</thead>
 	{% for user in object_list %}
-	<tr class="report_table__row">
-		<td>
-			{% if request.user.is_superuser %}
-		 		<a href="/employees/e/{{ user.username }}">{{ user.username }}</a>
-			{% elif request.user.username == user.username %}
-				<a href="/employees/e/{{ user.username }}">{{ user.username }}</a>
-			{% else %}
-				<a href="/employees/{{ user.username }}">{{ user.username }}</a>
-			{% endif %}
-		</td>
-		<td>{{ user.first_name }}</td>
-		<td>{{ user.last_name }}</td>
-		<td>{{ user.user_data.start_date }}</td>
-		<td>{{ user.user_data.end_date }}</td>
-	</tr>
+	<tbody>
+		<tr class="report_table__row">
+			<td>
+				{% if request.user.is_superuser %}
+			 		<a href="/employees/e/{{ user.username }}">{{ user.username }}</a>
+				{% elif request.user.username == user.username %}
+					<a href="/employees/e/{{ user.username }}">{{ user.username }}</a>
+				{% else %}
+					<a href="/employees/{{ user.username }}">{{ user.username }}</a>
+				{% endif %}
+			</td>
+			<td>{{ user.first_name }}</td>
+			<td>{{ user.last_name }}</td>
+			<td>{{ user.user_data.start_date }}</td>
+			<td>{{ user.user_data.end_date }}</td>
+		</tr>
+	</tbody>
 	{% endfor %}
 </table>
 

--- a/tock/tock/templates/employees/user_list.html
+++ b/tock/tock/templates/employees/user_list.html
@@ -1,9 +1,11 @@
 {% extends "base.html" %}
 
 {% block content %}
-<h2>Tock Users</h2>
 
 <table class="table-minimal report_table">
+  <caption>
+    <h2>Tock Users</h2>
+  </caption>
   <thead>
     <tr class="report_table__header-row">
       <th>Email Address</th>

--- a/tock/tock/templates/hours/reporting_period_detail.html
+++ b/tock/tock/templates/hours/reporting_period_detail.html
@@ -9,34 +9,42 @@
 <br><br>
 <h3>Users Who Have Not Filed a Timecard!</h3>
 <table>
-<tr>
-	<th>First Name</th>
-	<th>Last Name</th>
-	<th>Email</th>
-</tr>
-{% for user in users_without_filed_timecards %}
-<tr class='user'>
-	<td>{{ user.first_name }}</td>
-	<td>{{ user.last_name }}</td>
-	<td><a href="mailto:{{ user.email }}">{{ user.email }}</td>
-</tr>
-{% endfor %}
+	<thead>
+		<tr>
+			<th>First Name</th>
+			<th>Last Name</th>
+			<th>Email</th>
+		</tr>
+	</thead>
+	{% for user in users_without_filed_timecards %}
+	<tbody>
+		<tr class='user'>
+			<td>{{ user.first_name }}</td>
+			<td>{{ user.last_name }}</td>
+			<td><a href="mailto:{{ user.email }}">{{ user.email }}</td>
+		</tr>
+	</tbody>
+	{% endfor %}
 </table>
 <br><br>
 <h3>Users Who Have Filed a Timecard!</h3>
 <table>
-<tr>
-	<th>First Name</th>
-	<th>Last Name</th>
-	<th>View Timecard</th>
-</tr>
-{% for timecard in timecard_list %}
-<tr class='user'>
-	<td>{{ timecard.user.first_name }}</td>
-	<td>{{ timecard.user.last_name }}</td>
-	<td><a href="{% url 'reports:ReportingPeriodUserDetailView' reporting_period=timecard.reporting_period username=timecard.user.username %}">View Timecard</a></td>
-</tr>
-{% endfor %}
+	<thead>
+		<tr>
+			<th>First Name</th>
+			<th>Last Name</th>
+			<th>View Timecard</th>
+		</tr>
+	</thead>
+	{% for timecard in timecard_list %}
+	<tbody>
+		<tr class='user'>
+			<td>{{ timecard.user.first_name }}</td>
+			<td>{{ timecard.user.last_name }}</td>
+			<td><a href="{% url 'reports:ReportingPeriodUserDetailView' reporting_period=timecard.reporting_period username=timecard.user.username %}">View Timecard</a></td>
+		</tr>
+	</tbody>
+	{% endfor %}
 </table>
 
 {% endblock %}

--- a/tock/tock/templates/hours/reporting_period_detail.html
+++ b/tock/tock/templates/hours/reporting_period_detail.html
@@ -21,7 +21,7 @@
   </thead>
   {% for user in users_without_filed_timecards %}
   <tbody>
-    <tr class='user'>
+    <tr>
       <td>{{ user.first_name }}</td>
       <td>{{ user.last_name }}</td>
       <td><a href="mailto:{{ user.email }}">{{ user.email }}</td>
@@ -44,7 +44,7 @@
   </thead>
   {% for timecard in timecard_list %}
   <tbody>
-    <tr class='user'>
+    <tr>
       <td>{{ timecard.user.first_name }}</td>
       <td>{{ timecard.user.last_name }}</td>
       <td><a href="{% url 'reports:ReportingPeriodUserDetailView' reporting_period=timecard.reporting_period username=timecard.user.username %}">View Timecard</a></td>

--- a/tock/tock/templates/hours/reporting_period_detail.html
+++ b/tock/tock/templates/hours/reporting_period_detail.html
@@ -7,8 +7,11 @@
 <a href="{% url 'reports:ReportingPeriodCSVView' reporting_period %}">Download Full CSV Report</a>
 
 <br><br>
-<h3>Users Who Have Not Filed a Timecard!</h3>
+
 <table>
+  <caption>
+    <h3>Users Who Have Not Filed a Timecard!</h3>
+  </caption>
   <thead>
     <tr>
       <th>First Name</th>
@@ -27,8 +30,11 @@
   {% endfor %}
 </table>
 <br><br>
-<h3>Users Who Have Filed a Timecard!</h3>
+
 <table>
+  <caption>
+    <h3>Users Who Have Filed a Timecard!</h3>
+  </caption>
   <thead>
     <tr>
       <th>First Name</th>

--- a/tock/tock/templates/hours/reporting_period_detail.html
+++ b/tock/tock/templates/hours/reporting_period_detail.html
@@ -9,42 +9,42 @@
 <br><br>
 <h3>Users Who Have Not Filed a Timecard!</h3>
 <table>
-	<thead>
-		<tr>
-			<th>First Name</th>
-			<th>Last Name</th>
-			<th>Email</th>
-		</tr>
-	</thead>
-	{% for user in users_without_filed_timecards %}
-	<tbody>
-		<tr class='user'>
-			<td>{{ user.first_name }}</td>
-			<td>{{ user.last_name }}</td>
-			<td><a href="mailto:{{ user.email }}">{{ user.email }}</td>
-		</tr>
-	</tbody>
-	{% endfor %}
+  <thead>
+    <tr>
+      <th>First Name</th>
+      <th>Last Name</th>
+      <th>Email</th>
+    </tr>
+  </thead>
+  {% for user in users_without_filed_timecards %}
+  <tbody>
+    <tr class='user'>
+      <td>{{ user.first_name }}</td>
+      <td>{{ user.last_name }}</td>
+      <td><a href="mailto:{{ user.email }}">{{ user.email }}</td>
+    </tr>
+  </tbody>
+  {% endfor %}
 </table>
 <br><br>
 <h3>Users Who Have Filed a Timecard!</h3>
 <table>
-	<thead>
-		<tr>
-			<th>First Name</th>
-			<th>Last Name</th>
-			<th>View Timecard</th>
-		</tr>
-	</thead>
-	{% for timecard in timecard_list %}
-	<tbody>
-		<tr class='user'>
-			<td>{{ timecard.user.first_name }}</td>
-			<td>{{ timecard.user.last_name }}</td>
-			<td><a href="{% url 'reports:ReportingPeriodUserDetailView' reporting_period=timecard.reporting_period username=timecard.user.username %}">View Timecard</a></td>
-		</tr>
-	</tbody>
-	{% endfor %}
+  <thead>
+    <tr>
+      <th>First Name</th>
+      <th>Last Name</th>
+      <th>View Timecard</th>
+    </tr>
+  </thead>
+  {% for timecard in timecard_list %}
+  <tbody>
+    <tr class='user'>
+      <td>{{ timecard.user.first_name }}</td>
+      <td>{{ timecard.user.last_name }}</td>
+      <td><a href="{% url 'reports:ReportingPeriodUserDetailView' reporting_period=timecard.reporting_period username=timecard.user.username %}">View Timecard</a></td>
+    </tr>
+  </tbody>
+  {% endfor %}
 </table>
 
 {% endblock %}

--- a/tock/tock/templates/hours/reporting_period_user_detail.html
+++ b/tock/tock/templates/hours/reporting_period_user_detail.html
@@ -2,12 +2,12 @@
 
 {% block content %}
 
-<table class="table-minimal report_table">
+<table>
   <caption>
     <h2>{{ object.user }}'s time from {{ object.reporting_period.start_date }} to {{ object.reporting_period.end_date }}</h2>
   </caption>
   <thead>
-    <tr class="report_table__header-row">
+    <tr>
       <th>Project</th>
       <th>Billable</th>
       <th>Number of Hours</th>
@@ -15,8 +15,8 @@
   </thead>
   {% for entry in object.timecardobjects.all %}
   <tbody>
-    <tr class="report_table__row">
-      <td>{{ entry.project }}</td>
+    <tr>
+      <th scope="row">{{ entry.project }}</th>
       <td>
       {% if entry.project.is_billable %}
         <i class="fa fa-money icon-green"></i> <em>Billable</em>
@@ -27,7 +27,7 @@
       <td>{{ entry.hours_spent }}</td>
     </tr>
     {% if entry.notes %}
-    <tr class="report_table__row">
+    <tr>
       <td colspan="3">
         <strong>Notes entered for {{ entry.project }}</strong><br />
         <ul>
@@ -44,19 +44,19 @@
 <div>First Submitted: {{ object.created }}</div>
 Last Changed: {{ object.modified }}
 
-<table class="table-minimal report_table">
+<table>
   <caption>
     <h3>Reporting Period Summary</h3>
   </caption>
   <thead>
-    <tr class="report_table__header-row">
+    <tr>
       <th>Billable Hours</th>
       <th>Total Hours</th>
       <th>Billable %<br><span class="table-subtext">(billable hrs / total hrs)</span></th>
     </tr>
   </thead>
   <tbody>
-    <tr class="report_table__header-row">
+    <tr>
       <td> {{ user_billable_hours }} </td>
       <td> {{ user_all_hours }} </td>
       <td> {{ user_utilization }} </td>

--- a/tock/tock/templates/hours/reporting_period_user_detail.html
+++ b/tock/tock/templates/hours/reporting_period_user_detail.html
@@ -29,12 +29,10 @@
     {% if entry.notes %}
     <tr>
       <td colspan="3">
-        <strong>Notes entered for {{ entry.project }}</strong><br />
-        <ul>
+        <strong>Notes entered for {{ entry.project }}</strong>
         {% for note in entry.notes_list %}
-          <li>{{ note }}</li>
+        <p>{{ note }}</p>
         {% endfor %}
-        <ul>
       </td>
     </tr>
   </tbody>

--- a/tock/tock/templates/hours/reporting_period_user_detail.html
+++ b/tock/tock/templates/hours/reporting_period_user_detail.html
@@ -5,53 +5,60 @@
 <h2>{{ object.user }}'s time from {{ object.reporting_period.start_date }} to {{ object.reporting_period.end_date }}</h2>
 
 <table class="table-minimal report_table">
-	<tr class="report_table__header-row">
-		<th>Project</th>
-		<th>Billable</th>
-		<th>Number of Hours</th>
-	</tr>
+  <thead>
+  	<tr class="report_table__header-row">
+  		<th>Project</th>
+  		<th>Billable</th>
+  		<th>Number of Hours</th>
+  	</tr>
+  </thead>
 	{% for entry in object.timecardobjects.all %}
-	<tr class="report_table__row">
-		<td>{{ entry.project }}</td>
-		<td>
-		{% if entry.project.is_billable %}
+  <tbody>
+  	<tr class="report_table__row">
+  		<td>{{ entry.project }}</td>
+  		<td>
+  		{% if entry.project.is_billable %}
         <i class="fa fa-money icon-green"></i> <em>Billable</em>
-    {% else %}
-      	<i class="fa fa-money icon-18f"></i> <em>Non-Billable</em>
-    {% endif %}
-    </td>
-		<td>{{ entry.hours_spent }}</td>
-	</tr>
+      {% else %}
+        <i class="fa fa-money icon-18f"></i> <em>Non-Billable</em>
+      {% endif %}
+      </td>
+  		<td>{{ entry.hours_spent }}</td>
+  	</tr>
     {% if entry.notes %}
     <tr class="report_table__row">
-        <td colspan="3">
-            <strong>Notes entered for {{ entry.project }}</strong><br />
-
-            <ul>
-                {% for note in entry.notes_list %}
-                <li>{{ note }}</li>
-                {% endfor %}
-            <ul>
-        </td>
+      <td colspan="3">
+        <strong>Notes entered for {{ entry.project }}</strong><br />
+        <ul>
+        {% for note in entry.notes_list %}
+          <li>{{ note }}</li>
+        {% endfor %}
+        <ul>
+      </td>
     </tr>
-    {% endif %}
+  </tbody>
+  {% endif %}
 	{% endfor %}
 </table>
 <div>First Submitted: {{ object.created }}</div>
 Last Changed: {{ object.modified }}
 
-<h3> Reporting Period Summary </h3>
+<h3>Reporting Period Summary</h3>
 <table class="table-minimal report_table">
-	<tr class="report_table__header-row">
-		<th>Billable Hours</th>
-		<th>Total Hours</th>
-		<th>Billable %<br><span class="table-subtext">(billable hrs / total hrs)</span></th>
-	</tr>
-	<tr class="report_table__header-row">
-		<td> {{ user_billable_hours }} </td>
-		<td> {{ user_all_hours }} </td>
-		<td> {{ user_utilization }} </td>
-	</tr>
+  <thead>
+  	<tr class="report_table__header-row">
+  		<th>Billable Hours</th>
+  		<th>Total Hours</th>
+  		<th>Billable %<br><span class="table-subtext">(billable hrs / total hrs)</span></th>
+  	</tr>
+  </thead>
+  <tbody>
+  	<tr class="report_table__header-row">
+  		<td> {{ user_billable_hours }} </td>
+  		<td> {{ user_all_hours }} </td>
+  		<td> {{ user_utilization }} </td>
+  	</tr>
+  </tbody>
 </table>
 
 {% endblock %}

--- a/tock/tock/templates/hours/reporting_period_user_detail.html
+++ b/tock/tock/templates/hours/reporting_period_user_detail.html
@@ -2,9 +2,10 @@
 
 {% block content %}
 
-<h2>{{ object.user }}'s time from {{ object.reporting_period.start_date }} to {{ object.reporting_period.end_date }}</h2>
-
 <table class="table-minimal report_table">
+  <caption>
+    <h2>{{ object.user }}'s time from {{ object.reporting_period.start_date }} to {{ object.reporting_period.end_date }}</h2>
+  </caption>
   <thead>
     <tr class="report_table__header-row">
       <th>Project</th>
@@ -43,8 +44,10 @@
 <div>First Submitted: {{ object.created }}</div>
 Last Changed: {{ object.modified }}
 
-<h3>Reporting Period Summary</h3>
 <table class="table-minimal report_table">
+  <caption>
+    <h3>Reporting Period Summary</h3>
+  </caption>
   <thead>
     <tr class="report_table__header-row">
       <th>Billable Hours</th>

--- a/tock/tock/templates/hours/reporting_period_user_detail.html
+++ b/tock/tock/templates/hours/reporting_period_user_detail.html
@@ -6,25 +6,25 @@
 
 <table class="table-minimal report_table">
   <thead>
-  	<tr class="report_table__header-row">
-  		<th>Project</th>
-  		<th>Billable</th>
-  		<th>Number of Hours</th>
-  	</tr>
+    <tr class="report_table__header-row">
+      <th>Project</th>
+      <th>Billable</th>
+      <th>Number of Hours</th>
+    </tr>
   </thead>
-	{% for entry in object.timecardobjects.all %}
+  {% for entry in object.timecardobjects.all %}
   <tbody>
-  	<tr class="report_table__row">
-  		<td>{{ entry.project }}</td>
-  		<td>
-  		{% if entry.project.is_billable %}
+    <tr class="report_table__row">
+      <td>{{ entry.project }}</td>
+      <td>
+      {% if entry.project.is_billable %}
         <i class="fa fa-money icon-green"></i> <em>Billable</em>
       {% else %}
         <i class="fa fa-money icon-18f"></i> <em>Non-Billable</em>
       {% endif %}
       </td>
-  		<td>{{ entry.hours_spent }}</td>
-  	</tr>
+      <td>{{ entry.hours_spent }}</td>
+    </tr>
     {% if entry.notes %}
     <tr class="report_table__row">
       <td colspan="3">
@@ -38,7 +38,7 @@
     </tr>
   </tbody>
   {% endif %}
-	{% endfor %}
+  {% endfor %}
 </table>
 <div>First Submitted: {{ object.created }}</div>
 Last Changed: {{ object.modified }}
@@ -46,18 +46,18 @@ Last Changed: {{ object.modified }}
 <h3>Reporting Period Summary</h3>
 <table class="table-minimal report_table">
   <thead>
-  	<tr class="report_table__header-row">
-  		<th>Billable Hours</th>
-  		<th>Total Hours</th>
-  		<th>Billable %<br><span class="table-subtext">(billable hrs / total hrs)</span></th>
-  	</tr>
+    <tr class="report_table__header-row">
+      <th>Billable Hours</th>
+      <th>Total Hours</th>
+      <th>Billable %<br><span class="table-subtext">(billable hrs / total hrs)</span></th>
+    </tr>
   </thead>
   <tbody>
-  	<tr class="report_table__header-row">
-  		<td> {{ user_billable_hours }} </td>
-  		<td> {{ user_all_hours }} </td>
-  		<td> {{ user_utilization }} </td>
-  	</tr>
+    <tr class="report_table__header-row">
+      <td> {{ user_billable_hours }} </td>
+      <td> {{ user_all_hours }} </td>
+      <td> {{ user_utilization }} </td>
+    </tr>
   </tbody>
 </table>
 

--- a/tock/tock/templates/utilization/group_utilization.html
+++ b/tock/tock/templates/utilization/group_utilization.html
@@ -42,7 +42,41 @@
     <th>Fiscal Year to Date <br> (Ending {{ through_date }}) <br><span class="table-subtext">% billable (billable hrs / total hrs)</span></th>
     </tr>
   </thead>
-
+  <tfoot>
+    <tr>
+      <td><b>Totals:</b></td>
+      <td>
+        <b>
+        {% for ut in unit_totals %}
+        {% if i.1 is ut.last.unit_name %}
+          {{ ut.last.utilization }}<br>
+          ({{ ut.last.billable_hours }} / {{ ut.last.total_hours }})
+        {% endif %}
+        {% endfor %}
+        </b>
+      </td>
+      <td>
+        <b>
+        {% for ut in unit_totals %}
+        {% if i.1 is ut.last.unit_name %}
+          {{ ut.recent.utilization }}<br>
+          ({{ ut.recent.billable_hours }} / {{ ut.recent.total_hours }})
+        {% endif %}
+        {% endfor %}
+        </b>
+      </td>
+      <td>
+        <b>
+        {% for ut in unit_totals %}
+        {% if i.1 is ut.last.unit_name %}
+          {{ ut.fytd.utilization }}<br>
+          ({{ ut.fytd.billable_hours }} / {{ ut.fytd.total_hours }})
+        {% endif %}
+        {% endfor %}
+        </b>
+      </td>
+    </tr>
+  </tfoot>
   <tbody>
   {% for userdata in object_list %}
 
@@ -84,39 +118,7 @@
     </tr>
     {% endif %}
     {% endfor %}
-    <tr>
-      <td><b>Totals:</b></td>
-      <td>
-        <b>
-        {% for ut in unit_totals %}
-        {% if i.1 is ut.last.unit_name %}
-          {{ ut.last.utilization }}<br>
-          ({{ ut.last.billable_hours }} / {{ ut.last.total_hours }})
-        {% endif %}
-        {% endfor %}
-        </b>
-      </td>
-      <td>
-        <b>
-        {% for ut in unit_totals %}
-        {% if i.1 is ut.last.unit_name %}
-          {{ ut.recent.utilization }}<br>
-          ({{ ut.recent.billable_hours }} / {{ ut.recent.total_hours }})
-        {% endif %}
-        {% endfor %}
-        </b>
-      </td>
-      <td>
-        <b>
-        {% for ut in unit_totals %}
-        {% if i.1 is ut.last.unit_name %}
-          {{ ut.fytd.utilization }}<br>
-          ({{ ut.fytd.billable_hours }} / {{ ut.fytd.total_hours }})
-        {% endif %}
-        {% endfor %}
-        </b>
-      </td>
-    </tr>
+
   </tbody>
 </table>
 <br>

--- a/tock/tock/templates/utilization/group_utilization.html
+++ b/tock/tock/templates/utilization/group_utilization.html
@@ -23,7 +23,7 @@
 </p>
 <h3>Jump to:</h3>
 <ul>
-{% for i in unit_choices%}
+{% for i in unit_choices %}
   <li><a href="#{{i.1}}">{{i.1}}</a></li>
 {% endfor %}
 </ul>

--- a/tock/tock/templates/utilization/group_utilization.html
+++ b/tock/tock/templates/utilization/group_utilization.html
@@ -27,24 +27,24 @@
   <li><a href="#{{i.1}}">{{i.1}}</a></li>
 {% endfor %}
 </ul>
-<br>
 
 {% for i in unit_choices %}
 
-<h3 id="{{i.1}}">{{i.1}}</h3>
-
 <table class="table-minimal report_table">
+  <caption>
+    <h3 id="{{i.1}}">{{i.1}}</h3>
+  </caption>
   <thead>
     <tr class="report_table__header-row">
-      <th>Name</th>
-      <th>Last Week <br> (Ending {{ through_date }}) <br><span class="table-subtext">% billable (billable hrs / total hrs)</span></th>
-      <th>Last Four Weeks <br> ({{ recent_start_date }} - {{ through_date }}) <br><span class="table-subtext">% billable (billable hrs / total hrs)</span></th>
-    <th>Fiscal Year to Date <br> (Ending {{ through_date }}) <br><span class="table-subtext">% billable (billable hrs / total hrs)</span></th>
+      <th scope="col">Name</th>
+      <th scope="col">Last Week <br> (Ending {{ through_date }}) <br><span class="table-subtext">% billable (billable hrs / total hrs)</span></th>
+      <th scope="col">Last Four Weeks <br> ({{ recent_start_date }} - {{ through_date }}) <br><span class="table-subtext">% billable (billable hrs / total hrs)</span></th>
+      <th scope="col">Fiscal Year to Date <br> (Ending {{ through_date }}) <br><span class="table-subtext">% billable (billable hrs / total hrs)</span></th>
     </tr>
   </thead>
   <tfoot>
     <tr>
-      <td><b>Totals:</b></td>
+      <th scope="row"><b>Totals:</b></th>
       <td>
         <b>
         {% for ut in unit_totals %}
@@ -82,9 +82,9 @@
 
   {% if userdata.unit is i.0 %}
     <tr class="report_table__row">
-      <td>
+      <th scope="row">
         {{ userdata.user_data }}
-      </td>
+      </th>
       <td>
       {% if userdata.last_all_hours_total %}
         <a href='{{ userdata.last_url }}' title="Percent billable (billable hours / total hours)">
@@ -120,7 +120,6 @@
   {% endfor %}
   </tbody>
 </table>
-<br>
 
 {% endfor %}
 

--- a/tock/tock/templates/utilization/group_utilization.html
+++ b/tock/tock/templates/utilization/group_utilization.html
@@ -105,7 +105,6 @@
         --
       {% endif %}
       </td>
-
       <td>
       {% if userdata.fytd_all_hours_total %}
         {{ userdata.fytd }}

--- a/tock/tock/templates/utilization/group_utilization.html
+++ b/tock/tock/templates/utilization/group_utilization.html
@@ -6,20 +6,20 @@
 {% if request.user.is_staff %}
 <h3>Notes:</h3>
 <p>
-The following report contains users who are marked as billable in Tock,
-organized by their unit as listed in Tock. Both attributes may be easily
-updated via the <b>Employees</b> page of the Tock <a href="/admin"> admin </a>
-interface. Within each unit, employees are ordered alphabetically by last name.
+  The following report contains users who are marked as billable in Tock,
+  organized by their unit as listed in Tock. Both attributes may be easily
+  updated via the <b>Employees</b> page of the Tock <a href="/admin"> admin </a>
+  interface. Within each unit, employees are ordered alphabetically by last name.
 </p>
 <p>
-The contents of this page may only be viewed by Tock users who are marked as
-"staff" users. This attribute may be updated via the Tock
-<a href="/admin"> admin </a> interface, as well, via the <b>Users</b> page.
+  The contents of this page may only be viewed by Tock users who are marked as
+  "staff" users. This attribute may be updated via the Tock
+  <a href="/admin"> admin </a> interface, as well, via the <b>Users</b> page.
 </p>
 <p>
-Utilization is calculated by dividing the total number of hours submitted on
-projects that are marked "billable" in Tock, divided by the total number of
-hours submitted on all projects for the given period.
+  Utilization is calculated by dividing the total number of hours submitted on
+  projects that are marked "billable" in Tock, divided by the total number of
+  hours submitted on all projects for the given period.
 </p>
 <h3>Jump to:</h3>
 <ul>
@@ -29,91 +29,95 @@ hours submitted on all projects for the given period.
 </ul>
 <br>
 
-
-
- {% for i in unit_choices %}
-
-
+{% for i in unit_choices %}
 
 <h3 id="{{i.1}}">{{i.1}}</h3>
 
 <table class="table-minimal report_table">
   <thead>
     <tr class="report_table__header-row">
-        <th>Name</th>
-        <th>Last Week <br> (Ending {{ through_date }}) <br><span class="table-subtext">% billable (billable hrs / total hrs)</span></th>
-        <th>Last Four Weeks <br> ({{ recent_start_date }} - {{ through_date }}) <br><span class="table-subtext">% billable (billable hrs / total hrs)</span></th>
+      <th>Name</th>
+      <th>Last Week <br> (Ending {{ through_date }}) <br><span class="table-subtext">% billable (billable hrs / total hrs)</span></th>
+      <th>Last Four Weeks <br> ({{ recent_start_date }} - {{ through_date }}) <br><span class="table-subtext">% billable (billable hrs / total hrs)</span></th>
     <th>Fiscal Year to Date <br> (Ending {{ through_date }}) <br><span class="table-subtext">% billable (billable hrs / total hrs)</span></th>
     </tr>
   </thead>
 
-    {% for userdata in object_list %}
+  <tbody>
+  {% for userdata in object_list %}
 
-      {% if userdata.unit is i.0 %}
-      <tr class="report_table__row">
-        <td>
-          {{ userdata.user_data }}
-        </td>
-        <td>
-          {% if userdata.last_all_hours_total %}
-              <a href='{{ userdata.last_url }}' title="Percent billable (billable hours / total hours)">
-                {{ userdata.last }}
-                ({{ userdata.last_billable_hours_total }} /
-                {{ userdata.last_all_hours_total }})
-              </a>
-          {% else %}
-              --
-          {% endif %}
-        </td>
-        <td>
-          {% if userdata.recent_all_hours_total %}
-            {{ userdata.recent }}
-            ({{ userdata.recent_billable_hours_total }} /
-            {{ userdata.recent_all_hours_total }})
-          {% else %}
-            --
-          {% endif %}
-          </td>
-
-        <td>
-          {% if userdata.fytd_all_hours_total %}
-            {{ userdata.fytd }}
-            ({{ userdata.fytd_billable_hours_total }} /
-            {{ userdata.fytd_all_hours_total }})
-          {% else %}
-            --
-          {% endif %}
-        </td>
-      </tr>
+  {% if userdata.unit is i.0 %}
+    <tr class="report_table__row">
+      <td>
+        {{ userdata.user_data }}
+      </td>
+      <td>
+      {% if userdata.last_all_hours_total %}
+        <a href='{{ userdata.last_url }}' title="Percent billable (billable hours / total hours)">
+          {{ userdata.last }}
+          ({{ userdata.last_billable_hours_total }} /
+          {{ userdata.last_all_hours_total }})
+        </a>
+      {% else %}
+          --
       {% endif %}
+      </td>
+      <td>
+      {% if userdata.recent_all_hours_total %}
+        {{ userdata.recent }}
+        ({{ userdata.recent_billable_hours_total }} /
+        {{ userdata.recent_all_hours_total }})
+      {% else %}
+        --
+      {% endif %}
+      </td>
+
+      <td>
+      {% if userdata.fytd_all_hours_total %}
+        {{ userdata.fytd }}
+        ({{ userdata.fytd_billable_hours_total }} /
+        {{ userdata.fytd_all_hours_total }})
+      {% else %}
+        --
+      {% endif %}
+      </td>
+    </tr>
+    {% endif %}
     {% endfor %}
     <tr>
       <td><b>Totals:</b></td>
-        <td><b>
-    {% for ut in unit_totals %}
-      {% if i.1 is ut.last.unit_name %}
-          {{ ut.last.utilization }}<br />
+      <td>
+        <b>
+        {% for ut in unit_totals %}
+        {% if i.1 is ut.last.unit_name %}
+          {{ ut.last.utilization }}<br>
           ({{ ut.last.billable_hours }} / {{ ut.last.total_hours }})
         {% endif %}
-      {% endfor %}
-      </b></td>
-      <td><b>
-  {% for ut in unit_totals %}
-    {% if i.1 is ut.last.unit_name %}
-        {{ ut.recent.utilization }}<br />
-        ({{ ut.recent.billable_hours }} / {{ ut.recent.total_hours }})
-      {% endif %}
-    {% endfor %}
-    </b></td>
-    <td><b>
-{% for ut in unit_totals %}
-  {% if i.1 is ut.last.unit_name %}
-      {{ ut.fytd.utilization }}<br />
-      ({{ ut.fytd.billable_hours }} / {{ ut.fytd.total_hours }})
-    {% endif %}
-  {% endfor %}
-  </b></td>
-  </tr>
+        {% endfor %}
+        </b>
+      </td>
+      <td>
+        <b>
+        {% for ut in unit_totals %}
+        {% if i.1 is ut.last.unit_name %}
+          {{ ut.recent.utilization }}<br>
+          ({{ ut.recent.billable_hours }} / {{ ut.recent.total_hours }})
+        {% endif %}
+        {% endfor %}
+        </b>
+      </td>
+      <td>
+        <b>
+        {% for ut in unit_totals %}
+        {% if i.1 is ut.last.unit_name %}
+          {{ ut.fytd.utilization }}<br>
+          ({{ ut.fytd.billable_hours }} / {{ ut.fytd.total_hours }})
+        {% endif %}
+        {% endfor %}
+        </b>
+      </td>
+    </tr>
+  </tbody>
 </table>
 <br>
 

--- a/tock/tock/templates/utilization/group_utilization.html
+++ b/tock/tock/templates/utilization/group_utilization.html
@@ -38,12 +38,14 @@ hours submitted on all projects for the given period.
 <h3 id="{{i.1}}">{{i.1}}</h3>
 
 <table class="table-minimal report_table">
+  <thead>
     <tr class="report_table__header-row">
         <th>Name</th>
         <th>Last Week <br> (Ending {{ through_date }}) <br><span class="table-subtext">% billable (billable hrs / total hrs)</span></th>
         <th>Last Four Weeks <br> ({{ recent_start_date }} - {{ through_date }}) <br><span class="table-subtext">% billable (billable hrs / total hrs)</span></th>
     <th>Fiscal Year to Date <br> (Ending {{ through_date }}) <br><span class="table-subtext">% billable (billable hrs / total hrs)</span></th>
     </tr>
+  </thead>
 
     {% for userdata in object_list %}
 

--- a/tock/tock/templates/utilization/group_utilization.html
+++ b/tock/tock/templates/utilization/group_utilization.html
@@ -116,9 +116,8 @@
       {% endif %}
       </td>
     </tr>
-    {% endif %}
-    {% endfor %}
-
+  {% endif %}
+  {% endfor %}
   </tbody>
 </table>
 <br>

--- a/tock/tock/templates/utilization/group_utilization.html
+++ b/tock/tock/templates/utilization/group_utilization.html
@@ -8,13 +8,13 @@
 <p>
   The following report contains users who are marked as billable in Tock,
   organized by their unit as listed in Tock. Both attributes may be easily
-  updated via the <b>Employees</b> page of the Tock <a href="/admin"> admin </a>
+  updated via the <b>Employees</b> page of the Tock <a href="/admin">admin</a>
   interface. Within each unit, employees are ordered alphabetically by last name.
 </p>
 <p>
   The contents of this page may only be viewed by Tock users who are marked as
   "staff" users. This attribute may be updated via the Tock
-  <a href="/admin"> admin </a> interface, as well, via the <b>Users</b> page.
+  <a href="/admin">admin</a> interface, as well, via the <b>Users</b> page.
 </p>
 <p>
   Utilization is calculated by dividing the total number of hours submitted on

--- a/tock/tock/templates/utilization/group_utilization.html
+++ b/tock/tock/templates/utilization/group_utilization.html
@@ -30,7 +30,7 @@
 
 {% for i in unit_choices %}
 
-<table class="table-minimal report_table">
+<table class="report_table">
   <caption>
     <h3 id="{{i.1}}">{{i.1}}</h3>
   </caption>


### PR DESCRIPTION
## Description

- Adds `<thead>`, `<tfoot>`, and a `<tbody>` elements to properly mark up the table. 
- Fixes markup indentation.

TODO:

- [x] Add `scope="col"` or `scope="row"` to `th`s. See: https://standards.usa.gov/tables/
- [x] Add `<caption>` to table for title
- [x] Remove unused table classes

## This is what it looks like:
<img width="917" alt="screen shot 2016-11-29 at 2 59 52 pm" src="https://cloud.githubusercontent.com/assets/5249443/20732723/e1e37bae-b644-11e6-9cd1-882a84686c9a.png">
