### PR TITLE
[WIP] Fix timesheet error alert

### DIFF
--- a/tock/tock/static/sass/_entries.scss
+++ b/tock/tock/static/sass/_entries.scss
@@ -207,3 +207,7 @@
 .reporting-period {
   color: $color-medium;
 }
+
+.timecard-alert-error {
+  margin-bottom: 2rem;
+}

--- a/tock/tock/static/sass/_entries.scss
+++ b/tock/tock/static/sass/_entries.scss
@@ -164,6 +164,8 @@
 }
 
 .entries-total {
+  margin-top: 1rem;
+
 	.entries-add-more {
 		@include span-columns(3);
 	}

--- a/tock/tock/static/sass/_entries.scss
+++ b/tock/tock/static/sass/_entries.scss
@@ -200,7 +200,7 @@
 
 .form-error,
 .invalid {
-	color: $color-secondary;
+	color: $color-secondary-dark;
 	font-weight: bold;
 }
 

--- a/tock/tock/templates/hours/timecard_form.html
+++ b/tock/tock/templates/hours/timecard_form.html
@@ -56,7 +56,12 @@
     {% endfor %}
   </div>
   {% if formset.errors %}
-    <div class="alert-red"><b>{{ formset.non_form_errors }}</b></div>
+    <div class="usa-alert usa-alert-error" role="alert">
+      <div class="usa-alert-body">
+        <h3 class="usa-alert-heading">Complete your timecard</h3>
+        <p class="usa-alert-text">{{ formset.non_form_errors }}</p>
+      </div>
+    </div>
   {% endif %}
   {% if messages %}
   <ul class="messages">

--- a/tock/tock/templates/hours/timecard_form.html
+++ b/tock/tock/templates/hours/timecard_form.html
@@ -13,6 +13,21 @@
 <form class="form-horizontal form-inline" method="post">
   {% csrf_token %}
   {{ formset.management_form }}
+  {% if formset.errors %}
+    <div class="usa-alert usa-alert-error timecard-alert-error" role="alert">
+      <div class="usa-alert-body">
+        <h3 class="usa-alert-heading">Complete your timecard</h3>
+        <p class="usa-alert-text">{{ formset.non_form_errors }}</p>
+      </div>
+    </div>
+  {% endif %}
+  {% if messages %}
+  <ul class="messages">
+    {% for message in messages %}
+      <b><li{% if message.tags %} class="alert-{{ message.tags }}"{% endif %}>{{ message }}</li></b>
+    {% endfor %}
+  </ul>
+  {% endif %}
   <div class="entries">
     <ul class="entries-header">
       <li>PROJECTS</li>
@@ -55,21 +70,7 @@
       </div>
     {% endfor %}
   </div>
-  {% if formset.errors %}
-    <div class="usa-alert usa-alert-error" role="alert">
-      <div class="usa-alert-body">
-        <h3 class="usa-alert-heading">Complete your timecard</h3>
-        <p class="usa-alert-text">{{ formset.non_form_errors }}</p>
-      </div>
-    </div>
-  {% endif %}
-  {% if messages %}
-  <ul class="messages">
-    {% for message in messages %}
-      <b><li{% if message.tags %} class="alert-{{ message.tags }}"{% endif %}>{{ message }}</li></b>
-    {% endfor %}
-  </ul>
-  {% endif %}
+
   <div class="entries-total">
     <div class="entries-add-more"></br>
       <button type="button" class="add-timecard-entry">Add More Items</a>


### PR DESCRIPTION
## Description

Makes the following fixes to the error alert on the timesheet page:
- Uses the USWDS alert to be consistent with our style
- Adds a heading to the alert
- Fixes inline alert text color
- Moves alert to top of form to improve usability

### Thoughts

- What is the messages list do and what does it look like?
- Should we move the info alert about submitting the timecard to the landing page?

## This is what it looks like
![krfsvbg6mtiecaaaecbagqiecaaaecbagqiecaaaecbagqiecaaaecbagqieagmuavybhp6elw4mcbcpr06cvmfrzl1gydesbagaabagqiecbagaabagqiecbagaabagqiecbagaabagqiecbaik9al2gxweemji2njv12w5iwwn7egj0aaqiecbagqiaaaqiecbagqiaaaqiecbagqiaaaqiecbagqiaaaqljbhoni7004cterdh27fg4](https://cloud.githubusercontent.com/assets/5249443/21198654/fb71ea68-c1f4-11e6-8fa8-ffa4aa4fbbf0.png)

