### PR TITLE
Update timeout for gunicorn

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: cd tock && python manage.py migrate --settings=tock.settings.production --noinput && python manage.py collectstatic --settings=tock.settings.production --noinput && gunicorn -k gevent -w 2 tock.wsgi:application
+web: cd tock && python manage.py migrate --settings=tock.settings.production --noinput && python manage.py collectstatic --settings=tock.settings.production --noinput && gunicorn -t 120 -k gevent -w 2 tock.wsgi:application

--- a/manifest.yml
+++ b/manifest.yml
@@ -2,6 +2,9 @@
 applications:
 - name: tock
   instances: 4
+  routes:
+  - route: tock.18f.gov
+  - route: tock.18f.gov/api
 buildpack: python_buildpack
 env:
   NEW_RELIC_APP_NAME: Tock (Production)


### PR DESCRIPTION
This timeout is arbitrarily set at two minutes to allow for long API requests for timecard data that may take longer than 30 seconds. 30 seconds was the default coming from gunicorn after #708

## Acceptance criteria.

- [x] Allow for pulling timecard data that takes longer than 30s to process. https://gsa-tts.slack.com/archives/C1JFYCX3P/p1516811227001124?thread_ts=1516808162.000966&cid=C1JFYCX3P