### PR TITLE
Fix non-API hours and utilization view tests.

### DIFF
--- a/tock/hours/tests/test_views.py
+++ b/tock/hours/tests/test_views.py
@@ -48,14 +48,14 @@ class DashboardReportsListTests(WebTest):
     def test_response_ok(self):
         response = self.app.get(
             reverse('reports:DashboardReportsList'),
-            headers={'X_AUTH_USER': self.user.email},
+            user=self.user,
         )
         self.assertEqual(response.status_code, 200)
 
     def test_template_render(self):
         response = self.app.get(
             reverse('reports:DashboardReportsList'),
-            headers={'X_AUTH_USER': self.user.email},
+            user=self.user,
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -151,7 +151,7 @@ class DashboardViewTests(WebTest):
                 'reports:DashboardView',
                 kwargs={'reporting_period':'1999-12-31'}
             ),
-            headers={'X_AUTH_USER': self.user.email},
+            user=self.user,
         )
         self.assertEqual(response.status_code, 200)
 
@@ -162,7 +162,7 @@ class DashboardViewTests(WebTest):
                 kwargs={'reporting_period':'1999-12-31'}
             ),
             {'unit':'1'},
-            headers={'X_AUTH_USER': self.user.email},
+            user=self.user,
         )
         self.assertEqual(response.status_code, 200)
 
@@ -173,7 +173,7 @@ class DashboardViewTests(WebTest):
                 'reports:DashboardView',
                 kwargs={'reporting_period': date}
             ),
-            headers={'X_AUTH_USER': self.user.email},
+            user=self.user,
         )
         self.assertNotContains(response, '<td>$-2 (-100.00%)</td>')
 
@@ -189,7 +189,7 @@ class DashboardViewTests(WebTest):
                 'reports:DashboardView',
                 kwargs={'reporting_period': date}
             ),
-            headers={'X_AUTH_USER': self.user.email},
+            user=self.user,
         )
         self.assertContains(response, '<td data-title="Variance">$-2 (-100.00%)</td>')
 
@@ -201,7 +201,7 @@ class DashboardViewTests(WebTest):
                 'reports:DashboardView',
                 kwargs={'reporting_period':'1999-12-31'}
             ),
-            headers={'X_AUTH_USER': self.user.email},
+            user=self.user,
         )
         self.assertContains(response, 'Whoops!')
         self.assertContains(response, '1999-12-31')
@@ -219,7 +219,7 @@ class DashboardViewTests(WebTest):
                 'reports:DashboardView',
                 kwargs={'reporting_period': date}
             ),
-            headers={'X_AUTH_USER': self.user.email},
+            user=self.user,
         )
         self.assertContains(response, 'Whoops')
         self.assertContains(response, date)
@@ -234,7 +234,7 @@ class DashboardViewTests(WebTest):
                 kwargs={'reporting_period': date}
             ),
             {'unit':'13'},
-            headers={'X_AUTH_USER': self.user.email},
+            user=self.user,
         )
         self.assertEqual(
             response.context['units'],
@@ -250,7 +250,7 @@ class DashboardViewTests(WebTest):
                 kwargs={'reporting_period': date}
             ),
             {'unit':'1'},
-            headers={'X_AUTH_USER': self.user.email},
+            user=self.user,
         )
         self.assertEqual(
             response.context['variance_rev_cr_weekly'],
@@ -263,7 +263,7 @@ class DashboardViewTests(WebTest):
                 'reports:DashboardView',
                 kwargs={'reporting_period': date}
             ),
-            headers={'X_AUTH_USER': self.user.email},
+            user=self.user,
         )
         self.assertContains(
             response, '<td data-title="FYTD Performance">$4,500</td>')
@@ -282,7 +282,7 @@ class DashboardViewTests(WebTest):
                 'reports:DashboardView',
                 kwargs={'reporting_period': date}
             ),
-            headers={'X_AUTH_USER': self.user.email},
+            user=self.user,
         )
         self.assertContains(
             response, '<td data-title="Variance">$-2 (-100.00%)</td>')
@@ -297,7 +297,7 @@ class DashboardViewTests(WebTest):
                 kwargs={'reporting_period': date}
             ),
             {'unit':'1'},
-            headers={'X_AUTH_USER': self.user.email},
+            user=self.user,
         )
         self.assertContains(
             response,
@@ -311,7 +311,7 @@ class DashboardViewTests(WebTest):
                 kwargs={'reporting_period': date}
             ),
             {'unit':'13'},
