### PR TITLE
Add link to latest release in footer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,10 @@ workflows:
               only: /.*/
   build_and_deploy_staging:
     jobs:
-      - build
+      - build:
+          filters:
+            branches:
+              only: master
       - deploy_to_staging:
           requires:
             - build

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -132,6 +132,15 @@ Now, if you don't already have the autopilot plugin, you can install it by runni
 cf install-plugin autopilot -f -r CF-Community
 ```
 
+Open the `manifest-production.yml` file and add a `CIRCLE_TAG` value under
+`env:` which matches the release that you're manually deploying to production.
+
+```yaml
+env:
+  # other variables
+  CIRCLE_TAG: v20180202.1
+```
+
 Then use the autopilot plugin's `zero-downtime-push` command to deploy:
 
 ```sh

--- a/tock/tock/context_processors.py
+++ b/tock/tock/context_processors.py
@@ -6,8 +6,8 @@ def version_url(request):
     base_url = 'https://github.com/18F/tock/'
     name = settings.VERSION
     response = {
-        'release_url': '%stree/%s' % (base_url, name),
-        'release_name': settings.VERSION,
+        'x_tock_release_url': '%stree/%s' % (base_url, name),
+        'x_tock_release_name': name,
     }
     if re.match('/v20[1-9][0-9][0-9]+\.[0-9]+/', name):
         response['release_url'] = '%sreleases/tag/%s' % (base_url, name)

--- a/tock/tock/context_processors.py
+++ b/tock/tock/context_processors.py
@@ -1,0 +1,13 @@
+def version_url(request):
+    import re
+    from django.conf import settings
+    base_url = 'https://github.com/18F/tock/'
+    name = settings.VERSION
+    response = {
+        'release_url': '%stree/%s' % (base_url, name),
+        'release_name': settings.VERSION,
+    }
+    if re.match('/v20[1-9][0-9][0-9]+\.[0-9]+/', name):
+        response['release_url'] = '%sreleases/tag/%s' % (base_url, name)
+
+    return response

--- a/tock/tock/context_processors.py
+++ b/tock/tock/context_processors.py
@@ -1,6 +1,8 @@
+import re
+from django.conf import settings
+
+
 def version_url(request):
-    import re
-    from django.conf import settings
     base_url = 'https://github.com/18F/tock/'
     name = settings.VERSION
     response = {

--- a/tock/tock/context_processors.py
+++ b/tock/tock/context_processors.py
@@ -9,6 +9,9 @@ def version_url(request):
         'x_tock_release_url': '%stree/%s' % (base_url, name),
         'x_tock_release_name': name,
     }
+
+    # Regular expression here matches the regular expression found in
+    # .circleci/config.yml for filtering on tags for Production deployments
     if re.match('/v20[1-9][0-9][0-9]+\.[0-9]+/', name):
         response['release_url'] = '%sreleases/tag/%s' % (base_url, name)
 

--- a/tock/tock/settings/base.py
+++ b/tock/tock/settings/base.py
@@ -55,6 +55,7 @@ TEMPLATES =  [
                 'django.template.context_processors.tz',
                 'django.contrib.messages.context_processors.messages',
                 'django.template.context_processors.request',
+                'tock.context_processors.version_url',
             ],
         },
     },
@@ -104,3 +105,5 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.TokenAuthentication',
     ),
 }
+
+VERSION = env.get_credential('CIRCLE_TAG', 'master')

--- a/tock/tock/templates/base.html
+++ b/tock/tock/templates/base.html
@@ -121,5 +121,9 @@ m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
       {% block js %}
       {% endblock js %}
 <div>
+  <footer>
+    <p><i>The current release is <code>{{ release_name }}</code>, <a href="{{ release_url }}" title="{{ release_url }}">view this release on GitHub</a></i>.</p>
+  </footer>
+
   </body>
 </html>

--- a/tock/tock/templates/base.html
+++ b/tock/tock/templates/base.html
@@ -120,7 +120,7 @@ m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
       {% endblock %}
       {% block js %}
       {% endblock js %}
-<div>
+</div>
   <footer>
     <p><i>The current release is <code>{{ x_tock_release_name }}</code>, <a href="{{ x_tock_release_url }}" title="{{ x_tock_release_name }}">view this release on GitHub</a></i>.</p>
   </footer>

--- a/tock/tock/templates/base.html
+++ b/tock/tock/templates/base.html
@@ -122,7 +122,7 @@ m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
       {% endblock js %}
 <div>
   <footer>
-    <p><i>The current release is <code>{{ release_name }}</code>, <a href="{{ release_url }}" title="{{ release_url }}">view this release on GitHub</a></i>.</p>
+    <p><i>The current release is <code>{{ x_tock_release_name }}</code>, <a href="{{ x_tock_release_url }}" title="{{ x_tock_release_name }}">view this release on GitHub</a></i>.</p>
   </footer>
 
   </body>


### PR DESCRIPTION
## Description

Helpful after #652 and #712 to show what version is currently deployed to staging and production. 

## Acceptance criteria 

* Check the footer for a link to the mainline branch if on staging 
* Check the footer for a link to a GitHub release if on production 
