### PR TITLE
Trigger creation of reporting period if last reporting has ended (usually)

### DIFF
--- a/tock/hours/views.py
+++ b/tock/hours/views.py
@@ -512,17 +512,52 @@ class ReportingPeriodListView(PermissionMixin, ListView):
     """ Currently the home view that lists the completed and missing time
     periods """
     context_object_name = "incomplete_reporting_periods"
-    queryset = ReportingPeriod.objects.all()
+    queryset = ReportingPeriod.objects.all().order_by('-start_date')
     template_name = "hours/reporting_period_list.html"
     permission_classes = (IsAuthenticated, )
+
+    def disallowed_dates(self, date):
+        # If the end of the fiscal year is not on a weekend, then create
+        # a list of dates around (the buffer) the end of the fiscal year
+        # where a reporting period will not be automatically created. This
+        # prevents the automatic creation of a reporting period that has
+        # working week days that span two fiscal years.
+        fy_start_date = datetime.date(year=date.year, month=10, day=1)
+        if fy_start_date.weekday() < 5 and date.month < 10:
+            buffer_days = 7 # A week before and after.
+            buffer_start = fy_start_date - datetime.timedelta(days=buffer_days)
+            buffer_end = fy_start_date + datetime.timedelta(days=buffer_days)
+            return [ buffer_start + datetime.timedelta(days=i) for i in \
+                range((buffer_end - buffer_start).days) ]
+        else:
+            return []
+
+    def auto_create_reporting_period(self):
+        # Automatically creates a new reporting period if the latest reporting
+        # period has concluded.
+        latest_rp = self.queryset.first()
+        if not latest_rp:
+            return None # In case there are no reporting periods created yet.
+        if latest_rp.end_date >= datetime.datetime.utcnow().date():
+            return None # If the latest rp hasn't ended yet.
+        start_date = latest_rp.end_date + datetime.timedelta(days=1)
+        if start_date not in self.disallowed_dates(latest_rp.end_date):
+            ReportingPeriod.objects.create(
+                start_date=start_date,
+                end_date=start_date + datetime.timedelta(days=7),
+                max_working_hours=40,
+                min_working_hours=40,
+                exact_working_hours=40
+            )
 
     def get_context_data(self, **kwargs):
         context = super(
             ReportingPeriodListView, self).get_context_data(**kwargs)
+        self.auto_create_reporting_period()
         context['completed_reporting_periods'] = self.queryset.filter(
             timecard__submitted=True,
             timecard__user=self.request.user.id
-        ).distinct().order_by('-start_date')[:5]
+        ).distinct()[:5]
 
         try:
             unstarted_reporting_periods = self.queryset.exclude(

--- a/tock/hours/views.py
+++ b/tock/hours/views.py
@@ -522,13 +522,12 @@ class ReportingPeriodListView(PermissionMixin, ListView):
         # where a reporting period will not be automatically created. This
         # prevents the automatic creation of a reporting period that has
         # working week days that span two fiscal years.
+        if date.month not in [9, 10]:
+            return []
         fy_start_date = datetime.date(year=date.year, month=10, day=1)
-        if fy_start_date.weekday() < 5 and date.month < 10:
-            buffer_days = 7 # A week before and after.
-            buffer_start = fy_start_date - datetime.timedelta(days=buffer_days)
-            buffer_end = fy_start_date + datetime.timedelta(days=buffer_days)
-            return [ buffer_start + datetime.timedelta(days=i) for i in \
-                range((buffer_end - buffer_start).days) ]
+        if fy_start_date.weekday() not in [5, 6, 1]:
+            return [ fy_start_date + datetime.timedelta(days=i) for i in \
+                range(-7, 7) ] # A disallow dates a week before and after.
         else:
             return []
 


### PR DESCRIPTION
## Description

Addresses #628 by automatically creating a new `ReportingPeriod` if the `end_date` attribute of the latest `ReportingPeriod` has passed. The new `ReportingPeriod` will have a `start_date` that is one day after the `end_date` of the previous reporting period (with it's own `end_date` six days after that).

To avoid situations where a new `ReportingPeriod` is created that includes work week days in more than one fiscal year, auto-creation is disabled for any potential start dates seven days before and after October 1st of any year, as long as October first is _not_ on a weekend. For instance, auto-creation would be disabled for the last week of September 2015 and first week of October 2015. 

Auto-creation will remain active in the last week of September 2017 and first week of October 2017 because October 1st is, in fact, on a weekend.

**NOTE**: If a week includes a holiday, a Tock administrative user will still need to "attach" a `HolidayPrefill` to the auto-created `ReportingPeriod`.