### PR TITLE
Add browser notifications for 3pm local time on Friday

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If your team uses Tock and Slack, you might also find the ["angrytock" reminder 
 1. Run:
 
   ```shell
-  $ cp .env.sample .env
+  $ cp tock/.env.sample .env
   $ docker-compose build
   $ docker-compose run app python manage.py migrate
   $ docker-compose run app python manage.py loaddata test_data/data-update.json

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If your team uses Tock and Slack, you might also find the ["angrytock" reminder 
 1. Run:
 
   ```shell
-  $ cp tock/.env.sample .env
+  $ cp .env.sample .env
   $ docker-compose build
   $ docker-compose run app python manage.py migrate
   $ docker-compose run app python manage.py loaddata test_data/data-update.json

--- a/tock/tock/static/js/components/notifications.js
+++ b/tock/tock/static/js/components/notifications.js
@@ -1,4 +1,4 @@
-(function setup_notifications() {
+(function setupNotifications() {
   if("Notification" in window) {
     Notification.requestPermission().then(function(result) {
       // If the user grants permission, or has granted permission in the past,
@@ -45,6 +45,8 @@
       };
 
       setTimer();
+    }).catch(function(error) {
+      console.error('error:', error);
     });
   }
 })();

--- a/tock/tock/static/js/components/notifications.js
+++ b/tock/tock/static/js/components/notifications.js
@@ -1,0 +1,50 @@
+(function setup_notifications() {
+  if("Notification" in window) {
+    Notification.requestPermission().then(function(result) {
+      // If the user grants permission, or has granted permission in the past,
+      // setup the timers.  Otherwise bail out.
+      if (result !== 'granted') {
+        return;
+      }
+
+      var setTimer = function() {
+        var now = new Date();
+        var target;
+
+        // If it's Friday and before 3pm... (local times)
+        if(now.getDay() == 5 && now.getHours() < 15) {
+          // ...target is later today
+          var hoursForward = 15 - now.getHours();
+          target = new Date(now.getFullYear(), now.getMonth(), now.getDate(), now.getHours() + hoursForward);
+        } else {
+          // ...target is forward to the next Friday
+          var daysForward = 5 - now.getDay();
+          if(daysForward < 1) {
+            daysForward += 7;
+          }
+
+          target = new Date(now.getFullYear(), now.getMonth(), now.getDate() + daysForward, 15);
+        }
+
+        // Now compute the time difference between now and
+        // the target, so we know when to send up the notification.
+        var delay = target.getTime() - now.getTime();
+        setTimeout(issueNotification, delay);
+      };
+
+      var issueNotification = function() {
+        new Notification('Tock Your Time!', {
+          body: 'Don\'t forget to Tock your time before COB!',
+          requireInteraction: true,
+          icon: '/static/img/favicon.ico'
+        });
+
+        // Setup the next notification, but wait a few seconds to
+        // make sure the hour has rolled over.
+        setTimeout(setTimer, 10000);
+      };
+
+      setTimer();
+    });
+  }
+})();

--- a/tock/tock/templates/base.html
+++ b/tock/tock/templates/base.html
@@ -22,6 +22,7 @@
     <script src="{% static 'js/vendor/datalib.min.js' %}"></script>
     <script src="{% static 'js/vendor/document-register-element.js' %}"></script>
     <script src="{% static 'js/components/utilization-chart.js' %}"></script>
+    <script src="{% static 'js/components/notifications.js' %}"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.7.0/underscore-min.js" ></script>
 


### PR DESCRIPTION
## Description

Pop-up a browser notification in browsers that support it, at 3pm local time on Fridays.  Useful for people who leave Tock open all the time.

## Additional information

![screen shot 2017-08-04 at 3 00 07 pm](https://user-images.githubusercontent.com/1775733/28985083-868e2ee8-7926-11e7-8e2c-76d70591be98.png)

* The notification is currently flagged with `requireInteraction`, which means it requires the user to click to dismiss it.  I enabled that because it's my personal preference, but I recognize it might be more universally preferred for it to just go away on its own after a few seconds (whatever the browser does by default).

* Doesn't take into account folks on alternate work schedules