### PR TITLE
Add test suite to ensure most URLs are protected by auth.

### DIFF
--- a/tock/hours/tests/test_views.py
+++ b/tock/hours/tests/test_views.py
@@ -1004,7 +1004,8 @@ class ReportTests(WebTest):
             reverse(
                 'reports:ReportingPeriodCSVView',
                 kwargs={'reporting_period': '2015-01-01'},
-            )
+            ),
+            user=self.regular_user
         )
         lines = response.content.decode('utf-8').splitlines()
         self.assertEqual(len(lines), 3)
@@ -1033,7 +1034,8 @@ class ReportTests(WebTest):
             reverse(
                 'reports:ReportingPeriodCSVView',
                 kwargs={'reporting_period': '2015-01-01'},
-            )
+            ),
+            user=self.regular_user
         )
         lines = response.content.decode('utf-8').splitlines()
         self.assertEqual(len(lines), 4)
@@ -1055,7 +1057,8 @@ class ReportTests(WebTest):
             reverse(
                 'reports:ReportingPeriodCSVView',
                 kwargs={'reporting_period': '2015-01-01'},
-            )
+            ),
+            user=self.regular_user
         )
         lines = response.content.decode('utf-8').splitlines()
         self.assertEqual(len(lines), 3)
@@ -1067,7 +1070,8 @@ class ReportTests(WebTest):
             reverse(
                 'reports:ReportingPeriodDetailView',
                 kwargs={'reporting_period': '2015-01-01'},
-            )
+            ),
+            user=self.regular_user
         )
         self.assertEqual(
             len(response.html.find_all('tbody')), 2
@@ -1089,7 +1093,8 @@ class ReportTests(WebTest):
             reverse(
                 'reports:ReportingPeriodDetailView',
                 kwargs={'reporting_period': '2015-01-01'},
-            )
+            ),
+            user=self.regular_user
         )
 
         tables = response.html.find_all('table')
@@ -1119,7 +1124,8 @@ class ReportTests(WebTest):
             reverse(
                 'reports:ReportingPeriodDetailView',
                 kwargs={'reporting_period': '2015-01-01'},
-            )
+            ),
+            user=self.regular_user
         )
 
         tables = response.html.find_all('table')
@@ -1142,7 +1148,8 @@ class ReportTests(WebTest):
             reverse(
                 'reports:ReportingPeriodDetailView',
                 kwargs={'reporting_period': '2015-01-01'},
-            )
+            ),
+            user=self.regular_user
         )
         self.assertContains(response,
             '<td><a href="mailto:maya@gsa.gov">maya@gsa.gov</td>')

--- a/tock/hours/views.py
+++ b/tock/hours/views.py
@@ -925,7 +925,7 @@ class ReportsList(PermissionMixin, ListView):
         return sorted_fiscal_years
 
 
-class ReportingPeriodDetailView(ListView):
+class ReportingPeriodDetailView(PermissionMixin, ListView):
     template_name = 'hours/reporting_period_detail.html'
     context_object_name = 'timecard_list'
 
@@ -961,6 +961,7 @@ class ReportingPeriodDetailView(ListView):
         return context
 
 
+@api_view(['GET'])
 def ReportingPeriodCSVView(request, reporting_period):
     """Export a CSV of a specific reporting period"""
     response = HttpResponse(content_type='text/csv')

--- a/tock/projects/tests.py
+++ b/tock/projects/tests.py
@@ -139,6 +139,7 @@ class ProjectsTest(WebTest):
             project_lead = None
         )
         self.project_no_lead.save()
