### PR TITLE
Add CircleCI support.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       # documented at https://circleci.com/docs/2.0/circleci-images/
       - image: circleci/postgres:9.5
         environment:
-          - POSTGRES_USER=postgres
+          - POSTGRES_USER=circleci
           - POSTGRES_DB=tock-test
 
     working_directory: ~/repo
@@ -25,17 +25,21 @@ jobs:
     steps:
       - checkout
 
+      - run:
+          name: install nodejs
+          command: |
+            sudo apt-get update && curl -sL https://deb.nodesource.com/setup_6.x | sudo bash - && sudo apt-get install -y nodejs
+
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+          - v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}-{{ checksum "package.json" }}
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
       - run:
           name: install dependencies
           command: |
-            sudo apt-get update && curl -sL https://deb.nodesource.com/setup_6.x | sudo bash - && sudo apt-get install -y nodejs
             python3 -m venv venv
             . venv/bin/activate
             pip install codecov
@@ -45,7 +49,8 @@ jobs:
       - save_cache:
           paths:
             - ./venv
-          key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+            - ./node_modules
+          key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}-{{ checksum "package.json" }}
         
       # run tests!
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,64 @@
+# Python CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-python/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
+      - image: circleci/python:3.5.3
+        environment:
+          - TZ=America/New_York
+      
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      - image: circleci/postgres:9.5
+        environment:
+          - POSTGRES_USER=postgres
+          - POSTGRES_DB=tock-test
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run:
+          name: install dependencies
+          command: |
+            sudo apt-get update && curl -sL https://deb.nodesource.com/setup_6.x | sudo bash - && sudo apt-get install -y nodejs
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install codecov
+            pip install -r requirements.txt -r requirements-dev.txt
+            npm install
+
+      - save_cache:
+          paths:
+            - ./venv
+          key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+        
+      # run tests!
+      - run:
+          name: run tests
+          command: |
+            . venv/bin/activate
+            npm run build-css
+            cd tock
+            python manage.py migrate --noinput --settings=tock.settings.test
+            python manage.py test --noinput --settings=tock.settings.test
+            codecov
+
+      - store_artifacts:
+          path: test-reports
+          destination: test-reports
+          


### PR DESCRIPTION
This adds support for running continuous integration on Tock via CircleCI (instead of Travis, which 18F will be dropping support for in coming months).

I've forked this repo to my personal account and you can see it running here: https://circleci.com/gh/toolness/tock/2
