### PR TITLE
Add handbook page link and update Python to 3.6.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     docker:
       # specify the version you desire here
       # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
-      - image: circleci/python:3.6.3-jessie-node-browsers
+      - image: circleci/python:3.6.4-jessie-node-browsers
         environment:
           - TZ=America/New_York
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tock
 
-We use Tock to track our time. You can read more about Tock in this [blog post](https://18f.gsa.gov/2015/05/21/tockingtime/) about its features.
+We use Tock to track our time. You can read more about Tock in this [blog post](https://18f.gsa.gov/2015/05/21/tockingtime/) about its features and the [handbook page](https://handbook.18f.gov/tock/) for guidance and instructions.
 
 [![CircleCI](https://circleci.com/gh/18F/tock.svg?style=svg)](https://circleci.com/gh/18F/tock)
 

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.3
+python-3.6.4

--- a/tock/tock/templates/hours/timecard_form.html
+++ b/tock/tock/templates/hours/timecard_form.html
@@ -28,6 +28,14 @@
   </div>
 {% endfor %}
 
+<div class="usa-alert usa-alert-info">
+  <div class="usa-alert-body">
+    <p class="usa-alert-text">
+      For additional help and guidance with using Tock and entering hours, please consult the <a href="https://handbook.18f.gov/tock/">TTS Handbook page on Tock</a>.
+    </p>
+  </div>
+</div>
+
 <form method="post">
   {% csrf_token %}
   {{ formset.management_form }}


### PR DESCRIPTION
Part of #687 

This changeset adds a link to the [Tock handbook page](https://handbook.18f.gov/tock/) in the README and the timecard form itself.  In the case of the timecard form, it is a hardcoded info message that will appear below every other message to ensure that important and especially critical things are not missed:

<img width="1085" alt="screen shot 2018-01-22 at 9 55 35 am" src="https://user-images.githubusercontent.com/121565/35227199-6624e21c-ff5b-11e7-98ff-bdf67af4202c.png">

CircleCI and cloud.gov have recently updated their container/buildpack versions as well, which means we can use Python 3.6.4.  This changeset accounts for that as well.