+        self.app.set_user(user)
 
     def test_model(self):
         """
@@ -432,6 +433,7 @@ class TestProjectTimeline(WebTest):
             obj for obj in self.objs
             if obj.timecard.reporting_period.start_date in self.dates_recent
         ]
+        self.app.set_user(User.objects.get(pk=1))
 
     def test_project_timeline(self):
         res = project_timeline(self.project)
@@ -504,7 +506,7 @@ class ProjectViewTests(WebTest):
 
         response = self.app.get(
             reverse('ProjectView', kwargs={'pk': '1'}),
-            headers={'X-FORWARDED-EMAIL': 'aaron.snow@gsa.gov'}
+            user=User.objects.get(email='aaron.snow@gsa.gov')
         )
 
         self.assertEqual(float(response.html.select('#totalHoursAll')[0].string), 15)

--- a/tock/projects/views.py
+++ b/tock/projects/views.py
@@ -6,9 +6,10 @@ from django.views.generic.detail import DetailView
 
 from hours.models import TimecardObject
 from .models import Project
+from tock.utils import PermissionMixin
 
 
-class ProjectListView(ListView):
+class ProjectListView(PermissionMixin, ListView):
     """ View for listing all of the projects, sort projects by name """
     model = Project
     template_name = 'projects/project_list.html'
@@ -20,7 +21,7 @@ class ProjectListView(ListView):
         return context
 
 
-class ProjectView(DetailView):
+class ProjectView(PermissionMixin, DetailView):
     """ View for listing the details of a specific project """
     model = Project
     template_name = 'projects/project_detail.html'

--- a/tock/tock/tests/test_admin.py
+++ b/tock/tock/tests/test_admin.py
@@ -1,0 +1,26 @@
+from django.test import TestCase
+from django.contrib.auth.models import User
+
+
+class AdminLoginTests(TestCase):
+    url = '/admin/login/'
+
+    def test_anonymous_users_are_redirected_to_uaa_login(self):
+        response = self.client.get(self.url)
+        self.assertRedirects(
+            response, '/auth/login?next=/admin/login/',
+            fetch_redirect_response=False)
+
+    def test_staff_users_are_redirected_to_admin(self):
+        user = User.objects.create_user(
+            username='jacob', email='jacob@gsa.gov', is_staff=True)
+        self.client.force_login(user)
+        response = self.client.get(self.url)
+        self.assertRedirects(response, '/admin/')
+
+    def test_non_staff_users_are_forbidden(self):
+        user = User.objects.create_user(
+            username='jacob', email='jacob@gsa.gov')
+        self.client.force_login(user)
+        response = self.client.get(self.url)
+        self.assertEquals(response.status_code, 403)

--- a/tock/tock/tests/test_url_auth.py
+++ b/tock/tock/tests/test_url_auth.py
@@ -1,0 +1,122 @@
+from django.test import TestCase
+from django.core.urlresolvers import RegexURLPattern, RegexURLResolver, reverse
+
+import tock.urls
+
+DOT_STAR_GROUP = '(.+)'
+
+SAMPLE_DOT_STAR_ARG = "foo"
+
+SAMPLE_KWARGS = {
+    "reporting_period": "2018-01-01",
+    "reporting_period_start_date": "2018-01-02",
+    "username": "bar",
+    "pk": "1",
+    "content_type_id": "2",
+    "object_id": "3",
+    "app_label": "hours",
+}
+
+IGNORE_NAMESPACES = ['djdt']
+
+NAMESPACES_WITH_UNNAMED_PATTERNS = ['admin']
+
+
+def iter_patterns(urlconf, patterns=None, namespace=None):
+    if patterns is None:
+        patterns = urlconf.urlpatterns
+    for pattern in patterns:
+        if isinstance(pattern, RegexURLPattern):
+            viewname = pattern.name
+            if viewname is None and namespace not in NAMESPACES_WITH_UNNAMED_PATTERNS:
+                raise AssertionError(f'namespace {namespace} cannot contain unnamed patterns')
+            if namespace and viewname is not None:
+                viewname = f"{namespace}:{viewname}"
+            yield (viewname, pattern.regex)
+        elif isinstance(pattern, RegexURLResolver):
+            if pattern.regex.groups > 0:
+                raise AssertionError('resolvers are not expected to have groups')
+            if pattern.namespace and namespace is not None:
+                raise AssertionError('nested namespaces are not currently supported')
+            if pattern.namespace in IGNORE_NAMESPACES:
+                continue
+            yield from iter_patterns(
+                urlconf,
+                pattern.url_patterns,
+                namespace or pattern.namespace
+            )
+        else:
+            raise AssertionError('unknown pattern class')
+
+
+def iter_sample_urls(urlconf):
+    for viewname, regex in iter_patterns(urlconf):
+        if viewname is None:
+            continue
+
+        named_groups = regex.groupindex.keys()
+        kwargs = {}
+        args = ()
+
+        if len(named_groups) != regex.groups:
+            if regex.groups != 1:
+                raise AssertionError('Patterns can contain at most one unnamed group')
+            if DOT_STAR_GROUP not in regex.pattern:
+                raise AssertionError(f'Unnamed groups can only contain {DOT_STAR_GROUP}')
+            args = (SAMPLE_DOT_STAR_ARG,)
+        for kwarg in named_groups:
+            if kwarg not in SAMPLE_KWARGS:
+                raise AssertionError(
+                    f'Sample value for {kwarg} in pattern "{regex.pattern}" not found'
+                )
+            kwargs[kwarg] = SAMPLE_KWARGS[kwarg]
+        url = reverse(viewname, urlconf=urlconf, args=args, kwargs=kwargs)
+        yield (viewname, url)
+
+
+class URLAuthTests(TestCase):
+    IGNORE_URLS = [
+        # These are the UAA auth endpoints that always need
+        # to be public.
+        '/auth/login',
+        '/auth/callback',
+        # These end up in the URL config but are always
+        # disabled in production, so don't worry about them.
+        '/auth/fake/oauth/authorize',
+        '/auth/fake/oauth/token',
+        # Logging out of admin is always public, so ignore it.
+        '/admin/logout/',
+    ]
+
+    def assertURLIsProtectedByAuth(self, url):
+        response = self.client.get(url)
+        code = response.status_code
+        if code == 302:
+            redirect = response['location']
+            self.assertRegex(
+                redirect,
+                r'^\/(auth|admin)\/login',
+                f'GET {url} should redirect to login or deny access, but instead '
+                f'it redirects to {redirect}'
+            )
+        elif code == 401 or code == 403:
+            pass
+        else:
+            raise AssertionError(
+                f'GET {url} returned HTTP {code}, but should redirect to login or '
+                f'deny access'
+            )
+
+    @classmethod
+    def define_tests_for_urls(cls, urlconf):
+        def create_url_auth_test(url):
+            def test(self):
+                self.assertURLIsProtectedByAuth(url)
+            return test
+
+        for viewname, url in iter_sample_urls(urlconf):
+            if url not in cls.IGNORE_URLS:
+                setattr(cls, f'test_{viewname}', create_url_auth_test(url))
+
+
+URLAuthTests.define_tests_for_urls(tock.urls)

--- a/tock/tock/tests/test_url_auth.py
+++ b/tock/tock/tests/test_url_auth.py
@@ -127,7 +127,15 @@ class URLAuthTests(TestCase):
         to login or denies access outright.
         """
 
