### PR TITLE
Upgrade to Django 1 11

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 bandit==1.4.0
 coverage==4.4.1
 django-debug-toolbar==1.9.1
-django-webtest==1.7.9
+django-webtest==1.9.2
 factory-boy==2.8.1
 flake8==3.5.0
 nplusone==0.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.10.8
+Django==1.11.11
 dj-database-url==0.4.2
 psycopg2==2.7.3.2
 model-mommy==1.3.0

--- a/tock/hours/tests/test_views.py
+++ b/tock/hours/tests/test_views.py
@@ -162,7 +162,7 @@ class DashboardViewTests(WebTest):
                 'reports:DashboardView',
                 kwargs={'reporting_period':'1999-12-31'}
             ),
-            {'unit':'1'},
+            params={'unit':'1'},
             user=self.user,
         )
         self.assertEqual(response.status_code, 200)
@@ -956,7 +956,7 @@ class ReportTests(WebTest):
                 'reportingperiod:UpdateTimesheet',
                 kwargs={'reporting_period': date}
             ),
-            {
+            params={
                 'save_only': '1',
                 'timecardobjects-TOTAL_FORMS': '1',
                 'timecardobjects-INITIAL_FORMS': '0',


### PR DESCRIPTION
This moves us closer to #699 by upgrading us to Django 1.11.  From there we will be able to upgrade to yet another version of Django, the infamous 2.0!

## Notes

* In order to properly use the changes in this new PR, Docker users will have to run `docker-compose build`, while non-Docker users will need to re-run `pip install -r requirements.txt`.  **To avoid confusion, we should mention this on Slack as soon as this PR is merged.**

* As @ccostino noted in https://github.com/18F/tock/issues/699#issuecomment-359467001, the select widgets in the timecard form are broken. This is because we have a custom subclass of `forms.widgets.Select` called `SelectWithData` which needed to be upgraded to use [Django's  new form rendering API](https://docs.djangoproject.com/en/2.0/ref/forms/renderers/).  Specifically, I had to override the superclass' [`create_option` method](https://github.com/django/django/blob/master/django/forms/widgets.py#L606-L624) to add the custom data attributes that we expect (among other things).

    The good news is that because of the new form rendering API's separation between widget data and template rendering, the new subclass is more concise than the old one.

## To do

- [x] Make the tests pass again.
