### PR TITLE
Add acquisitions project filter

### DIFF
--- a/tock/hours/tests/test_views.py
+++ b/tock/hours/tests/test_views.py
@@ -168,6 +168,33 @@ class DashboardViewTests(WebTest):
         )
         self.assertEqual(response.status_code, 200)
 
+    def test_acq_exclusion(self):
+        date = self.rp_2.end_date.strftime('%Y-%m-%d')
+        response = self.app.get(
+            reverse(
+                'reports:DashboardView',
+                kwargs={'reporting_period': date}
+            ),
+            headers={'X_AUTH_USER': self.user.email},
+        )
+        self.assertNotContains(response, '<td>$-2 (-100.00%)</td>')
+
+        p_l = projects.models.ProfitLossAccount.objects.create(
+            name='FY17 Acquisition Svcs Billable',
+        )
+        self.project_1.profit_loss_account = p_l
+        self.project_1.save()
+        self.project_2.profit_loss_account = p_l
+        self.project_2.save()
+        response = self.app.get(
+            reverse(
+                'reports:DashboardView',
+                kwargs={'reporting_period': date}
+            ),
+            headers={'X_AUTH_USER': self.user.email},
+        )
+        self.assertContains(response, '<td>$-2 (-100.00%)</td>')
+
     def test_no_reporting_period(self):
         """Tests errors are handled when there is no matching reporting
         period."""

--- a/tock/hours/views.py
+++ b/tock/hours/views.py
@@ -170,6 +170,8 @@ class DashboardView(TemplateView):
             timecard__reporting_period__end_date__lte=requested_date,
             project__accounting_code__billable=True,
             timecard__user__user_data__in=employees
+        ).exclude(
+            project__profit_loss_account__name='FY17 Acquisition Svcs Billable'
         ).aggregate(Sum('hours_spent'))['hours_spent__sum'])
         rev_fytd = hours_billed_fytd * target.labor_rate
 
@@ -179,6 +181,8 @@ class DashboardView(TemplateView):
                 rp_selected.start_date.strftime('%Y-%m-%d'),
             project__accounting_code__billable=True,
             timecard__user__user_data__in=employees
+        ).exclude(
+            project__profit_loss_account__name='FY17 Acquisition Svcs Billable'
         ).aggregate(Sum('hours_spent'))['hours_spent__sum'])
         rev_weekly = hours_billed_weekly * target.labor_rate
 


### PR DESCRIPTION
## Description

Filters out projects that have Acquisition Services profit / loss information from the operations report, per @joshuabailes.