### PR TITLE
Include 'grade' in timecards.json response.

### DIFF
--- a/api-docs/projects.md
+++ b/api-docs/projects.md
@@ -32,6 +32,7 @@ To fetch a list of projects  information.
         "billable": true,
         "start_date": null,
         "end_date": null,
+        "grade": 16,
         "active": true
     },...
 
@@ -48,5 +49,8 @@ To fetch a list of projects  information.
 $ curl https://tock.18f.gov/api/projects.json -H 'Authorization: Token randomalphanumericstringed854b18ba024327'
 ```
 
-* **Notes:** None.
- 
+* **Notes:**
+
+Note that `grade` may be `null` if no grade information is
+available. If it is non-null, it will be a number corresponding to a grade;
+the mapping is defined by `GRADE_CHOICES` in `tock/employees/models.py`.

--- a/tock/api/tests.py
+++ b/tock/api/tests.py
@@ -70,6 +70,20 @@ class TimecardsAPITests(WebTest):
         clean_res = json.loads(res.decode())
         self.assertEqual(len(clean_res), 2)
 
+    def test_timecards_grade_is_null_when_absent(self):
+        res = client(self).get(
+            reverse('TimecardList'),
+            data={'date': '2016-06-01'}).content
+        clean_res = json.loads(res.decode())
+        self.assertEqual(clean_res[0]['grade'], None)
+
+    def test_timecards_grade_is_populated_when_present(self):
+        res = client(self).get(
+            reverse('TimecardList'),
+            data={'date': '2015-06-01'}).content
+        clean_res = json.loads(res.decode())
+        self.assertEqual(clean_res[0]['grade'], 4)
+
     # TODO: test with more diverse data
     def test_get_timecards(self):
         """ Check that get time cards returns the correct queryset """

--- a/tock/api/views.py
+++ b/tock/api/views.py
@@ -109,6 +109,8 @@ class TimecardSerializer(serializers.Serializer):
     project_organization = serializers.CharField(
         source='project.organization_name'
     )
+    grade = serializers.IntegerField(
+        source='grade.grade')
 
 # API Views
 
@@ -167,6 +169,7 @@ class TimecardList(generics.ListAPIView):
         'timecard__user',
         'project__accounting_code__agency',
         'timecard__reporting_period',
+        'grade',
     ).order_by(
         'timecard__reporting_period__start_date'
     )

--- a/tock/hours/fixtures/timecards.json
+++ b/tock/hours/fixtures/timecards.json
@@ -1,5 +1,14 @@
 [
   {
+    "model": "employees.EmployeeGrade",
+    "fields": {
+      "employee": 1,
+      "grade": 4,
+      "g_start_date": "2015-05-28"
+    },
+    "pk": 1
+  },
+  {
     "model": "hours.reportingperiod",
     "fields": {
       "start_date": "2015-06-01",
@@ -24,6 +33,7 @@
       "timecard": 1,
       "project": 1,
       "hours_spent": 20,
+      "grade": 1,
       "created": "2015-06-08T12:00:00.000Z",
       "modified": "2015-06-08T12:00:00.000Z"
     },


### PR DESCRIPTION
Fixes #756.

## To do

- [x] Document this in `api-docs/timecards.md`.
- [x] ~~Should we convert the grade from an integer to an actual grade level string, e.g. `"GS14"`?~~ Decided not to do this; one advantage of keeping it as a number is that it's very easy to compare one grade to another.
- [x] In #461, Patrick says with regard to providing grade information via a superuser-only view, "The purpose of this is to limit the availability of employee-level grade information and protect the privacy of our employees".  Do we only want to provide the grade information if the requester (or the token associated with them) is a superuser? Right now we're just returning the information all the time.

  **Update:**

    I emailed the GSA's Chief Privacy Officer about this and he said:

    > Current GS level is considered "releaseable" under GSA Policy, meaning that it is not confidential/sensitive info:  https://insite.gsa.gov/portal/content/674050

    So we should be good to go!
