### PR TITLE
Fix delete checkbox label

### DIFF
--- a/tock/tock/templates/hours/timecard_form.html
+++ b/tock/tock/templates/hours/timecard_form.html
@@ -71,7 +71,7 @@
       {% if unsubmitted %}
       <div class="entry-delete usa-width-two-thirds">
         {{ project_entry.DELETE }}
-        <label>Delete this item</label>
+        <label for="id_timecardobjects-{{ forloop.counter0 }}-DELETE">Delete this item</label>
       </div>
       {% endif %}
     </div>


### PR DESCRIPTION
## Description

Resolves #643 by building an id from an existing `forloop` variable and some static text, then set it as the `for` value for the label.