### PR TITLE
511 Add hours endpoint [updated]

### DIFF
--- a/tock/hours/hours_adder.py
+++ b/tock/hours/hours_adder.py
@@ -52,9 +52,6 @@ class HoursAdder(object):
             reporting_period_id=self.reporting_period_id,
             user_id=self.user_id)
 
-        if created:
-            tc.save()
-
         tco, created = TimecardObject.objects.get_or_create(
             timecard_id=tc.id,
             project_id=project.id)
@@ -69,6 +66,7 @@ class HoursAdder(object):
         updated_hours = max(0, tco.hours_spent + self.hours)
         tco.hours_spent = updated_hours
         tco.save()
+        tc.save()
 
         self.message = self.generate_successful_message(self.hours, project)
         self.operation_was_successful = True

--- a/tock/hours/hours_adder.py
+++ b/tock/hours/hours_adder.py
@@ -9,6 +9,8 @@ ERROR_MSG = """
     tock.gov/addHours?project=231&hours=1
 """
 
+NEGATIVE_HOURS_ERROR_MSG = "The total hours after the operation cannot be negative"
+
 class HoursAdder(object):
     """Service object in charge of adding hours to a timecard object"""
 
@@ -70,7 +72,7 @@ class HoursAdder(object):
             project = Project.objects.get(id=self.project_id)
         except Project.DoesNotExist:
             self.message = ERROR_MSG
-            return True
+            return
 
         tc, created = Timecard.objects.get_or_create(
             reporting_period_id=self.reporting_period_id,
@@ -84,7 +86,11 @@ class HoursAdder(object):
         if tco.hours_spent is None:
             tco.hours_spent = 0
 
-        updated_hours = max(0, tco.hours_spent + self.hours)
+        updated_hours = tco.hours_spent + self.hours
+        if updated_hours < 0:
+            self.message = NEGATIVE_HOURS_ERROR_MSG
+            return
+
         tco.hours_spent = updated_hours
         tco.save()
         tc.save()

--- a/tock/hours/hours_adder.py
+++ b/tock/hours/hours_adder.py
@@ -1,0 +1,70 @@
+from django.template.defaultfilters import pluralize
+from django.core.urlresolvers import reverse
+from .models import ReportingPeriod, Timecard, TimecardObject, Project
+
+class HoursAdder(object):
+    """Service object in charge of adding hours to a timecard object"""
+
+    def __init__(self, **kwargs):
+        self.project_id = kwargs.get('project_id', None)
+        self.hours = kwargs.get('hours', None)
+        self.reporting_period_id = kwargs.get('reporting_period_id', None)
+        self.message = "Unknown error"
+        self.user_id = kwargs.get('user_id', None)
+        self.operation_was_successful = False
+
+    def generate_successful_message(self, hours, project):
+        if hours > 0:
+            plural_hours = pluralize(hours, 'hour,hours')
+            has = pluralize(hours, 'has,have')
+            undo_query = "?hours=-%s&project=%s" % (hours, project.id)
+            undo_url = reverse('AddHours') + undo_query
+            undo_tag = "<a href=\"%s\">Undo</a>" % (undo_url)
+            return "%s %s %s been added to %s. %s" % (hours, plural_hours, has,
+                    project.name, undo_tag)
+
+        plural_hours = pluralize(-hours, 'hour,hours')
+        has = pluralize(-hours, 'has,have')
+        return "%s %s %s been removed from %s." % (-hours, plural_hours, has,
+                project.name)
+
+    def perform_operation(self):
+        error_msg = "Oops. That command was not correct and no time was added to your timecard. Try again by entering a URL with this format: tock.gov/addHours?project=231&hours=1"
+        try:
+            project = Project.objects.get(id=self.project_id)
+        except Project.DoesNotExist:
+            self.message = error_msg
+            self.operation_was_successful = False
+
+        tc, created = Timecard.objects.get_or_create(
+            reporting_period_id=self.reporting_period_id,
+            user_id=self.user_id)
+
+        if created:
+            tc.save()
+
+        tco, created = TimecardObject.objects.get_or_create(
+            timecard_id=tc.id,
+            project_id=project.id)
+
+        if self.hours is None:
+            self.message = error_msg
+            self.operation_was_successful = False
+            return
+
+        if tco.hours_spent is None:
+            tco.hours_spent = 0
+
+        updated_hours = tco.hours_spent + self.hours
+        updated_hours = max(0, updated_hours)
+        tco.hours_spent = updated_hours
+        tco.save()
+
+        self.message = self.generate_successful_message(self.hours, project)
+        self.operation_was_successful = True
+
+    def successful(self):
+        return self.operation_was_successful
+
+    def message(self):
+        return self.message

--- a/tock/hours/hours_adder.py
+++ b/tock/hours/hours_adder.py
@@ -12,14 +12,14 @@ class HoursAdder(object):
         self.message = "Unknown error"
         self.user_id = kwargs.get('user_id', None)
         self.operation_was_successful = False
+        self.undo_url = kwargs.get('undo_url', '')
 
     def generate_successful_message(self, hours, project):
         if hours > 0:
             plural_hours = pluralize(hours, 'hour,hours')
             has = pluralize(hours, 'has,have')
             undo_query = "?hours=-%s&project=%s" % (hours, project.id)
-            undo_url = reverse('AddHours') + undo_query
-            undo_tag = "<a href=\"%s\">Undo</a>" % (undo_url)
+            undo_tag = "<a href=\"%s\">Undo</a>" % (self.undo_url + undo_query)
             return "%s %s %s been added to %s. %s" % (hours, plural_hours, has,
                     project.name, undo_tag)
 
@@ -29,7 +29,13 @@ class HoursAdder(object):
                 project.name)
 
     def perform_operation(self):
