### PR TITLE
new end date should be six days from start date, not seven

### DIFF
--- a/tock/hours/tests/test_views.py
+++ b/tock/hours/tests/test_views.py
@@ -613,6 +613,12 @@ class ReportTests(WebTest):
             new_rps.first().start_date,
             (self.reporting_period.end_date + datetime.timedelta(days=1))
         )
+        self.assertEqual(
+            new_rps.first().end_date,
+            (self.reporting_period.end_date +  \
+             datetime.timedelta(days=1)) + \
+             datetime.timedelta(days=6)
+        )
 
     def test_auto_create_reporting_period_fy_end(self):
         """ Check that a reporting period is NOT automatically created if

--- a/tock/hours/views.py
+++ b/tock/hours/views.py
@@ -545,7 +545,7 @@ class ReportingPeriodListView(PermissionMixin, ListView):
         new_start not in self.disallowed_dates(latest_rp.end_date):
             ReportingPeriod.objects.create(
                 start_date=new_start,
-                end_date=new_start + datetime.timedelta(days=7),
+                end_date=new_start + datetime.timedelta(days=6),
                 max_working_hours=40,
                 min_working_hours=40,
                 exact_working_hours=40


### PR DESCRIPTION
## Description

I noticed that when this week's reporting period auto-created it had a Sunday end date (7/30) instead of a Saturday end date (7/29). Fix was a one liner, switching a `timedelta()` to `6` instead of `7` days, plus a test to verify success.

