### PR TITLE
Update Getting Started w/ valid username

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If your team uses Tock and Slack, you might also find the ["angrytock" reminder 
   $ docker-compose build
   $ docker-compose run app python manage.py migrate
   $ docker-compose run app python manage.py loaddata test_data/data-update-deduped.json
-  $ docker-compose run app python manage.py createsuperuser --username admin@gsa.gov --email admin@gsa.gov --noinput
+  $ docker-compose run app python manage.py createsuperuser --username admin --email admin@gsa.gov --noinput
   ```
 
 1. Once the above commands are successful, run:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,12 @@ If your team uses Tock and Slack, you might also find the ["angrytock" reminder 
   $ docker-compose build
   $ docker-compose run app python manage.py migrate
   $ docker-compose run app python manage.py loaddata test_data/data-update-deduped.json
-  $ docker-compose run app python manage.py createsuperuser --username admin --email admin@gsa.gov --noinput
+  $ docker-compose run app \
+    python manage.py \
+        createsuperuser \
+        --username admin.user \
+        --email admin.user@gsa.gov \
+        --noinput
   ```
 
 1. Once the above commands are successful, run:


### PR DESCRIPTION
## Description

Small tweak for https://github.com/18F/tock/issues/733#issuecomment-370942684

To create a development admin account, users should call ``createsuperuser`` with a non-email username.

Manually inserting an email username breaks ``utilization.GroupUtilizationView.get_queryset`` as email addresses are not caught by the current regex for the ``reports:ReportingPeriodUserDetailView`` urlpattern.

## Additional information

Not expected to encounter non-conforming usernames outside of development as ``@DOMAIN`` is truncated on user creation. There's only a single authorized domain at the moment,  this approach may lead to issues down the line if/when others are added.