-        error_msg = "Oops. That command was not correct and no time was added to your timecard. Try again by entering a URL with this format: tock.gov/addHours?project=231&hours=1"
+        error_msg = """
+            Oops.
+            That command was not correct and no time was added to your timecard.
+            Try again by entering a URL with this format:
+            tock.gov/addHours?project=231&hours=1
+        """
+
         try:
             self.hours = Decimal(self.hours)
         except InvalidOperation:

--- a/tock/hours/hours_adder.py
+++ b/tock/hours/hours_adder.py
@@ -10,6 +10,7 @@ ERROR_MSG = """
 """
 
 NEGATIVE_HOURS_ERROR_MSG = "The total hours after the operation cannot be negative"
+SUBMIT_ERROR_MSG = "A submitted timecard for the current period already exists"
 
 class HoursAdder(object):
     """Service object in charge of adding hours to a timecard object"""
@@ -72,6 +73,16 @@ class HoursAdder(object):
             project = Project.objects.get(id=self.project_id)
         except Project.DoesNotExist:
             self.message = ERROR_MSG
+            return
+
+        submited_timecards_current_period = Timecard.objects.filter(
+            reporting_period_id=self.reporting_period_id,
+            submitted=True,
+            user_id=self.user_id
+        )
+
+        if len(submited_timecards_current_period) > 0:
+            self.message = SUBMIT_ERROR_MSG
             return
 
         tc, created = Timecard.objects.get_or_create(

--- a/tock/hours/hours_adder.py
+++ b/tock/hours/hours_adder.py
@@ -1,6 +1,7 @@
 from django.template.defaultfilters import pluralize
 from decimal import Decimal, InvalidOperation
-from .models import ReportingPeriod, Timecard, TimecardObject, Project
+from .models import ReportingPeriod, Timecard, TimecardObject, Project, ReportingPeriod
+import datetime
 
 ERROR_MSG = """
     Oops.
@@ -11,9 +12,12 @@ ERROR_MSG = """
 
 NEGATIVE_HOURS_ERROR_MSG = "The total hours after the operation cannot be negative"
 SUBMIT_ERROR_MSG = "A submitted timecard for the current period already exists"
+INVALID_PERIOD_MSG = "Could not find a current time period"
 
 class HoursAdder(object):
-    """Service object in charge of adding hours to a timecard object"""
+    """Service object in charge of adding hours to a timecard object.
+    self.current_date is an optional argument used for Dependency Injection during tests.
+    """
 
     def __init__(self, **kwargs):
         self.project_id = kwargs.get('project_id', None)
@@ -23,6 +27,7 @@ class HoursAdder(object):
         self.user_id = kwargs.get('user_id', None)
         self.operation_was_successful = False
         self.undo_url = kwargs.get('undo_url', '')
+        self.current_date = kwargs.get('current_date', None)
 
     def generate_successful_message(self, hours, project):
         if hours > 0:
@@ -46,6 +51,23 @@ class HoursAdder(object):
             return True
 
         if self.reporting_period_id is None:
+            return True
+
+        if self.current_date is None:
+            self.current_date = datetime.datetime.now().date()
+
+        try:
+            reporting_period = ReportingPeriod.objects.get(id=self.reporting_period_id)
+        except ReportingPeriod.DoesNotExist:
+            self.message = ERROR_MSG
+            return True
+
+        if reporting_period.start_date > self.current_date:
+            self.message = INVALID_PERIOD_MSG
+            return True
+
+        if reporting_period.end_date < self.current_date:
+            self.message = INVALID_PERIOD_MSG
             return True
 
         try:

--- a/tock/hours/tests/test_hours_adder.py
+++ b/tock/hours/tests/test_hours_adder.py
@@ -1,0 +1,92 @@
+from django.test import TestCase, RequestFactory
+from django.contrib.auth import get_user_model
+import hours.models
+from hours.hours_adder import HoursAdder
+from employees.models import UserData
+from decimal import Decimal
+import datetime
+import projects.models
+
+class HoursAdderTests(TestCase):
+    fixtures = [
+        'projects/fixtures/projects.json',
+        'tock/fixtures/prod_user.json',
+    ]
+
+    def setUp(self):
+        self.reporting_period = hours.models.ReportingPeriod.objects.create(
+            start_date=datetime.date(2015, 1, 1),
+            end_date=datetime.date(2015, 1, 7),
+            exact_working_hours=40)
+        self.user = get_user_model().objects.create(
+            username='john',
+            email='john@gsa.gov',
+            is_superuser=False,
+        )
+        self.user.save()
+        UserData(
+            user=self.user,
+            start_date=datetime.date(2015, 1, 1),
+            end_date=datetime.date(2017, 1, 1),
+        ).save()
+
+    def test_add_without_tco(self):
+        project_midas = projects.models.Project.objects.get(name="Midas")
+        new_period = hours.models.ReportingPeriod.objects.create(
+            start_date=datetime.date(2016, 1, 1),
+            end_date=datetime.date(2016, 1, 7),
+        )
+        new_timecard = hours.models.Timecard.objects.create(
+            user=self.user,
+            submitted=False,
+            reporting_period=new_period
+        )
+        hours_adder = HoursAdder(
+            project_id = project_midas.id,
+            hours = '2',
+            user_id = self.user.id,
+            reporting_period_id = new_period.id,
+            undo_url = ''
+        )
+
+        old_count = new_timecard.timecardobjects.count()
+        hours_adder.perform_operation()
+        new_count = new_timecard.timecardobjects.count()
+
+        self.assertTrue(hours_adder.successful())
+        self.assertEqual(1, new_count)
+
+    def test_add_hours_with_existing_tco(self):
+        """
+        Test that addHours increases the current timecard by the
+        specified amount
+        """
+        new_period = hours.models.ReportingPeriod.objects.create(
+            start_date=datetime.date(2016, 1, 1),
+            end_date=datetime.date(2016, 1, 7),
+        )
+        new_timecard = hours.models.Timecard.objects.create(
+            user=self.user,
+            submitted=False,
+            reporting_period=new_period
+        )
+        project_midas = projects.models.Project.objects.get(name="Midas")
+        new_tco = hours.models.TimecardObject.objects.create(
+            timecard=new_timecard,
+            project=project_midas,
+            hours_spent=10.12
+        )
+        hours_adder = HoursAdder(
+            project_id = project_midas.id,
+            hours = '2',
+            user_id = self.user.id,
+            reporting_period_id = new_period.id,
+            undo_url = ''
+        )
+        hours_adder.perform_operation()
+        new_tco.refresh_from_db()
+
+        self.assertTrue(hours_adder.successful())
+        self.assertEqual(new_tco.hours_spent, Decimal('12.12'))
+        expected_message = '2 hours have been added to Midas. <a href="?hours=-2&project=35">Undo</a>'
+        self.assertEqual(expected_message, hours_adder.message)

--- a/tock/hours/tests/test_hours_adder.py
+++ b/tock/hours/tests/test_hours_adder.py
@@ -1,7 +1,7 @@
 from django.test import TestCase, RequestFactory
 from django.contrib.auth import get_user_model
 import hours.models
-from hours.hours_adder import HoursAdder
+from hours.hours_adder import HoursAdder, ERROR_MSG
 from employees.models import UserData
 from decimal import Decimal
 import datetime
@@ -55,6 +55,86 @@ class HoursAdderTests(TestCase):
 
         self.assertTrue(hours_adder.successful())
         self.assertEqual(1, new_count)
+
+    def test_invalid_hour_inputs_return_error_messages(self):
+        new_period = hours.models.ReportingPeriod.objects.create(
+            start_date=datetime.date(2016, 1, 1),
+            end_date=datetime.date(2016, 1, 7),
+        )
+        project_midas = projects.models.Project.objects.get(name="Midas")
+        hours_adder = HoursAdder(
+            project_id = project_midas.id,
+            hours = 'foobar',
+            user_id = self.user.id,
+            reporting_period_id = new_period.id,
+            undo_url = ''
+        )
+        hours_adder.perform_operation()
+        self.assertFalse(hours_adder.successful())
+        self.assertEqual(ERROR_MSG, hours_adder.message)
+
+        hours_adder = HoursAdder(
+            project_id = project_midas.id,
+            user_id = self.user.id,
+            reporting_period_id = new_period.id,
+            undo_url = ''
+        )
+        hours_adder.perform_operation()
+        self.assertFalse(hours_adder.successful())
+        self.assertEqual(ERROR_MSG, hours_adder.message)
+
+    def test_invalid_project_id_returns_error_message(self):
+        new_period = hours.models.ReportingPeriod.objects.create(
+            start_date=datetime.date(2016, 1, 1),
+            end_date=datetime.date(2016, 1, 7),
+        )
+        hours_adder = HoursAdder(
+            project_id = 200000,
+            hours = '2',
+            user_id = self.user.id,
+            reporting_period_id = new_period.id,
+            undo_url = ''
+        )
+        hours_adder.perform_operation()
+        self.assertFalse(hours_adder.successful())
+        self.assertEqual(ERROR_MSG, hours_adder.message)
+
+        hours_adder = HoursAdder(
+            hours = '2',
+            user_id = self.user.id,
+            reporting_period_id = new_period.id,
+            undo_url = ''
+        )
+        hours_adder.perform_operation()
+        self.assertFalse(hours_adder.successful())
+        self.assertEqual(ERROR_MSG, hours_adder.message)
+
+        hours_adder = HoursAdder(
+            project_id = 'foobar',
+            hours = '2',
+            user_id = self.user.id,
+            reporting_period_id = new_period.id,
+            undo_url = ''
+        )
+        hours_adder.perform_operation()
+        self.assertFalse(hours_adder.successful())
+        self.assertEqual(ERROR_MSG, hours_adder.message)
+
+    def test_invalid_user_id_returns_error_message(self):
+        new_period = hours.models.ReportingPeriod.objects.create(
+            start_date=datetime.date(2016, 1, 1),
+            end_date=datetime.date(2016, 1, 7),
+        )
+        hours_adder = HoursAdder(
+            project_id = 200000,
+            hours = '2',
+            user_id = None,
+            reporting_period_id = new_period.id,
+            undo_url = ''
+        )
+        hours_adder.perform_operation()
+        self.assertFalse(hours_adder.successful())
+        self.assertEqual(ERROR_MSG, hours_adder.message)
 
     def test_add_hours_with_existing_tco(self):
         """

--- a/tock/hours/tests/test_hours_adder.py
+++ b/tock/hours/tests/test_hours_adder.py
@@ -31,6 +31,28 @@ class HoursAdderTests(TestCase):
             end_date=datetime.date(2017, 1, 1),
         ).save()
 
+    def test_check_latest_period_is_the_present_one(self):
+        project_midas = projects.models.Project.objects.get(name="Midas")
+        new_period = hours.models.ReportingPeriod.objects.create(
+            start_date=datetime.date(2015, 2, 1),
+            end_date=datetime.date(2015, 2, 7),
+        )
+        new_timecard = hours.models.Timecard.objects.create(
+            user=self.user,
+            submitted=False,
+            reporting_period=new_period
+        )
+        hours_adder = HoursAdder(
+            project_id = project_midas.id,
+            hours = '2',
+            user_id = self.user.id,
+            reporting_period_id = new_period.id,
+            undo_url = '',
+            current_date=datetime.date(2016, 1, 2)
+        )
+        self.assertFalse(hours_adder.successful())
+
+
     def test_add_without_tco(self):
         project_midas = projects.models.Project.objects.get(name="Midas")
         new_period = hours.models.ReportingPeriod.objects.create(
@@ -46,6 +68,7 @@ class HoursAdderTests(TestCase):
             project_id = project_midas.id,
             hours = '2',
             user_id = self.user.id,
+            current_date=datetime.date(2016, 1, 2),
             reporting_period_id = new_period.id,
             undo_url = ''
         )
@@ -76,6 +99,7 @@ class HoursAdderTests(TestCase):
             hours = '2',
             user_id = self.user.id,
             reporting_period_id = new_period.id,
+            current_date=datetime.date(2016, 1, 2),
             undo_url = ''
         )
         hours_adder.perform_operation()
@@ -93,6 +117,7 @@ class HoursAdderTests(TestCase):
             hours = 'foobar',
             user_id = self.user.id,
             reporting_period_id = new_period.id,
+            current_date=datetime.date(2016, 1, 2),
             undo_url = ''
         )
         hours_adder.perform_operation()
@@ -103,6 +128,7 @@ class HoursAdderTests(TestCase):
             project_id = project_midas.id,
             user_id = self.user.id,
             reporting_period_id = new_period.id,
+            current_date=datetime.date(2016, 1, 2),
             undo_url = ''
         )
         hours_adder.perform_operation()
@@ -119,6 +145,7 @@ class HoursAdderTests(TestCase):
             hours = '2',
             user_id = self.user.id,
             reporting_period_id = new_period.id,
+            current_date=datetime.date(2016, 1, 2),
             undo_url = ''
         )
         hours_adder.perform_operation()
@@ -129,6 +156,7 @@ class HoursAdderTests(TestCase):
             hours = '2',
             user_id = self.user.id,
             reporting_period_id = new_period.id,
+            current_date=datetime.date(2016, 1, 2),
             undo_url = ''
         )
         hours_adder.perform_operation()
@@ -156,6 +184,7 @@ class HoursAdderTests(TestCase):
             hours = '2',
             user_id = None,
             reporting_period_id = new_period.id,
+            current_date=datetime.date(2016, 1, 2),
             undo_url = ''
         )
         hours_adder.perform_operation()
@@ -183,6 +212,7 @@ class HoursAdderTests(TestCase):
             hours = '-12.12',
             user_id = self.user.id,
             reporting_period_id = new_period.id,
+            current_date=datetime.date(2016, 1, 2),
             undo_url = ''
         )
         hours_adder.perform_operation()
@@ -219,6 +249,7 @@ class HoursAdderTests(TestCase):
             hours = '2',
             user_id = self.user.id,
             reporting_period_id = new_period.id,
+            current_date=datetime.date(2016, 1, 2),
             undo_url = ''
         )
         hours_adder.perform_operation()

--- a/tock/hours/tests/test_models.py
+++ b/tock/hours/tests/test_models.py
@@ -95,8 +95,9 @@ class TimecardTests(TestCase):
         timecard = Timecard.objects.first()
         self.assertEqual(timecard.user.pk, 1)
         self.assertEqual(timecard.reporting_period.exact_working_hours, 40)
-        self.assertEqual(timecard.created.day, datetime.date.today().day)
-        self.assertEqual(timecard.modified.day, datetime.date.today().day)
+        today_utc_day = datetime.datetime.utcnow().day
+        self.assertEqual(timecard.created.day, today_utc_day)
+        self.assertEqual(timecard.modified.day, today_utc_day)
         self.assertEqual(len(timecard.time_spent.all()), 2)
 
     def test_time_card_unique_constraint(self):
@@ -121,8 +122,10 @@ class TimecardTests(TestCase):
         self.assertEqual(timecardobj.timecard.user.pk, 1)
         self.assertEqual(timecardobj.project.name, 'openFEC')
         self.assertEqual(timecardobj.hours_spent, 12)
-        self.assertEqual(timecardobj.created.day, datetime.date.today().day)
-        self.assertEqual(timecardobj.modified.day, datetime.date.today().day)
+        today_utc_day = datetime.datetime.utcnow().day
+
+        self.assertEqual(timecardobj.created.day, today_utc_day)
+        self.assertEqual(timecardobj.modified.day, today_utc_day)
 
     def test_timecardobject_hours(self):
         """Test the TimeCardObject hours method."""

--- a/tock/hours/tests/test_views.py
+++ b/tock/hours/tests/test_views.py
@@ -665,6 +665,16 @@ class ReportTests(WebTest):
         new_tco.refresh_from_db()
         self.assertEqual(new_tco.hours_spent, Decimal('12.12'))
 
+        undo_url = "%s?project=%d&hours=-2" % (reverse('AddHours'), new_project.id)
+
+        response = self.app.get(
+            undo_url, None,
+            headers={'X_AUTH_USER': self.user.email}
+        )
+        self.assertEqual(response.status_code, 302)
+        new_tco.refresh_from_db()
+        self.assertEqual(new_tco.hours_spent, Decimal('10.12'))
+
     def test_do_not_prefill_timecard(self):
         """
         Test that a timecard doesn't get prefilled

--- a/tock/hours/tests/test_views.py
+++ b/tock/hours/tests/test_views.py
@@ -626,10 +626,15 @@ class ReportTests(WebTest):
         )
         self.assertEqual(prefilled_hours, {None})
 
