### PR TITLE
Patch Ops Report

### DIFF
--- a/tock/hours/tests/test_views.py
+++ b/tock/hours/tests/test_views.py
@@ -198,7 +198,7 @@ class DashboardViewTests(WebTest):
         self.assertContains(response, 'Whoops')
         self.assertContains(response, date)
 
-    def test_unit_param(self):
+        """def test_unit_param(self):
         date = self.rp_2.end_date.strftime('%Y-%m-%d')
         self.ud.unit = 13
         self.ud.save()
@@ -229,8 +229,7 @@ class DashboardViewTests(WebTest):
         self.assertEqual(
             response.context['variance_rev_cr_weekly'],
             '$0'
-        )
-
+        )"""
     def test_template_render(self):
         date = self.rp_2.end_date.strftime('%Y-%m-%d')
         response = self.app.get(
@@ -244,7 +243,7 @@ class DashboardViewTests(WebTest):
         self.assertContains(response, '<td>13.0 (650.00%)</td>')
         self.assertContains(response, '<td>$1,498 (59900.00%)</td>')
 
-        self.ud.unit = 13
+        """self.ud.unit = 13
         self.ud.save()
         response = self.app.get(
             reverse(
@@ -259,6 +258,7 @@ class DashboardViewTests(WebTest):
             '<td>$0 (0.00%)</td>',
             html=True
         )
+
         response = self.app.get(
             reverse(
                 'reports:DashboardView',
@@ -271,7 +271,7 @@ class DashboardViewTests(WebTest):
             response,
             '<td>14.0 (1400.00%)</td>',
             html=True
-        )
+        )"""
 
 
 

--- a/tock/hours/tests/test_views.py
+++ b/tock/hours/tests/test_views.py
@@ -76,6 +76,7 @@ class DashboardViewTests(WebTest):
         self.user = User.objects.first()
         self.ud = UserData.objects.first()
         self.ud.user = self.user
+        self.ud.unit = 0
         self.ud.save()
         self.rp_1 = hours.models.ReportingPeriod.objects.create(
             start_date=datetime.date(2016, 10, 1),
@@ -242,6 +243,20 @@ class DashboardViewTests(WebTest):
         self.assertContains(response, '<td>$4,500</td>')
         self.assertContains(response, '<td>13.0 (650.00%)</td>')
         self.assertContains(response, '<td>$1,498 (59900.00%)</td>')
+        self.assertNotContains(response, '<td>$-2 (-100.00%)</td>')
+
+        # Test that units are correctly excluded.
+        self.ud.unit = 4
+        self.ud.save()
+        response = self.app.get(
+            reverse(
+                'reports:DashboardView',
+                kwargs={'reporting_period': date}
+            ),
+            headers={'X_AUTH_USER': self.user.email},
+        )
+        self.assertContains(response, '<td>$-2 (-100.00%)</td>')
+        self.assertNotContains(response, '<td>$1,498 (59900.00%)</td>')
 
         """self.ud.unit = 13
         self.ud.save()

--- a/tock/hours/views.py
+++ b/tock/hours/views.py
@@ -79,7 +79,7 @@ class DashboardView(TemplateView):
         context = super(DashboardView, self).get_context_data(**kwargs)
 
         # Get unit param.
-        unit_param = get_params('unit')
+        unit_param = None #get_params('unit')
 
         # Get requested date and corresponding reporting period.
         requested_date = datetime.datetime.strptime(
@@ -108,10 +108,15 @@ class DashboardView(TemplateView):
             current_employee=True
         )
         units = []
+        missing_units = []
         for e in employees:
-            units.append(
-                (e.unit, e.get_unit_display())
-            )
+            if e.unit:
+                units.append(
+                    (e.unit, e.get_unit_display())
+                )
+            else:
+                missing_units.append(e)
+
         units = sorted(set(units), key=lambda x: x[1])
 
         # Narrow to unit employees, if applicable.
@@ -206,6 +211,7 @@ class DashboardView(TemplateView):
         context.update(
             {   # Unit data.
                 'units':units,
+                'missing_units':missing_units,
                 # Target info.
                 'revenue_target_cr':'${:,}'.format(
                     target.revenue_target_cr

--- a/tock/hours/views.py
+++ b/tock/hours/views.py
@@ -106,7 +106,7 @@ class DashboardView(TemplateView):
         employees = UserData.objects.filter(
             is_18f_employee=True,
             current_employee=True
-        )
+        ).exclude(unit__in=[4, 9, 14, 15])
         units = []
         missing_units = []
         for e in employees:

--- a/tock/tock/templates/hours/dashboard.html
+++ b/tock/tock/templates/hours/dashboard.html
@@ -19,21 +19,7 @@
 <li>Revenue on cost recovery revenue target of {{ revenue_target_cr }} and
   financial plan revenue target of {{ revenue_target_plan }}.</li>
 <li>Revenue performance calculated using a blended labor rate of {{ labor_rate }} per hour.</li>
-
 </ul>
-<h4>Select a unit or all:</h4>
-{% if request.GET.unit %}
-<a href="{% url 'reports:DashboardView' rp_selected.end_date %}">All</a>
-{% else %}
-<b>All</b>
-{% endif %}
-{% for unit in units %}
-  {% if unit.0|stringformat:"s" == request.GET.unit %}
-  | <b>{{ unit.1 }}</b>
-  {% else %}
-  | <a href="{% url 'reports:DashboardView' rp_selected.end_date %}?unit={{ unit.0}}">{{ unit.1 }}</a>
-  {% endif %}
-{% endfor %}
 <h3>Performance vs. Targets, Fiscal Year to Date</h3>
 <i>{{ fytd_start_date }} to {{ rp_selected.end_date }}</i>
 <table>


### PR DESCRIPTION
## Description

Rolls back the ability to "zoom in" on specific units in the Operations Dashboard, which will require a better understanding of how @joshuabailes and the business calculates such things. Also updates report so that only 18F "units" are included (excludes PIF and AcqStack) in the org-level report.

## Additional information

Screenshot:
<img width="1057" alt="screen shot 2016-12-06 at 2 21 52 pm" src="https://cloud.githubusercontent.com/assets/7645362/20940060/5f7665ac-bbbf-11e6-9ad4-0ea5fae1b946.png">
