### PR TITLE
Add error views instead of reusing login_error.html

### DIFF
--- a/tock/hours/views.py
+++ b/tock/hours/views.py
@@ -11,10 +11,10 @@ from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.urlresolvers import reverse
 from django.http import Http404, HttpResponse
-from django.shortcuts import render
 from django.views.generic import ListView, DetailView, TemplateView
 from django.views.generic.edit import CreateView, UpdateView, FormView
 from django.db.models import Sum
+from django.shortcuts import render_to_response
 
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.decorators import api_view
@@ -586,17 +586,11 @@ def user_timeline_view(request):
         timecard__user__user_data__organization__name='organization'
     )
 
+
 @api_view(['GET'])
 def admin_bulk_timecard_list(request):
     if not request.user.is_superuser:
-        return render(
-            request,
-            'uaa_client/login_error.html',
-            context={
-                'superuser': request.user.is_superuser,
-            },
-            status=403
-        )
+        return render_to_response('403.html')
 
     queryset = get_timecards(TimecardList.queryset, request.GET)
     serializer = AdminBulkTimecardSerializer()

--- a/tock/hours/views.py
+++ b/tock/hours/views.py
@@ -8,13 +8,13 @@ from operator import attrgetter
 # Create your views here.
 from django.contrib import messages
 from django.contrib.auth import get_user_model
-from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.core.exceptions import ObjectDoesNotExist, ValidationError, \
+    PermissionDenied
 from django.core.urlresolvers import reverse
 from django.http import Http404, HttpResponse
 from django.views.generic import ListView, DetailView, TemplateView
 from django.views.generic.edit import CreateView, UpdateView, FormView
 from django.db.models import Sum
-from django.shortcuts import render_to_response
 
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.decorators import api_view
@@ -597,7 +597,7 @@ def user_timeline_view(request):
 @api_view(['GET'])
 def admin_bulk_timecard_list(request):
     if not request.user.is_superuser:
-        return render_to_response('403.html')
+        raise PermissionDenied
 
     queryset = get_timecards(TimecardList.queryset, request.GET)
     serializer = AdminBulkTimecardSerializer()

--- a/tock/hours/views.py
+++ b/tock/hours/views.py
@@ -1032,9 +1032,10 @@ class ReportingPeriodUserDetailView(PermissionMixin, DetailView):
 
     def get_context_data(self, **kwargs):
         rp_period = self.kwargs['reporting_period']
