### PR TITLE
Fixes server errors when trying to access non-existent reporting periods

### DIFF
--- a/tock/hours/tests/test_views.py
+++ b/tock/hours/tests/test_views.py
@@ -4,7 +4,6 @@ import requests
 import json
 
 from django.core.urlresolvers import reverse
-from django.http import Http404
 from django.test import TestCase, RequestFactory
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import User

--- a/tock/hours/tests/test_views.py
+++ b/tock/hours/tests/test_views.py
@@ -4,6 +4,7 @@ import requests
 import json
 
 from django.core.urlresolvers import reverse
+from django.http import Http404
 from django.test import TestCase, RequestFactory
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import User
@@ -738,14 +739,14 @@ class ReportTests(WebTest):
         """
         date = datetime.date(2017, 10, 1)
 
-        response = self.app.get(
-            reverse(
-                'reportingperiod:UpdateTimesheet',
-                kwargs={'reporting_period': date}
-            ),
-            headers={'X_AUTH_USER': self.regular_user.email},
-        )
-        self.assertEqual(response.status_code, 404)
+        with self.assertRaises(Http404):
+            response = self.app.get(
+                reverse(
+                    'reportingperiod:UpdateTimesheet',
+                    kwargs={'reporting_period': date}
+                ),
+                headers={'X_AUTH_USER': self.regular_user.email},
+            )
 
     def test_holiday_prefill(self):
         """Tests when a holiday is related to a reporting period that it is

--- a/tock/hours/tests/test_views.py
+++ b/tock/hours/tests/test_views.py
@@ -732,6 +732,21 @@ class ReportTests(WebTest):
         )
         self.assertEqual(response.status_code, 200)
 
+    def test_reportperiod_updatetimesheet_no_reportperiod(self):
+        """
+        Tests that a 404 is returned when a reporting period is not found.
+        """
+        date = datetime.date(2017, 10, 1)
+
+        response = self.app.get(
+            reverse(
+                'reportingperiod:UpdateTimesheet',
+                kwargs={'reporting_period': date}
+            ),
+            headers={'X_AUTH_USER': self.regular_user.email},
+        )
+        self.assertEqual(response.status_code, 404)
+
     def test_holiday_prefill(self):
         """Tests when a holiday is related to a reporting period that it is
         contained in the timecard formset."""

--- a/tock/hours/tests/test_views.py
+++ b/tock/hours/tests/test_views.py
@@ -739,15 +739,15 @@ class ReportTests(WebTest):
         """
         date = datetime.date(2017, 10, 1)
 
-        with self.assertRaises(Http404):
-            response = self.app.get(
-                reverse(
-                    'reportingperiod:UpdateTimesheet',
-                    kwargs={'reporting_period': date}
-                ),
-                headers={'X_AUTH_USER': self.regular_user.email},
-                expect_errors=True
-            )
+        response = self.app.get(
+            reverse(
+                'reportingperiod:UpdateTimesheet',
+                kwargs={'reporting_period': date}
+            ),
+            headers={'X_AUTH_USER': self.regular_user.email},
+            expect_errors=True
+        )
+        self.assertEqual(response.status_code, 404)
 
     def test_holiday_prefill(self):
         """Tests when a holiday is related to a reporting period that it is

--- a/tock/hours/tests/test_views.py
+++ b/tock/hours/tests/test_views.py
@@ -737,7 +737,7 @@ class ReportTests(WebTest):
         """
         Tests that a 404 is raised when a reporting period is not found.
         """
-        date = datetime.date(2017, 10, 1)
+        date = datetime.date(1980, 10, 1)
 
         response = self.app.get(
             reverse(

--- a/tock/hours/tests/test_views.py
+++ b/tock/hours/tests/test_views.py
@@ -735,7 +735,7 @@ class ReportTests(WebTest):
 
     def test_reportperiod_updatetimesheet_no_reportperiod(self):
         """
-        Tests that a 404 is returned when a reporting period is not found.
+        Tests that a 404 is raised when a reporting period is not found.
         """
         date = datetime.date(2017, 10, 1)
 
@@ -746,6 +746,7 @@ class ReportTests(WebTest):
                     kwargs={'reporting_period': date}
                 ),
                 headers={'X_AUTH_USER': self.regular_user.email},
+                expect_errors=True
             )
 
     def test_holiday_prefill(self):


### PR DESCRIPTION
Fixes #692

This changeset adds a bit of extra error handling when trying to access timecards that are associated with reporting periods that do not exist, e.g., trying to fill out a future timecard that has not been officially opened yet.

h/t to @jmcarp and @tbaxter-18f for reporting this issue!