### PR TITLE
Enable FY18-only reports

### DIFF
--- a/tock/tock/templates/hours/reports_list.html
+++ b/tock/tock/templates/hours/reports_list.html
@@ -10,22 +10,27 @@
 		<li>Complete timecard data:
 			<a href="{% url 'reports:BulkTimecardList' %}">All</a>
 			<a href="{% url 'reports:BulkTimecardList' %}?after=2016-10-02">FY2017</a>
+            <a href="{% url 'reports:BulkTimecardList' %}?after=2017-10-01">FY2018</a>
 		</li>
 		<li>Complete timecard data with fewer fields:
 			<a href="{% url 'reports:SlimBulkTimecardList' %}">All</a>
 			<a href="{% url 'reports:SlimBulkTimecardList' %}?after=2016-10-02">FY2017</a>
+            <a href="{% url 'reports:SlimBulkTimecardList' %}?after=2017-10-01">FY2018</a>
 		</li>
 		<li>Complete snippet data for 'General':
 				<a href="{% url 'reports:GeneralSnippetsView' %}">All</a>
 				<a href="{% url 'reports:GeneralSnippetsView' %}?after=2016-10-02">FY2017</a>
+                <a href="{% url 'reports:GeneralSnippetsView' %}?after=2017-10-01">FY2018</a>
 		</li>
 		<li>Aggregate hourly data by project and reporting period:
 			<a href="{% url 'reports:ProjectTimelineView' %}">All</a>
 			<a href="{% url 'reports:ProjectTimelineView' %}?after=2016-10-02">FY2017</a>
+            <a href="{% url 'reports:ProjectTimelineView' %}?after=2017-10-01">FY2018</a>
 		</li>
 		<li>Aggregate hourly data by user, reporting period, and project billable status:
 			<a href="{% url 'reports:UserTimelineView' %}">All</a>
 			<a href="{% url 'reports:UserTimelineView' %}?after=2016-10-02">FY2017</a>
+            <a href="{% url 'reports:UserTimelineView' %}?after=2017-10-01">FY2018</a>
 		</li>
 		<li><a href="{% url 'reports:ProjectList' %}">Download list of all projects</a></li>
 		<li><a href="{% url 'reports:UserDataView' %}">Download list of all users</a></li>
@@ -38,7 +43,8 @@
     <h2 class="usa-alert-heading">Superuser Reports</h2>
     <p class="usa-alert-text">Complete timecard data with grade info:<br>
 				<a href="{% url 'reports:AdminBulkTimecardList' %}">All</a>
-				<a href="{% url 'reports:AdminBulkTimecardList' %}?after=2016-10-01">FY2017</a></p>
+				<a href="{% url 'reports:AdminBulkTimecardList' %}?after=2016-10-01">FY2017</a>
+                <a href="{% url 'reports:AdminBulkTimecardList' %}?after=2017-10-01">FY2018</a></p>
   </div>
 </div>
 


### PR DESCRIPTION
This changeset adds links to make FY18 data as a standalone.  Note that a more in-depth fix will need to be made to ensure that things like the FY17 reports contain just FY17 data as right now they will still pull in FY18 data as well.