+        username = self.kwargs['username']
         user_billable_hours = TimecardObject.objects.filter(
             timecard__reporting_period__start_date=rp_period,
-            timecard__user__username=self.kwargs['username'],
+            timecard__user__username=username,
             project__accounting_code__billable=True
         ).aggregate(
             (
@@ -1044,7 +1045,7 @@ class ReportingPeriodUserDetailView(PermissionMixin, DetailView):
 
         user_all_hours = TimecardObject.objects.filter(
             timecard__reporting_period__start_date=rp_period,
-            timecard__user__username=self.kwargs['username'],
+            timecard__user__username=username,
         ).aggregate(
             (
                 Sum('hours_spent')

--- a/tock/tock/settings/base.py
+++ b/tock/tock/settings/base.py
@@ -23,6 +23,8 @@ SECRET_KEY = env.get_credential('DJANGO_SECRET_KEY', get_random_string(50))
 LOGIN_URL = '/auth/login'
 LOGIN_REDIRECT_URL = '/'
 
+CSRF_FAILURE_VIEW = 'tock.views.csrf_failure'
+
 INSTALLED_APPS = (
     'django.contrib.contenttypes',  # may be okay to remove
     'django.contrib.staticfiles',

--- a/tock/tock/settings/base.py
+++ b/tock/tock/settings/base.py
@@ -43,11 +43,12 @@ INSTALLED_APPS = (
     'rest_framework.authtoken',
 )
 
-TEMPLATES =  [
+TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': ['/templates/'
-            ],
+        'DIRS': [
+            '/templates/'
+        ],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [

--- a/tock/tock/templates/403.html
+++ b/tock/tock/templates/403.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+<h2>Forbidden</h2>
+<p>You don't have access to view this page.</p>
+
+{% endblock %}

--- a/tock/tock/templates/404.html
+++ b/tock/tock/templates/404.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+<h2>Not Found</h2>
+<p>The content for this page could not be found.</p>
+
+{% endblock %}
+

--- a/tock/tock/templates/500.html
+++ b/tock/tock/templates/500.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+<h2>Server Error</h2>
+<p>A server error has occurred.</p>
+
+{% endblock %}
+

--- a/tock/tock/templates/uaa_client/login_error.html
+++ b/tock/tock/templates/uaa_client/login_error.html
@@ -1,14 +1,22 @@
 {% extends "base.html" %}
 {% block content %}
 
-<h2>UAA Login Error</h2>
+<h2>cloud.gov Login Error</h2>
 
-{% if error_code == "missing_state" or error_code == "missing_session_state" or error_code == "invalid_state" %}
-  <p>Bad session state</p>
+{% if error_code == "missing_state" or
+      error_code == "missing_session_state" or
+      error_code == "invalid_state" %}
+
+<p>Bad session state</p>
+
 {% elif error_code == "missing_code" %}
-  <p>Missing session code</p>
+
+<p>Missing session code</p>
+
 {% elif error_code == "authenticate_failed" %}
-  <p>Authentication failed</p>
+
+<p>Authentication failed</p>
+
 {% endif %}
 
 {% endblock %}

--- a/tock/tock/templates/uaa_client/login_error.html
+++ b/tock/tock/templates/uaa_client/login_error.html
@@ -1,14 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
 
-{% if not superuser %}
-<h2>Whoops, you don't have access</h2>
-
-<p>You don't have access to view this page.<p>
-{% endif %}
-
-{% if error_code %}
-<h2>Whoops, login error!</h2>
+<h2>UAA Login Error</h2>
 
 {% if error_code == "missing_state" or error_code == "missing_session_state" or error_code == "invalid_state" %}
   <p>Bad session state</p>
@@ -16,8 +9,6 @@
   <p>Missing session code</p>
 {% elif error_code == "authenticate_failed" %}
   <p>Authentication failed</p>
-{% endif %}
-
 {% endif %}
 
 {% endblock %}

--- a/tock/tock/urls.py
+++ b/tock/tock/urls.py
@@ -12,8 +12,7 @@ import projects.urls
 urlpatterns = [
     url(r'^$',
         hours.views.ReportingPeriodListView.as_view(),
-        name='ListReportingPeriods'
-    ),
+        name='ListReportingPeriods'),
     url(r'^reporting_period/', include(
         'hours.urls.timesheets',
         namespace='reportingperiod'

--- a/tock/tock/utils.py
+++ b/tock/tock/utils.py
@@ -6,7 +6,8 @@ import sys
 from rest_framework.permissions import IsAuthenticated
 from django.contrib.auth.mixins import LoginRequiredMixin
 from rest_framework.permissions import BasePermission
-from django.shortcuts import redirect, render
+from django.core.exceptions import PermissionDenied
+from django.shortcuts import redirect
 
 from tock.settings import base
 
@@ -32,14 +33,7 @@ class PermissionMixin(LoginRequiredMixin, object):
                         logger.info("User isn't logged in, redirecting...")
                         return redirect('/auth/login')
                     logger.info("User isn't allowed, redirecting...")
-                    return render(
-                        request,
-                        'uaa_client/login_error.html',
-                        context={
-                            'superuser': request.user.is_superuser,
-                        },
-                        status=403
-                    )
+                    raise PermissionDenied
             return view(request, args, **kwargs)
         return wrapped
 

--- a/tock/tock/views.py
+++ b/tock/tock/views.py
@@ -1,0 +1,5 @@
+from django.shortcuts import render_to_response
+
+
+def csrf_failure(request, reason=""):
+    return render_to_response('403.html')

--- a/tock/tock/views.py
+++ b/tock/tock/views.py
@@ -1,5 +1,16 @@
-from django.shortcuts import render_to_response
+import logging
+
+from django.shortcuts import render
+
+logger = logging.getLogger(__name__)
 
 
 def csrf_failure(request, reason=""):
-    return render_to_response('403.html')
+    logger.warn(
+        'CSRF Failure for request [%s] for reason [%s]' %
+        (
+            request.META,
+            reason
+        )
+    )
+    return render(request, '403.html')


### PR DESCRIPTION
**This branch is to be merged into #720 and not `master`.**

[This work refactors the error states](https://github.com/18F/tock/pull/730#issuecomment-370475323) and leaves the any files touched linted into a better state then how they were found.

### Acceptance Criteria

- [x] Add `404`, `403`, `500` error pages
- [x] Add CSRF redirect error page
- [x] Refactor renders to `login_error.html` from various places by raising errors instead