-        response = self.client.get(url)
+        try:
+            response = self.client.get(url)
+        except Exception as e:
+            # It'll be helpful to provide information on what URL was being
+            # accessed at the time the exception occurred.  Python 3 will
+            # also include a full traceback of the original exception, so
+            # we don't need to worry about hiding the original cause.
+            raise AssertionError(f'Accessing {url} raised "{e}"')
+
         code = response.status_code
         if code == 302:
             redirect = response['location']

--- a/tock/tock/urls.py
+++ b/tock/tock/urls.py
@@ -1,9 +1,21 @@
 from django.conf import settings
 from django.conf.urls import include, url
+from django.contrib.auth.decorators import user_passes_test
+from django.core.exceptions import PermissionDenied
 
 # Enable the Django admin.
 from django.contrib import admin
 admin.autodiscover()
+
+def check_if_staff(user):
+    if not user.is_authenticated():
+        return False
+    if user.is_staff:
+        return True
+    raise PermissionDenied
+
+staff_login_required = user_passes_test(check_if_staff)
+admin.site.login = staff_login_required(admin.site.login)
 
 import hours.views
 import api.urls

--- a/tock/utilization/views.py
+++ b/tock/utilization/views.py
@@ -6,9 +6,10 @@ from django.core.urlresolvers import reverse
 from hours.models import TimecardObject, ReportingPeriod
 from employees.models import UserData
 
+from tock.utils import PermissionMixin
 from .utils import get_dates, calculate_utilization
 
-class GroupUtilizationView(ListView):
+class GroupUtilizationView(PermissionMixin, ListView):
     template_name = 'utilization/group_utilization.html'
 
     def get_queryset(self):


### PR DESCRIPTION
**Note: This PR is against #720, not `master`.**

This adds a test suite that ensures that most URLs are protected by auth, fixing #728.

To run it, use:

```
python manage.py test tock.tests.test_url_auth
```

## Notes

* This test suite finds URLs by digging into Django internals a bit, specifically [`django.core.urlresolvers`](https://docs.djangoproject.com/en/1.9/_modules/django/core/urlresolvers/).  It's likely that this will break when upgrading to new versions of Django, which is probably OK; this test  suite doesn't need to last forever, but it's particularly important for #720.

## To do

- [x] ~~Ensure the test suite is actually run by CI.  It's located in a `tests` directory in the _project_ directory, not an app directory, which makes me worry that Django's `manage.py test` command might not automatically find it.~~ Verified this new test suite is run during CI by inspecting the CircleCI log for this PR.

- [x] Fix auth holes (i.e., failing tests) uncovered by this new suite:

  - [x] `test_reports:ReportingPeriodDetailView`

    The view at `/reports/2018-01-01/` doesn't have a `PermissionMixin`, nor does it have the `permission_classes` property like a lot of other `ListView` subclasses do.

    Aside from that, this view is raising a `DoesNotExist: ReportingPeriod matching query does not exist.`, which suggests that, even if the current user _is_ authenticated, we should be catching this and returning a 404, instead of propagating the exception. (File a separate bug for this.)

  - [x] `test_reports:ReportingPeriodCSVView`

    Looks like `/reports/2018-01-01.csv/` is returning 200.

  - [x] `test_ProjectListView`

    Looks like `/projects/` is returning 200.

  - [x] `test_ProjectView`

    Looks like `/projects/1/` is returning 404, but if we want it protected by auth, we should probably be redirecting to login instead, even on views that return 404.  (Otherwise, I guess we should actually make a project with id 1 before running this suite.)

  - [x] `test_utilization:GroupUtilizationView`

    Looks like `/utilization/` is not only exposed to unauthenticated users, but it's also raising an `IndexError: list index out of range` exception.  We should fix the former and file an issue to fix the latter later.

  - [X] `test_admin:login`

    So `/admin/login` seems to be exposed, which is not good because it has a password field in it--yet we're not using password-based auth!  We can fix by ensuring this view always redirects to UAA Auth--see [how we fix it in CALC](https://github.com/18F/calc/blob/develop/hourglass/urls.py#L12-L16) for details.
