### PR TITLE
Convert hours API endpoints to be DRF API views.

### DIFF
--- a/tock/hours/tests/test_views.py
+++ b/tock/hours/tests/test_views.py
@@ -9,6 +9,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import User
 from django_webtest import WebTest
 
+from api.tests import client
 from api.views import UserDataSerializer, ProjectSerializer
 from employees.models import UserData
 from hours.utils import number_of_hours
@@ -25,18 +26,6 @@ FIXTURES = [
     'employees/fixtures/user_data.json',
     'organizations/fixtures/organizations.json',
 ]
-
-
-def client(self):
-    # Note that this function was originally brought in from
-    # api.tests, but that client can't authenticate past the
-    # @login_required decorator we're currently using for
-    # this package's API-like views. For more details, see:
-    #
-    # https://github.com/18F/tock/pull/726
-    user = User.objects.get_or_create(username='aaron.snow')[0]
-    self.client.force_login(user)
-    return self.client
 
 
 def decode_streaming_csv(response, **reader_options):
@@ -539,7 +528,8 @@ class UserReportsTest(TestCase):
         )
 
     def test_user_reporting_period_report(self):
-        response = client(self).get(reverse(
+        self.client.force_login(self.user)
+        response = self.client.get(reverse(
             'reports:ReportingPeriodUserDetailView',
             kwargs={'reporting_period':'1999-12-31', 'username':'aaron.snow'}
         ))

--- a/tock/hours/views.py
+++ b/tock/hours/views.py
@@ -11,12 +11,13 @@ from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.urlresolvers import reverse
 from django.http import Http404, HttpResponse
+from django.shortcuts import render
 from django.views.generic import ListView, DetailView, TemplateView
 from django.views.generic.edit import CreateView, UpdateView, FormView
 from django.db.models import Sum
-from django.contrib.auth.decorators import login_required
 
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.decorators import api_view
 from rest_framework import serializers
 
 from api.views import get_timecards, \
@@ -471,7 +472,7 @@ class AdminBulkTimecardSerializer(serializers.Serializer):
     )
 
 
-@login_required
+@api_view(['GET'])
 def user_data_csv(request):
     """
     Stream all user data as CSV.
@@ -480,7 +481,7 @@ def user_data_csv(request):
     serializer = UserDataSerializer()
     return stream_csv(queryset, serializer)
 
-@login_required
+@api_view(['GET'])
 def projects_csv(request):
     """
     Stream all of the projects as CSV.
@@ -489,7 +490,7 @@ def projects_csv(request):
     serializer = ProjectSerializer()
     return stream_csv(queryset, serializer)
 
-@login_required
+@api_view(['GET'])
 def bulk_timecard_list(request):
     """
     Stream all the timecards as CSV.
@@ -498,7 +499,7 @@ def bulk_timecard_list(request):
     serializer = BulkTimecardSerializer()
     return stream_csv(queryset, serializer)
 
-@login_required
+@api_view(['GET'])
 def slim_bulk_timecard_list(request):
     """
     Stream a slimmed down version of all the timecards as CSV.
@@ -507,7 +508,7 @@ def slim_bulk_timecard_list(request):
     serializer = SlimBulkTimecardSerializer()
     return stream_csv(queryset, serializer)
 
-@login_required
+@api_view(['GET'])
 def general_snippets_only_timecard_list(request):
     """
     Stream all timecard data that is for General and has a snippet.
@@ -520,7 +521,6 @@ def general_snippets_only_timecard_list(request):
     serializer = GeneralSnippetsTimecardSerializer()
     return stream_csv(queryset, serializer)
 
-@login_required
 def timeline_view(request, value_fields=(), **field_alias):
     """ CSV endpoint for the project timeline viz. """
     queryset = get_timecards(TimecardList.queryset, request.GET)
@@ -560,7 +560,7 @@ def timeline_view(request, value_fields=(), **field_alias):
 
     return response
 
-@login_required
+@api_view(['GET'])
 def project_timeline_view(request):
     return timeline_view(
         request,
@@ -574,7 +574,7 @@ def project_timeline_view(request):
         project__organization__name='organization'
     )
 
-@login_required
+@api_view(['GET'])
 def user_timeline_view(request):
     return timeline_view(
         request,
@@ -586,7 +586,7 @@ def user_timeline_view(request):
         timecard__user__user_data__organization__name='organization'
     )
 
-@login_required
+@api_view(['GET'])
 def admin_bulk_timecard_list(request):
     if not request.user.is_superuser:
         return render(

--- a/tock/tock/settings/base.py
+++ b/tock/tock/settings/base.py
@@ -100,6 +100,7 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.TokenAuthentication',
+        'rest_framework.authentication.SessionAuthentication',
     ),
 }
 


### PR DESCRIPTION
**Note: This is a PR against #720, not `master`.**

This follows up on #726 to make the API views of `hours` (which deliver CSV content rather than HTML) use [DRF's `api_view` decorator](http://www.django-rest-framework.org/api-guide/views/#api_view) instead of `login_required`.

Crucially, they also modify the app's DRF settings to use [`SessionAuthentication`](http://www.django-rest-framework.org/api-guide/authentication/#sessionauthentication), in addition to the existing [`TokenAuthentication`](http://www.django-rest-framework.org/api-guide/authentication/#tokenauthentication), which makes it possible for the endpoints to be accessed by both programmatic API clients (via `TokenAuthentication`) _and_ website visitors (via `SessionAuthentication`).
