### PR TITLE
Disable searching for project categories

### DIFF
--- a/tock/tock/templates/hours/timecard_form.html
+++ b/tock/tock/templates/hours/timecard_form.html
@@ -203,7 +203,8 @@
 
 $( document ).ready(function() {
     var chosenOptions = {
-      search_contains: true
+      search_contains: true,
+      group_search: false
     };
 
     $("#save-timecard").on("click", function() {


### PR DESCRIPTION
Fixes issue #651

This changeset addresses an issue where the project category labels are included in the search for a project.  These categories cannot be selected and cause issues when trying to find a project that contains the same word in its name.

This change is the result of discovering an [undocumented option](https://github.com/harvesthq/chosen/issues/2752) with the [Chosen](https://harvesthq.github.io/chosen/) utility (specifically, [this one](https://github.com/harvesthq/chosen/pull/1343/files#diff-a3162852f1360124c43007c8130261dcR30)) that affects the items searched for in the search box that appears.