### PR TITLE
Redirect /admin/login to UAA, return 403 if not staff.

### DIFF
--- a/tock/tock/tests/test_admin.py
+++ b/tock/tock/tests/test_admin.py
@@ -1,0 +1,26 @@
+from django.test import TestCase
+from django.contrib.auth.models import User
+
+
+class AdminLoginTests(TestCase):
+    url = '/admin/login/'
+
+    def test_anonymous_users_are_redirected_to_uaa_login(self):
+        response = self.client.get(self.url)
+        self.assertRedirects(
+            response, '/auth/login?next=/admin/login/',
+            fetch_redirect_response=False)
+
+    def test_staff_users_are_redirected_to_admin(self):
+        user = User.objects.create_user(
+            username='jacob', email='jacob@gsa.gov', is_staff=True)
+        self.client.force_login(user)
+        response = self.client.get(self.url)
+        self.assertRedirects(response, '/admin/')
+
+    def test_non_staff_users_are_forbidden(self):
+        user = User.objects.create_user(
+            username='jacob', email='jacob@gsa.gov')
+        self.client.force_login(user)
+        response = self.client.get(self.url)
+        self.assertEquals(response.status_code, 403)

--- a/tock/tock/urls.py
+++ b/tock/tock/urls.py
@@ -1,9 +1,21 @@
 from django.conf import settings
 from django.conf.urls import include, url
+from django.contrib.auth.decorators import user_passes_test
+from django.core.exceptions import PermissionDenied
 
 # Enable the Django admin.
 from django.contrib import admin
 admin.autodiscover()
+
+def check_if_staff(user):
+    if not user.is_authenticated():
+        return False
+    if user.is_staff:
+        return True
+    raise PermissionDenied
+
+staff_login_required = user_passes_test(check_if_staff)
+admin.site.login = staff_login_required(admin.site.login)
 
 import hours.views
 import api.urls


### PR DESCRIPTION
**Note: This is a PR against #729, not `master`.**

This fixes login in a way similar to what we did for CALC.  It contains a simplified version of the [`staff_login_required`](https://github.com/18F/calc/blob/develop/hourglass/decorators.py) decorator that we used in CALC.

## To do

- [ ] Instead of merging this PR, we might want to consider actually adding CALC's `staff_login_required` decorator to [cg-django-uaa](https://github.com/18F/cg-django-uaa) and using it from there.  It's likely that any Django project that uses both cg-django-uaa and the admin UI will want to wrap the admin login view with a decorator like this. **Update:** Filed https://github.com/18F/cg-django-uaa/issues/43 to address this.
- [x] If we decide to go with this solution, add tests.

Thoughts @rogeruiz ?