-    def test_add_hours_with_existing_tco(self):
+    def test_add_hours(self):
         """
         Test that addHours increases the current timecard by the
-        specified amount
+        specified amount.
+
+        This test exists both as a sanity check, and for checking HoursAdder is being used
+        internally. Normally we would assert HoursAdded is called with the Mock library,
+        but since that dependency isn't in that project yet, we'll have to settle
+        and test side effects instead.
         """
         self.user = self.regular_user
 
@@ -659,35 +664,6 @@ class ReportTests(WebTest):
         self.assertEqual(response.status_code, 302)
         new_tco.refresh_from_db()
         self.assertEqual(new_tco.hours_spent, Decimal('12.12'))
-
-    def test_add_hours_without_tco(self):
-        """
-        Test that addHours creates a new timecardobject when
-        none is available
-        """
-        self.user = self.regular_user
-
-        new_project = projects.models.Project.objects.get(name="Midas")
-        new_period = hours.models.ReportingPeriod.objects.create(
-            start_date=datetime.date(2016, 1, 1),
-            end_date=datetime.date(2016, 1, 7),
-        )
-        new_timecard = hours.models.Timecard.objects.create(
-            user=self.user,
-            submitted=False,
-            reporting_period=new_period
-        )
-
-        url = "%s?project=%d&hours=2" % (reverse('AddHours'), new_project.id)
-
-        old_count = new_timecard.timecardobjects.count()
-        response = self.app.get(
-            url, None,
-            headers={'X_AUTH_USER': self.user.email}
-        )
-        new_count = new_timecard.timecardobjects.count()
-        self.assertEqual(old_count + 1, new_count)
-
 
     def test_do_not_prefill_timecard(self):
         """

--- a/tock/hours/tests/test_views.py
+++ b/tock/hours/tests/test_views.py
@@ -638,10 +638,12 @@ class ReportTests(WebTest):
         """
         self.user = self.regular_user
 
