### PR TITLE
Billable vs. All Toggle for Util Report

### DIFF
--- a/tock/tock/templates/utilization/group_utilization.html
+++ b/tock/tock/templates/utilization/group_utilization.html
@@ -21,12 +21,21 @@
   projects that are marked "billable" in Tock, divided by the total number of
   hours submitted on all projects for the given period.
 </p>
+<h3>Select employee type: </h4>
+  {% if request.GET.all == '' %}
+  All | <a href="{% url 'utilization:GroupUtilizationView' %}">Billable Only</a>
+  {% else %}
+  <a href="{% url 'utilization:GroupUtilizationView'%}?all">All</a> | Billable Only
+  {% endif %}
+
 <h3>Jump to:</h3>
-<ul>
-{% for i in unit_choices %}
-  <li><a href="#{{i.1}}">{{i.1}}</a></li>
+{% for i in unit_choices|slice:":1" %}
+  <a href="#{{i.1}}">{{i.1}}</a></li>
 {% endfor %}
-</ul>
+{% for i in unit_choices|slice:"1:" %}
+  | <a href="#{{i.1}}">{{i.1}}</a></li>
+{% endfor %}
+
 
 {% for i in unit_choices %}
 

--- a/tock/utilization/tests/test_views.py
+++ b/tock/utilization/tests/test_views.py
@@ -125,6 +125,31 @@ class TestGroupUtilizationView(WebTest):
             response.context['user_list'][0].__dict__['_user_data_cache'].\
             __dict__['unit'], 0)
 
+    def test_all_param(self):
+        self.user_data.is_billable = False
+        self.user_data.save()
+
+        # Check that nonbillable employee is included with all param.
+        response = self.app.get(
+            url='{}?all'.format(
+                reverse(
+                    'utilization:GroupUtilizationView',
+                )
+            ),
+            headers={'X_AUTH_USER': 'aaron.snow@gsa.gov'}
+        )
+        self.assertContains(response, 'regular.user')
+        self.assertEqual(response.context['user_list'].count(), 2)
+
+        # Check that nonbillable employee is not included w/o all param.
+        response = self.app.get(
+            url=reverse('utilization:GroupUtilizationView'),
+            headers={'X_AUTH_USER': 'aaron.snow@gsa.gov'}
+        )
+
+        self.assertNotContains(response, 'regular.user')
+        self.assertEqual(response.context['user_list'].count(), 1)
+
     def test_summary_rows(self):
         response = self.app.get(
             url=reverse('utilization:GroupUtilizationView'),

--- a/tock/utilization/views.py
+++ b/tock/utilization/views.py
@@ -21,6 +21,7 @@ class GroupUtilizationView(ListView):
         accept a form response that allows the user or app to dynamically
         customize number of periods to include in the queryset."""
 
+
         available_periods = ReportingPeriod.objects.count()
         requested_periods = 4
 
@@ -28,13 +29,16 @@ class GroupUtilizationView(ListView):
             recent_rps = get_dates(requested_periods)
         else:
             recent_rps = get_dates(available_periods)
-
-        billable_staff = User.objects.filter(
-            user_data__is_billable=True,
-            user_data__current_employee=True
-        ).prefetch_related('user_data')
-
-        for staffer in billable_staff:
+        if 'all' in self.request.GET.dict().keys():
+            employees = User.objects.filter(
+                user_data__current_employee=True
+            ).prefetch_related('user_data')
+        else:
+            employees = User.objects.filter(
+                user_data__is_billable=True,
+                user_data__current_employee=True
+            ).prefetch_related('user_data')
+        for staffer in employees:
             staffer.unit = staffer.user_data.unit
 
             """Create smallest possible TimecardObject queryset based on the
@@ -155,7 +159,7 @@ class GroupUtilizationView(ListView):
                 }
             )
 
-        return billable_staff
+        return employees
 
     def get_context_data(self, **kwargs):
         context = super(GroupUtilizationView, self).get_context_data(**kwargs)


### PR DESCRIPTION
## Description

Addresses need in #542 by allowing the user to toggle the utilization report between "billable" and "all" employees, with default to "billable" only. Accomplishes this functionality through including the parameter "all" in the request to view all employees.

Also makes slight tweak to display of units for a more consolidated design.

## Additional information

Screen shot:

<img width="1039" alt="screen shot 2016-12-06 at 6 04 13 pm" src="https://cloud.githubusercontent.com/assets/7645362/20947711/76d59866-bbde-11e6-9a71-ab3861094326.png">

