### PR TITLE
Fix time drift issue w/ utcnow() for tests

### DIFF
--- a/tock/employees/tests/test_admin.py
+++ b/tock/employees/tests/test_admin.py
@@ -20,15 +20,15 @@ class TestUserDataForm(TestCase):
         ProfitLossAccount.objects.create(
             name='PL',
             accounting_string='1234',
-            as_start_date=datetime.date.today() + datetime.timedelta(
+            as_start_date=datetime.datetime.utcnow() + datetime.timedelta(
                 days=10
             ),
-            as_end_date=datetime.date.today() + datetime.timedelta(days=20),
+            as_end_date=datetime.datetime.utcnow() + datetime.timedelta(days=20),
             account_type='Expense'
         )
         form_data = {
             'user': User.objects.first().id,
-            'start_date': datetime.date.today(),
+            'start_date': datetime.datetime.utcnow(),
             'end_date': '',
             'current_employee': '',
             'is_18f_employee': '',

--- a/tock/employees/tests/test_models.py
+++ b/tock/employees/tests/test_models.py
@@ -16,7 +16,7 @@ class EmployeeGradeTests(TestCase):
         self.employeegrade = EmployeeGrade.objects.create(
             employee=User.objects.get(pk=1),
             grade=8,
-            g_start_date=datetime.date.today()
+            g_start_date=datetime.datetime.utcnow()
         )
     def test_unique_with_g_start_date(self):
         """Check that multiple EmployeeGrade objects with the same g_start_date
@@ -25,7 +25,7 @@ class EmployeeGradeTests(TestCase):
             another_employeegrade = EmployeeGrade.objects.create(
             employee=User.objects.get(pk=1),
             grade=9,
-            g_start_date=datetime.date.today()
+            g_start_date=datetime.datetime.utcnow()
         )
 
     def test_string_method(self):

--- a/tock/hours/tests/test_models.py
+++ b/tock/hours/tests/test_models.py
@@ -140,8 +140,8 @@ class TimecardObjectTests(TestCase):
             g_start_date=datetime.date(2016, 1, 1)
         )
         self.reporting_period = ReportingPeriod.objects.create(
-            start_date=datetime.date.today() - datetime.timedelta(days=7),
-            end_date=datetime.date.today()
+            start_date=datetime.datetime.utcnow() - datetime.timedelta(days=7),
+            end_date=datetime.datetime.utcnow()
         )
         self.timecard = Timecard.objects.create(
             user=self.user[0],
@@ -150,22 +150,22 @@ class TimecardObjectTests(TestCase):
         self.pl_acct = ProfitLossAccount.objects.create(
             name='PL',
             accounting_string='string',
-            as_start_date=datetime.date.today() - datetime.timedelta(days=10),
-            as_end_date=datetime.date.today() + datetime.timedelta(days=355),
+            as_start_date=datetime.datetime.utcnow() - datetime.timedelta(days=10),
+            as_end_date=datetime.datetime.utcnow() + datetime.timedelta(days=355),
             account_type='Revenue'
         )
         self.pl_acct_2 = ProfitLossAccount.objects.create(
             name='PL2',
             accounting_string='newstring',
-            as_start_date=datetime.date.today() + datetime.timedelta(days=10),
-            as_end_date=datetime.date.today() - datetime.timedelta(days=10),
+            as_start_date=datetime.datetime.utcnow() + datetime.timedelta(days=10),
+            as_end_date=datetime.datetime.utcnow() - datetime.timedelta(days=10),
             account_type='Expense'
         )
         self.pl_acct_3 = ProfitLossAccount.objects.create(
             name='PL3',
             accounting_string='newstring',
-            as_start_date=datetime.date.today() - datetime.timedelta(days=10),
-            as_end_date=datetime.date.today() + datetime.timedelta(days=355),
+            as_start_date=datetime.datetime.utcnow() - datetime.timedelta(days=10),
+            as_end_date=datetime.datetime.utcnow() + datetime.timedelta(days=355),
             account_type='Expense'
         )
 

--- a/tock/hours/views.py
+++ b/tock/hours/views.py
@@ -235,6 +235,8 @@ class ReportingPeriodListView(PermissionMixin, ListView):
             timecard__submitted=True,
             timecard__user=self.request.user.id
         ).distinct().order_by('-start_date')[:5]
+        context['server_time'] = datetime.datetime.now()
+        context['utc_time'] = datetime.datetime.utcnow()
 
         try:
             unstarted_reporting_periods = self.queryset.exclude(

--- a/tock/projects/tests.py
+++ b/tock/projects/tests.py
@@ -26,8 +26,8 @@ class AdminTests(TestCase):
     def test_profitloss_form(self):
         """Tests custom validation on the ProfitLossAccountForm."""
         form_data = {
-            'as_start_date':datetime.date.today(),
-            'as_end_date':datetime.date.today() - datetime.timedelta(days=1),
+            'as_start_date':datetime.datetime.utcnow(),
+            'as_end_date':datetime.datetime.utcnow() - datetime.timedelta(days=1),
             'name': 'foo',
             'accounting_string':'bar',
             'account_type': 'Revenue'
@@ -42,10 +42,10 @@ class AdminTests(TestCase):
         ProfitLossAccount.objects.create(
             name='PL',
             accounting_string='1234',
-            as_start_date=datetime.date.today() + datetime.timedelta(
+            as_start_date=datetime.datetime.utcnow() + datetime.timedelta(
                 days=10
             ),
-            as_end_date=datetime.date.today() + datetime.timedelta(days=20),
+            as_end_date=datetime.datetime.utcnow() + datetime.timedelta(days=20),
             account_type='Revenue'
         )
         data = {
@@ -53,7 +53,7 @@ class AdminTests(TestCase):
             'mbnumber':'',
             'accounting_code':AccountingCode.objects.first().id,
             'description':'',
-            'start_date':datetime.date.today(),
+            'start_date':datetime.datetime.utcnow(),
             'end_date':'',
             'active':'',
             'notes_required':'',
@@ -410,7 +410,7 @@ class TestProjectTimeline(WebTest):
             name='Test Project',
         )
         self.dates = [
-            datetime.date.today() + datetime.timedelta(weeks * 7)
+            datetime.datetime.utcnow().date() + datetime.timedelta(weeks * 7)
             for weeks in range(10)
         ]
         self.objs = [

--- a/tock/tock/tests/test_remote_user_auth.py
+++ b/tock/tock/tests/test_remote_user_auth.py
@@ -44,7 +44,7 @@ class AuthTests(WebTest):
         self.assertEqual('tock.tock', user.username)
         self.assertIsNotNone(UserData.objects.get(user=user))
         self.assertEqual(
-            datetime.date.today(), UserData.objects.get(user=user).start_date
+            datetime.datetime.utcnow().date(), UserData.objects.get(user=user).start_date
         )
         self.assertEqual('Tock', user.first_name)
         self.assertEqual('Tock', user.last_name)


### PR DESCRIPTION
## Description

Extends the smart fixes proposed by @elg0nz to the remaining today() occurrences in a variety of tests. For additional info, see #597 and commit message on https://github.com/18F/tock/pull/597/commits/03cd1b2a57cb45463fd9a975f14f700ba00c4d62.