### PR TITLE
In dev mode, set SECRET_KEY to constant value

### DIFF
--- a/tock/tock/settings/dev.py
+++ b/tock/tock/settings/dev.py
@@ -8,6 +8,8 @@ from .base import (DATABASES, INSTALLED_APPS, MIDDLEWARE_CLASSES, TEMPLATES)
 
 DEBUG = True
 
+SECRET_KEY = 'development_mode'
+
 for t in TEMPLATES:
     t.setdefault('OPTIONS', {})
     t['OPTIONS']['debug'] = True


### PR DESCRIPTION
This fixes #738 by setting `SECRET_KEY` to a constant value of `"development_mode"` during development.  Without this, `SECRET_KEY` defaults to a random 50-byte string, which means that whenever the dev server reloads due to a code change, the session (which I think is held on the client side and signed with the secret) gets invalidated.