### PR TITLE
Add a stop gap for checking the FLOAT API key

### DIFF
--- a/tock/tock/utils.py
+++ b/tock/tock/utils.py
@@ -44,7 +44,7 @@ class IsSuperUserOrSelf(BasePermission):
 
 def is_running_test_suite():
     return (os.path.basename(sys.argv[0]) == 'manage.py' and
-            len(sys.argv) > 1 and sys.argv[1] == 'test')
+            len(sys.argv) > 1 and sys.argv[1] == 'test') or base.FLOAT_API_KEY == ''
 
 def get_float_data(endpoint, params=None):
     """Fetch Float data from given endpoint with given params. Different request


### PR DESCRIPTION
This changeset alleviates an immediate issue with not being able to debug/test Tock locally without a Float API key.  This is not quite an ideal fix, but it addresses an immediate need until more time can be spent shoring this up a bit.