### PR TITLE
Refactor manifests away from deprecated changes

### DIFF
--- a/manifest-production.yml
+++ b/manifest-production.yml
@@ -1,12 +1,11 @@
 ---
-buildpack: python_buildpack
-memory: 512M
-path: .
-stack: cflinuxfs2
-timeout: 180
-
 applications:
 - name: tock
+  buildpack: python_buildpack
+  memory: 512M
+  path: .
+  stack: cflinuxfs2
+  timeout: 180
   routes:
   - route: tock.18f.gov
   - route: tock.18f.gov/api

--- a/manifest-staging.yml
+++ b/manifest-staging.yml
@@ -1,12 +1,11 @@
 ---
-buildpack: python_buildpack
-memory: 512M
-path: .
-stack: cflinuxfs2
-timeout: 180
-
 applications:
 - name: tock
+  buildpack: python_buildpack
+  memory: 512M
+  path: .
+  stack: cflinuxfs2
+  timeout: 180
   routes:
   - route: tock.app.cloud.gov
   - route: tock.app.cloud.gov/api


### PR DESCRIPTION
:eyes: http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#deprecated

`cf push` complained about it here.

```shell
Using manifest file manifest-${ENVIRONMENT}.yml

Deprecation warning: Specifying app manifest attributes at the top level is deprecated. Found: buildpack, timeout, memory, path, stack.
Please see http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#deprecated for alternatives and other app manifest deprecations. This feature will be removed in the future.

# ...
```