-            headers={'X_AUTH_USER': self.user.email},
+            user=self.user,
         )
         self.assertContains(
             response,
@@ -328,7 +328,7 @@ class DashboardViewTests(WebTest):
                 'reports:DashboardView',
                 kwargs={'reporting_period': date}
             ),
-            headers={'X_AUTH_USER': self.user.email},
+            user=self.user,
         )
 
         self.assertContains(response, '18F Operations Dashboard')
@@ -594,7 +594,7 @@ class ReportTests(WebTest):
             start_date=datetime.date(2016, 1, 1),
             end_date=datetime.date(2016, 1, 7),
             exact_working_hours=40)
-        response = self.app.get(reverse('reports:ListReports'))
+        response = self.app.get(reverse('reports:ListReports'), user=self.user)
         response = response.content.decode('utf-8')
         self.assertTrue(response.index('2016') < response.index('2015'))
 
@@ -603,7 +603,7 @@ class ReportTests(WebTest):
         user with with userdata """
         response = self.app.get(
             reverse('ListReportingPeriods'),
-            headers={'X_AUTH_USER': self.regular_user.email},
+            user=self.regular_user,
         )
         self.assertEqual(response.status_code, 200)
 
@@ -613,7 +613,7 @@ class ReportTests(WebTest):
         existing_rps = hours.models.ReportingPeriod.objects.all()
         self.app.get(
             reverse('ListReportingPeriods'),
-            headers={'X_AUTH_USER': self.regular_user.email},
+            user=self.regular_user,
         )
         new_rps = hours.models.ReportingPeriod.objects.all()
         self.assertNotEqual(existing_rps, new_rps)
@@ -637,7 +637,7 @@ class ReportTests(WebTest):
         existing_rps = hours.models.ReportingPeriod.objects.all()
         self.app.get(
             reverse('ListReportingPeriods'),
-            headers={'X_AUTH_USER': self.regular_user.email},
+            user=self.regular_user,
         )
         new_rps = hours.models.ReportingPeriod.objects.all()
         self.assertEqual(len(existing_rps), len(new_rps))
@@ -654,7 +654,7 @@ class ReportTests(WebTest):
             self.reporting_period.save()
             self.app.get(
                 reverse('ListReportingPeriods'),
-                headers={'X_AUTH_USER': self.regular_user.email},
+                user=self.regular_user,
             )
             ct_new_rps = len(hours.models.ReportingPeriod.objects.all())
             self.assertNotEqual(ct_existing_rps, ct_new_rps)
@@ -671,7 +671,7 @@ class ReportTests(WebTest):
             self.reporting_period.save()
             self.app.get(
                 reverse('ListReportingPeriods'),
-                headers={'X_AUTH_USER': self.regular_user.email},
+                user=self.regular_user,
             )
             ct_new_rps = len(hours.models.ReportingPeriod.objects.all())
             self.assertEqual(ct_existing_rps, ct_new_rps)
@@ -687,7 +687,7 @@ class ReportTests(WebTest):
             self.reporting_period.save()
             self.app.get(
                 reverse('ListReportingPeriods'),
-                headers={'X_AUTH_USER': self.regular_user.email},
+                user=self.regular_user,
             )
             ct_new_rps = len(hours.models.ReportingPeriod.objects.all())
             self.assertNotEqual(ct_existing_rps, ct_new_rps)
@@ -702,7 +702,7 @@ class ReportTests(WebTest):
         self.reporting_period.save()
         self.app.get(
             reverse('ListReportingPeriods'),
-            headers={'X_AUTH_USER': self.regular_user.email},
+            user=self.regular_user,
         )
         ct_new_rps = len(hours.models.ReportingPeriod.objects.all())
         self.assertEqual(ct_existing_rps, ct_new_rps)
@@ -713,7 +713,7 @@ class ReportTests(WebTest):
         self.reporting_period.delete()
         self.app.get(
             reverse('ListReportingPeriods'),
-            headers={'X_AUTH_USER': self.regular_user.email},
+            user=self.regular_user,
         )
         self.assertIsNotNone(hours.models.ReportingPeriod.objects.all())
 
@@ -727,7 +727,7 @@ class ReportTests(WebTest):
                 'reportingperiod:UpdateTimesheet',
                 kwargs={'reporting_period': date}
             ),
-            headers={'X_AUTH_USER': self.regular_user.email},
+            user=self.regular_user,
         )
         self.assertEqual(response.status_code, 200)
 
@@ -742,7 +742,7 @@ class ReportTests(WebTest):
                 'reportingperiod:UpdateTimesheet',
                 kwargs={'reporting_period': date}
             ),
-            headers={'X_AUTH_USER': self.regular_user.email},
+            user=self.regular_user,
             expect_errors=True
         )
         self.assertEqual(response.status_code, 404)
@@ -773,7 +773,7 @@ class ReportTests(WebTest):
                 'reportingperiod:UpdateTimesheet',
                 kwargs={'reporting_period': '2016-01-01'}
             ),
-            headers={'X_AUTH_USER': self.user.email},
+            user=self.user,
         )
 
         # Checks response context for the prefilled project and hours.
@@ -804,7 +804,7 @@ class ReportTests(WebTest):
                 'reportingperiod:UpdateTimesheet',
                 kwargs={'reporting_period': '2016-01-01'}
             ),
-            headers={'X_AUTH_USER': self.user.email},
+            user=self.user,
         )
         str_formset = str(response.context['formset']).split('\n')
         for line in str_formset:
@@ -828,7 +828,7 @@ class ReportTests(WebTest):
                 'reportingperiod:UpdateTimesheet',
                 kwargs={'reporting_period': date}
             ),
-            headers={'X_AUTH_USER': self.user.email},
+            user=self.user,
         )
 
         # projects prefilled in the html
@@ -893,7 +893,7 @@ class ReportTests(WebTest):
                 'reportingperiod:UpdateTimesheet',
                 kwargs={'reporting_period': date}
             ),
-            headers={'X_AUTH_USER': self.user.email},
+            user=self.user,
         )
         first_hour_val = response.html \
             .find('div', {'class': 'entry-amount'}) \
@@ -919,7 +919,7 @@ class ReportTests(WebTest):
                 'reportingperiod:UpdateTimesheet',
                 kwargs={'reporting_period': date}
             ),
-            headers={'X_AUTH_USER': self.user.email},
+            user=self.user,
         )
         delete_divs = response.html.find_all('div', {'class': 'entry-delete'})
 
@@ -937,7 +937,7 @@ class ReportTests(WebTest):
                 'reportingperiod:UpdateTimesheet',
                 kwargs={'reporting_period': date}
             ),
-            headers={'X_AUTH_USER': self.user.email},
+            user=self.user,
         )
         delete_divs = response.html.find_all('div', {'class': 'entry-delete'})
 
@@ -963,35 +963,36 @@ class ReportTests(WebTest):
                 'timecardobjects-0-project': '4',
                 'timecardobjects-0-hours_spent': None,
             },
-            headers={'X_AUTH_USER': self.regular_user.email},
+            user=self.regular_user,
         )
         formset = response.context['formset']
         self.assertTrue(formset.save_only)
 
     def test_report_list_not_authenticated(self):
         response = self.app.get(
-            reverse('ListReportingPeriods'), expect_errors=True)
-        self.assertEqual(response.status_code, 403)
+            reverse('ListReportingPeriods'))
+        self.assertRedirects(response, '/auth/login',
+                             fetch_redirect_response=False)
 
     def test_create_reporting_period_superuser(self):
         periods = list(hours.models.ReportingPeriod.objects.all())
         get_res = self.app.get(
             reverse('reportingperiod:ReportingPeriodCreateView'),
-            headers={'X_AUTH_USER': self.user.email},
+            user=self.user,
         )
         form = get_res.forms[0]
         form['start_date'] = '07/04/2015'
         form['end_date'] = '07/11/2015'
         form['min_working_hours'] = '40'
         form['max_working_hours'] = '60'
-        form.submit(headers={'X_AUTH_USER': self.user.email})
+        form.submit(user=self.user)
         updated_periods = list(hours.models.ReportingPeriod.objects.all())
         self.assertTrue(len(updated_periods) == len(periods) + 1)
 
     def test_create_reporting_period_not_superuser(self):
         response = self.app.get(
             reverse('reportingperiod:ReportingPeriodCreateView'),
-            headers={'X_AUTH_USER': self.regular_user.email},
+            user=self.regular_user,
             expect_errors=True,
         )
         self.assertEqual(response.status_code, 403)
@@ -1202,7 +1203,7 @@ class PrefillDataViewTests(WebTest):
                 'reportingperiod:UpdateTimesheet',
                 kwargs={'reporting_period': self.rp_1.start_date}
             ),
-            headers={'X_AUTH_USER': self.user.email},
+            user=self.user,
         )
 
         # Only our prefilled object should appear in this form.
@@ -1231,7 +1232,7 @@ class PrefillDataViewTests(WebTest):
                 'reportingperiod:UpdateTimesheet',
                 kwargs={'reporting_period': self.rp_2.start_date}
             ),
-            headers={'X_AUTH_USER': self.user.email},
+            user=self.user,
         )
 
         # Only our prefilled object should appear in this form.
@@ -1271,7 +1272,7 @@ class PrefillDataViewTests(WebTest):
                 'reportingperiod:UpdateTimesheet',
                 kwargs={'reporting_period': self.rp_2.start_date}
             ),
-            headers={'X_AUTH_USER': self.user.email},
+            user=self.user,
         )
 
         # Only our prefilled object should appear in this form.
@@ -1306,7 +1307,7 @@ class PrefillDataViewTests(WebTest):
                 'reportingperiod:UpdateTimesheet',
                 kwargs={'reporting_period': self.rp_1.start_date}
             ),
-            headers={'X_AUTH_USER': self.user.email},
+            user=self.user,
         )
 
         # Only the existing timecard object should appear in this form; no

--- a/tock/hours/tests/test_views.py
+++ b/tock/hours/tests/test_views.py
@@ -9,7 +9,6 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import User
 from django_webtest import WebTest
 
-from api.tests import client
 from api.views import UserDataSerializer, ProjectSerializer
 from employees.models import UserData
 from hours.utils import number_of_hours
@@ -26,6 +25,19 @@ FIXTURES = [
     'employees/fixtures/user_data.json',
     'organizations/fixtures/organizations.json',
 ]
+
+
+def client(self):
+    # Note that this function was originally brought in from
+    # api.tests, but that client can't authenticate past the
+    # @login_required decorator we're currently using for
+    # this package's API-like views. For more details, see:
+    #
+    # https://github.com/18F/tock/pull/726
+    user = User.objects.get_or_create(username='aaron.snow')[0]
+    self.client.force_login(user)
+    return self.client
+
 
 def decode_streaming_csv(response, **reader_options):
     lines = [line.decode('utf-8') for line in response.streaming_content]

--- a/tock/utilization/tests/test_views.py
+++ b/tock/utilization/tests/test_views.py
@@ -68,6 +68,8 @@ class TestGroupUtilizationView(WebTest):
         req_user_data.is_billable = True
         req_user_data.save()
 
+        self.req_user = req_user
+
         self.user = User.objects.create(
             username='regular.user'
         )
@@ -102,7 +104,7 @@ class TestGroupUtilizationView(WebTest):
     def test_utilization(self):
         response = self.app.get(
             url=reverse('utilization:GroupUtilizationView'),
-            headers={'X_AUTH_USER': 'aaron.snow@gsa.gov'}
+            user=self.req_user
         )
 
         self.assertEqual(len(
@@ -126,7 +128,7 @@ class TestGroupUtilizationView(WebTest):
     def test_summary_rows(self):
         response = self.app.get(
             url=reverse('utilization:GroupUtilizationView'),
-            headers={'X_AUTH_USER': 'aaron.snow@gsa.gov'}
+            user=self.req_user
         )
         self.assertEqual(
             response.context['unit_totals'][0]['recent']['total_hours'],
@@ -138,7 +140,7 @@ class TestGroupUtilizationView(WebTest):
         self.b_timecard_object.save()
         response = self.app.get(
             url=reverse('utilization:GroupUtilizationView'),
-            headers={'X_AUTH_USER': 'aaron.snow@gsa.gov'}
+            user=self.req_user
         )
         self.assertContains(response,int(
             self.b_timecard_object.hours_spent + \


### PR DESCRIPTION
**Note: This is a PR against #720, not `master`.**

This fixes the hours and utilization view tests that aren't API-related.

I wasn't sure what to do about the views that seem to behave like API views: in the legacy version of the app, these views seem to have been protected by token-based auth, but now they have `@login_required` decorators around them, which suggests that they have cookie-based auth, and I'm not sure if that is actually what we want.  If it _is_ what we want, then I can fix these tests to work properly, but if it's _not_ what we want, I guess we should remove the `@login_required` decorators from the relevant views and have their auth managed by Django Rest Framework.  Um, I think.