### PR TITLE
Handling Float API errors gracefully

### DIFF
--- a/tock/tock/templates/hours/timecard_form.html
+++ b/tock/tock/templates/hours/timecard_form.html
@@ -11,7 +11,7 @@
     </p>
   </div>
 </div>
-{% if float_data %}
+{% if float_data is not None %}
   <div class="usa-alert usa-alert-error">
     <div class="usa-alert-body">
       <p class="usa-alert-text">
@@ -28,7 +28,13 @@
            {% if i.task_name %}
             assigned to {{ i.task_name }}
            {% endif %}
-        </li>
+         </li>
+        {% empty %}
+         <li>We're sorry, there was an error retrieving your data from Float.
+            <strong><a href="https://18f.float.com/">Please visit Float directly to see your information</a></strong> while the Tock admins work to resolve this.  Thank you for your patience!
+         </li>
+         <li>You can also <strong><a href="http://status.float.com/">check the Float service Status page</a></strong> if you're curious to see if there might be an outage.
+         </li>
         {% endfor %}
       </ul>
     </div>

--- a/tock/tock/utils.py
+++ b/tock/tock/utils.py
@@ -1,4 +1,5 @@
 import functools
+import logging
 import os
 import sys
 
@@ -10,8 +11,9 @@ from rest_framework.permissions import BasePermission
 
 from tock.settings import base
 
-class PermissionMixin(object):
+logger = logging.getLogger(__name__)
 
+class PermissionMixin(object):
     @classmethod
     def as_view(cls, **initkwargs):
         view = super(PermissionMixin, cls).as_view(**initkwargs)
@@ -52,7 +54,7 @@ def get_float_data(endpoint, params=None):
 
     # If testing, get mock response.
     if is_running_test_suite():
-        print('Fetching data from mock Float API server via {}...'.format(url))
+        logger.info('Fetching data from mock Float API server via {}...'.format(url))
 
         def get_mock_content(path_to_content):
             with open(path_to_content) as infile:
@@ -88,7 +90,7 @@ def get_float_data(endpoint, params=None):
 
     # Otherwise get real data from Float API.
     else:
-        print('Fetching data from real Float API server via {}...'.format(url))
+        logger.info('Fetching data from real Float API server via {}...'.format(url))
         r = requests.get(
             url=url,
             headers=base.FLOAT_API_HEADER,
@@ -99,7 +101,7 @@ def get_float_data(endpoint, params=None):
     if r.status_code == 200:
         return r
     else:
-        print('Failed call to Float with {}. Response:\n\n{}'.format(
+        logger.error('Failed call to Float with {}. Response:\n\n{}'.format(
             r.url, r.content))
         return None
 


### PR DESCRIPTION
Fixes issue #669 

This changeset provides much more robust error handling for the Float API calls and more graceful handling of them so that users can still see and enter their timecards.  If an error occurs while accessing Float data, the user is presented with a message saying so and the error is logged behind the scenes so we can see what went wrong and why.  We currently only see a stack trace saying that we cannot call a method on a NoneType object.

There's more to be done here for the future, but at this point we just need to make sure the timecards always work regardless of whether or not retrieving the Float data does and, in the case of such errors, where the breakdown actually happened and why.