+        todays_date = datetime.datetime.now().date()
         new_period = hours.models.ReportingPeriod.objects.create(
-            start_date=datetime.date(2016, 1, 1),
-            end_date=datetime.date(2016, 1, 7),
+            start_date=todays_date,
+            end_date=todays_date + datetime.timedelta(days=2),
         )
+
         new_timecard = hours.models.Timecard.objects.create(
             user=self.user,
             submitted=False,

--- a/tock/hours/tests/test_views.py
+++ b/tock/hours/tests/test_views.py
@@ -6,6 +6,7 @@ from django.test import TestCase, RequestFactory
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import User
 from django_webtest import WebTest
+from decimal import Decimal
 
 from api.renderers import stream_csv
 
@@ -624,6 +625,69 @@ class ReportTests(WebTest):
             response.html.find_all('div', {'class': 'entry-amount'})[:-1]
         )
         self.assertEqual(prefilled_hours, {None})
+
+    def test_add_hours_with_existing_tco(self):
+        """
+        Test that addHours increases the current timecard by the
+        specified amount
+        """
+        self.user = self.regular_user
+
+        new_period = hours.models.ReportingPeriod.objects.create(
+            start_date=datetime.date(2016, 1, 1),
+            end_date=datetime.date(2016, 1, 7),
+        )
+        new_timecard = hours.models.Timecard.objects.create(
+            user=self.user,
+            submitted=False,
+            reporting_period=new_period
+        )
+        new_project = projects.models.Project.objects.get(name="Midas")
+        new_tco = hours.models.TimecardObject.objects.create(
+            timecard=new_timecard,
+            project=new_project,
+            hours_spent=10.12
+        )
+
+        url = "%s?project=%d&hours=2" % (reverse('AddHours'), new_project.id)
+
+        response = self.app.get(
+            url, None,
+            headers={'X_AUTH_USER': self.user.email}
+        )
+
+        self.assertEqual(response.status_code, 302)
+        new_tco.refresh_from_db()
+        self.assertEqual(new_tco.hours_spent, Decimal('12.12'))
+
+    def test_add_hours_without_tco(self):
+        """
+        Test that addHours creates a new timecardobject when
+        none is available
+        """
+        self.user = self.regular_user
+
+        new_project = projects.models.Project.objects.get(name="Midas")
+        new_period = hours.models.ReportingPeriod.objects.create(
+            start_date=datetime.date(2016, 1, 1),
+            end_date=datetime.date(2016, 1, 7),
+        )
+        new_timecard = hours.models.Timecard.objects.create(
+            user=self.user,
+            submitted=False,
+            reporting_period=new_period
+        )
+
+        url = "%s?project=%d&hours=2" % (reverse('AddHours'), new_project.id)
+
+        old_count = new_timecard.timecardobjects.count()
+        response = self.app.get(
+            url, None,
+            headers={'X_AUTH_USER': self.user.email}
+        )
+        new_count = new_timecard.timecardobjects.count()
+        self.assertEqual(old_count + 1, new_count)
+
 
     def test_do_not_prefill_timecard(self):
         """

--- a/tock/hours/views.py
+++ b/tock/hours/views.py
@@ -593,7 +593,7 @@ def add_hours_view(request):
     reporting_period = ReportingPeriod.objects.latest()
     hours_adder = HoursAdder(
         project_id = request.GET['project'],
-        hours = Decimal(request.GET['hours']),
+        hours = request.GET['hours'],
         user_id = request.user.id,
         reporting_period_id = reporting_period.id
     )

--- a/tock/hours/views.py
+++ b/tock/hours/views.py
@@ -1,6 +1,7 @@
 import csv
 import datetime
 import io
+from decimal import Decimal
 from itertools import chain
 from operator import attrgetter
 
@@ -10,11 +11,12 @@ from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError, ObjectDoesNotExist
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse
-from django.shortcuts import get_object_or_404
+from django.shortcuts import get_object_or_404, redirect
 from django.views.generic import ListView, DetailView, TemplateView
 from django.views.generic.edit import CreateView, UpdateView, FormView
 from django.db.models import Prefetch, Q, Sum
 from django.contrib.auth.decorators import user_passes_test
+from django.template.defaultfilters import pluralize
 
 from rest_framework.permissions import IsAuthenticated
 from rest_framework import serializers
@@ -587,6 +589,64 @@ class ReportingPeriodBulkImportView(PermissionMixin, FormView):
     def get_success_url(self):
         return reverse("ListReportingPeriods")
 
+def display_add_hours_error_message(request):
+    error_msg = "Oops. That command was not correct and no time was added to your timecard. Try again by entering a URL with this format: tock.gov/addHours?project=231&hours=1"
+    messages.add_message(
+        request,
+        messages.ERROR,
+        error_msg
+    )
+
+
+def add_hours_view(request):
+    project_id = request.GET['project']
+    hours = Decimal(request.GET['hours'])
+    r = ReportingPeriod.objects.latest()
+
+    try:
+        proj = Project.objects.get(id=project_id)
+    except Project.DoesNotExist:
+        display_add_hours_error_message(request)
+        return redirect(reverse('reportingperiod:UpdateTimesheet', args=[r]))
+
+    tc, created = Timecard.objects.get_or_create(
+        reporting_period_id=r.id,
+        user_id=request.user.id)
+
+    if created:
+        tc.save()
+
+    tco, created = TimecardObject.objects.get_or_create(
+        timecard_id=tc.id,
+        project_id=proj.id)
+
+    if tco.hours_spent is None:
+        tco.hours_spent = 0
+        display_add_hours_error_message(request)
+        return redirect(reverse('reportingperiod:UpdateTimesheet', args=[r]))
+
+    updated_hours = tco.hours_spent + hours
+    updated_hours = max(0, updated_hours)
+
+    tco.hours_spent = updated_hours
+    tco.save()
+
+    if hours > 0:
+        plural_hours = pluralize(hours, 'hour,hours')
+        has = pluralize(hours, 'has,have')
+        undo_query = "?hours=-%s&project=%s" % (hours, proj.id)
+        undo_url = reverse('AddHours') + undo_query
+        undo_tag = "<a href=\"%s\">Undo</a>" % (undo_url)
+        msg = "%s %s %s been added to %s. %s" % (hours, plural_hours, has,
+                proj.name, undo_tag)
+    else:
+        plural_hours = pluralize(-hours, 'hour,hours')
+        has = pluralize(-hours, 'has,have')
+        msg = "%s %s %s been removed from %s." % (-hours, plural_hours, has,
+                proj.name)
+
+    messages.add_message(request, messages.INFO, msg)
+    return redirect(reverse('reportingperiod:UpdateTimesheet', args=[r]))
 
 class TimecardView(UpdateView):
     form_class = TimecardForm

--- a/tock/hours/views.py
+++ b/tock/hours/views.py
@@ -595,7 +595,8 @@ def add_hours_view(request):
         project_id = request.GET['project'],
         hours = request.GET['hours'],
         user_id = request.user.id,
-        reporting_period_id = reporting_period.id
+        reporting_period_id = reporting_period.id,
+        undo_url = reverse('AddHours')
     )
 
     hours_adder.perform_operation()

--- a/tock/tock/templates/hours/timecard_form.html
+++ b/tock/tock/templates/hours/timecard_form.html
@@ -61,7 +61,7 @@
   {% if messages %}
   <ul class="messages">
     {% for message in messages %}
-      <b><li{% if message.tags %} class="alert-{{ message.tags }}"{% endif %}>{{ message }}</li></b>
+      <b><li{% if message.tags %} class="alert-{{ message.tags }}"{% endif %}>{{ message | safe }}</li></b>
     {% endfor %}
   </ul>
   {% endif %}

--- a/tock/tock/urls.py
+++ b/tock/tock/urls.py
@@ -14,6 +14,10 @@ urlpatterns = [
         hours.views.ReportingPeriodListView.as_view(),
         name='ListReportingPeriods'
     ),
+    url(r'^addHours/',
+        hours.views.add_hours_view,
+        name='AddHours'
+    ),
     url(r'^reporting_period/', include(
         'hours.urls.timesheets',
         namespace='reportingperiod'


### PR DESCRIPTION
## Description
This PR implements #511: an AddHours endpoint that allows a user to add hours for a specific line item to the current time card so that it's easier to contemporaneously track time in Tock.