### PR TITLE
[wip] Reduce multiple migrations on deployments

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: cd tock && python manage.py migrate --settings=tock.settings.production --noinput && python manage.py collectstatic --settings=tock.settings.production --noinput && gunicorn -k gevent -w 2 tock.wsgi:application
+web: bin/run.sh

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -3,7 +3,7 @@
 set -o errexit
 set -o pipefail
 
-cd ../tock
+cd tock
 python manage.py migrate --settings=tock.settings.production --noinput
 python manage.py collectstatic --settings=tock.settings.production --noinput
 gunicorn -k gevent -w 2 tock.wsgi:application

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,0 +1,9 @@
+#/bin/sh
+
+set -o errexit
+set -o pipefail
+
+cd ../tock
+python manage.py migrate --settings=tock.settings.production --noinput
+python manage.py collectstatic --settings=tock.settings.production --noinput
+gunicorn -k gevent -w 2 tock.wsgi:application


### PR DESCRIPTION
Running into this when deploying the latest work from the Jingle Sprint. The migrations are running for each instance type, and we don't want that as migrations should only run once.

 ## Acceptance Criteria

- [ ] Push a multi-instance version of Tock to staging and see the migrations only running once.
- [ ] Migrations only run on the zeroth instance.
- [ ] Migrations that take a long time (longer than three minutes) are run as tasks and this is documented.