### PR TITLE
Add helper methods for filtering projects

### DIFF
--- a/tock/hours/tests/test_models.py
+++ b/tock/hours/tests/test_models.py
@@ -338,3 +338,44 @@ class TimecardObjectTests(TestCase):
         )
 
         self.assertFalse(tco.grade)
+
+
+class ProjectTests(TestCase):
+    fixtures = [
+        'projects/fixtures/projects.json',
+    ]
+
+    def setUp(self):
+        self.project_1 = Project.objects.get(name='openFEC')
+        self.project_2 = Project.objects.get(name='Peace Corps')
+
+        self.project_1.active = False
+        self.project_2.active = False
+
+        self.project_1.save()
+        self.project_2.save()
+
+    def test_active_projects_model_manager(self):
+        """Test that only active projects are returned by the active() model
+        manager method."""
+
+        projects = list(Project.objects.active())
+        project_count = len(projects)
+        total_project_count = Project.objects.count()
+
+        self.assertNotIn(self.project_1, projects)
+        self.assertNotIn(self.project_2, projects)
+        self.assertEqual(project_count, total_project_count - 2)
+
+    def test_inactive_projects_model_manager(self):
+        """Test that only active projects are returned by the active() model
+        manager method."""
+
+        projects = list(Project.objects.inactive())
+        project_count = len(projects)
+        total_project_count = Project.objects.count()
+
+        self.assertIn(self.project_1, projects)
+        self.assertIn(self.project_2, projects)
+        self.assertEqual(project_count, 2)
+        self.assertNotEqual(project_count, total_project_count)

--- a/tock/projects/models.py
+++ b/tock/projects/models.py
@@ -177,6 +177,9 @@ class ProjectManager(models.Manager):
     Also, not to be confused with a human in a similarly named role. :-)
     """
 
+    def get_queryset(self):
+        return super().get_queryset().order_by('name')
+
     def active(self):
         return self.get_queryset().filter(active=True)
 

--- a/tock/projects/models.py
+++ b/tock/projects/models.py
@@ -170,6 +170,20 @@ class ProfitLossAccount(models.Model):
             end_date
         )
 
+
+class ProjectManager(models.Manager):
+    """Provides convenience methods for filtering Project models.
+
+    Also, not to be confused with a human in a similarly named role. :-)
+    """
+
+    def active(self):
+        return self.get_queryset().filter(active=True)
+
+    def inactive(self):
+        return self.get_queryset().filter(active=False)
+
+
 class Project(models.Model):
     """ Stores information about a specific project"""
     name = models.CharField(max_length=200)
@@ -200,6 +214,8 @@ class Project(models.Model):
         verbose_name='Profit/loss Accounting String'
     )
     project_lead = models.ForeignKey(User, null=True)
+
+    objects = ProjectManager()
 
     class Meta:
         verbose_name = "Project"


### PR DESCRIPTION
Addresses #688

This changeset adds a `ProjectManager` model manager (not a human being...) for the `Project` model that provides a couple of convenience methods for easily retrieving all active and inactive projects.  The Project admin page already has the filtering exposed for inactive and active projects, but this will be needed when we start adding support to pre-populate time cards and only want to work through a list of active projects.