### PR TITLE
Fix ID mismatch with label element

### DIFF
--- a/tock/tock/templates/hours/timecard_form.html
+++ b/tock/tock/templates/hours/timecard_form.html
@@ -300,15 +300,22 @@ $( document ).ready(function() {
           nextNumber % 2 == 0 ? entry.addClass('even').removeClass('odd') :
             entry.addClass('odd').removeClass('even');
 
-          entry.find('input, select, textarea').each(function(i) {
+          entry.find('input, select, textarea, label').each(function(i) {
             var formItem = $(this);
-            var formerID = formItem.attr('id');
-            var nextID = formerID.replace(previousNumber, nextNumber);
-            formItem.attr('id', nextID);
 
-            var formerName = formItem.attr('name');
-            var nextName = formerName.replace(previousNumber, nextNumber);
-            formItem.attr('name', nextName);
+            if (formItem[0].tagName.toLowerCase() !== 'label') {
+                var formerID = formItem.attr('id');
+                var nextID = formerID.replace(previousNumber, nextNumber);
+                formItem.attr('id', nextID);
+
+                var formerName = formItem.attr('name');
+                var nextName = formerName.replace(previousNumber, nextNumber);
+                formItem.attr('name', nextName);
+            } else {
+                var formerFor = formItem.attr('for');
+                var nextFor = formerFor.replace(previousNumber, nextNumber);
+                formItem.attr('for', nextFor);
+            }
           });
         }).appendTo('.entries');
 


### PR DESCRIPTION
Fixes #685

This changeset fixes an issue with the `label` element associated with the delete checkboxes, specifically when adding a new item.  The new items were not properly updating the `for` attribute in the `label` associated with the delete checkbox.

h/t to @hbillings for flagging this!