### PR TITLE
Shut off New Relic High Security

### DIFF
--- a/newrelic.ini
+++ b/newrelic.ini
@@ -83,7 +83,7 @@ ssl = true
 # configuration file AND be set to 'true' in the server-side
 # configuration in the New Relic user interface. For details, see
 # https://docs.newrelic.com/docs/subscriptions/high-security
-high_security = true
+high_security = false
 
 # The Python Agent will attempt to connect directly to the New
 # Relic service. If there is an intermediate firewall between


### PR DESCRIPTION
Tock does not currently have priveleges for high security in New Relic, so we are turning it off for the time being.