### PR TITLE
change hours increment on timecard_form

### DIFF
--- a/tock/hours/forms.py
+++ b/tock/hours/forms.py
@@ -160,7 +160,7 @@ class TimecardObjectForm(forms.ModelForm):
         min_value=0,
         required=False,
         widget=forms.NumberInput(attrs={
-            'step': '0.25'
+            'step': '0.50'
         })
     )
 


### PR DESCRIPTION
## Description

Changes hours increment on timecard form from 0.25 to 0.50. The built-in widget enforces the increment on submit.

## Additional information
<img width="818" alt="screen shot 2017-07-06 at 3 46 30 pm" src="https://user-images.githubusercontent.com/7645362/27929789-53d88b7c-6262-11e7-9b45-4286125cd0db.png">
