### PR TITLE
Revert Python version for CF buildpack

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.4
+python-3.6.3


### PR DESCRIPTION
It turns out that the latest Python buildpack for Cloud Foundry is not deployed in cloud.gov just yet, so we need to go back one patch level version for Python.