### PR TITLE
Upgrade Django to 1.10.7 to fix potential vulnerabilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.10.3
+Django==1.10.7
 dj-database-url==0.4.1
 psycopg2==2.6.2
 model-mommy==1.3.0


### PR DESCRIPTION
## Description

Ref https://gemnasium.com/github.com/18F/tock/alerts and https://www.djangoproject.com/weblog/2017/apr/04/security-releases/