### PR TITLE
Update slim report

### DIFF
--- a/tock/hours/tests/test_models.py
+++ b/tock/hours/tests/test_models.py
@@ -95,8 +95,8 @@ class TimecardTests(TestCase):
         timecard = Timecard.objects.first()
         self.assertEqual(timecard.user.pk, 1)
         self.assertEqual(timecard.reporting_period.exact_working_hours, 40)
-        self.assertEqual(timecard.created.day, datetime.date.today().day)
-        self.assertEqual(timecard.modified.day, datetime.date.today().day)
+        self.assertEqual(timecard.created.day, datetime.datetime.utcnow().day)
+        self.assertEqual(timecard.modified.day, datetime.datetime.utcnow().day)
         self.assertEqual(len(timecard.time_spent.all()), 2)
 
     def test_time_card_unique_constraint(self):
@@ -121,8 +121,8 @@ class TimecardTests(TestCase):
         self.assertEqual(timecardobj.timecard.user.pk, 1)
         self.assertEqual(timecardobj.project.name, 'openFEC')
         self.assertEqual(timecardobj.hours_spent, 12)
-        self.assertEqual(timecardobj.created.day, datetime.date.today().day)
-        self.assertEqual(timecardobj.modified.day, datetime.date.today().day)
+        self.assertEqual(timecardobj.created.day, datetime.datetime.utcnow().day)
+        self.assertEqual(timecardobj.modified.day, datetime.datetime.utcnow().day)
 
     def test_timecardobject_hours(self):
         """Test the TimeCardObject hours method."""

--- a/tock/hours/tests/test_views.py
+++ b/tock/hours/tests/test_views.py
@@ -420,6 +420,7 @@ class BulkTimecardsTests(TestCase):
         rows = decode_streaming_csv(response)
         expected_fields = set((
             'project_name',
+            'project_id',
             'billable',
             'employee',
             'start_date',

--- a/tock/hours/views.py
+++ b/tock/hours/views.py
@@ -366,6 +366,7 @@ class GeneralSnippetsTimecardSerializer(serializers.Serializer):
 
 class SlimBulkTimecardSerializer(serializers.Serializer):
     project_name = serializers.CharField(source='project.name')
+    project_id = serializers.CharField(source='project.id')
     employee = serializers.StringRelatedField(source='timecard.user')
     start_date = serializers.DateField(source='timecard.reporting_period.start_date')
     end_date = serializers.DateField(source='timecard.reporting_period.end_date')


### PR DESCRIPTION
## Description

Adds the `project_id` attribute from the `Project` class to the `SlimBulkTimecardSerializer` per @HuixianXu's request. Tests updated to reflect addition.

While making change, updated two failing tests to rely on UTC time, instead of local.
