### PR TITLE
Recycle production instances on a schedule

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,11 +88,14 @@ jobs:
       - attach_workspace:
           at: .
       - run:
+          name: Login to cloud.gov Staging
+          command: cf login -a ${CF_API} -u ${CF_DEPLOYER_USERNAME_STAGING} -p ${CF_DEPLOYER_PASSWORD_STAGING}
+      - run:
+          name: Save version to file system
+          command: echo ${CIRCLE_SHA1} > tock/VERSION
+      - run:
           name: deploy Tock Staging to cloud.gov
-          command: |
-            cf login -a ${CF_API} -u ${CF_DEPLOYER_USERNAME_STAGING} -p ${CF_DEPLOYER_PASSWORD_STAGING}
-            echo ${CIRCLE_SHA1} > tock/VERSION
-            cf_deploy.sh tock gsa-18f-tock staging manifest-staging.yml
+          command: cf_deploy.sh tock gsa-18f-tock staging manifest-staging.yml
 
   deploy_to_production:
     <<: *CF_DOCKER_IMAGE
@@ -103,7 +106,14 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: deploy Tock Production to cloud.gov
+          name: Login to cloud.gov Production
+          command: cf login -a ${CF_API} -u ${CF_DEPLOYER_USERNAME_PRODUCTION} -p ${CF_DEPLOYER_PASSWORD_PRODUCTION}
+      - run:
+          name: Save version to file system
+          command: echo ${CIRCLE_TAG} > tock/VERSION
+      - run:
+          name: Deploy Tock Production to cloud.gov
+          command: cf_deploy.sh tock gsa-18f-tock prod manifest-production.yml
 
   recycle_production:
     <<: *CF_DOCKER_IMAGE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,6 +128,7 @@ jobs:
           name: Install cf-recycle-plugin 1.0.0 release
           command: |
             curl -o cf-recycle-plugin https://github.com/rogeruiz/cf-recycle-plugin/releases/download/v1.0.0/cf-recycle-plugin.linux64
+            chmod +x cf-recycle-plugin
             cf install-plugin cf-recycle-plugin -f
       - run:
           name: Recycle Tock Production instances

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,10 +104,24 @@ jobs:
           at: .
       - run:
           name: deploy Tock Production to cloud.gov
+
+  recycle_production:
+    <<: *CF_DOCKER_IMAGE
+
+    <<: *WORKING_DIRECTORY
+
+    steps:
+      - run:
+          name: Login to cloud.gov Production
+          command: cf login -a ${CF_API} -u ${CF_DEPLOYER_USERNAME_PRODUCTION} -p ${CF_DEPLOYER_PASSWORD_PRODUCTION}
+      - run:
+          name: Install cf-recycle-plugin 1.0.0 release
           command: |
-            cf login -a ${CF_API} -u ${CF_DEPLOYER_USERNAME_PRODUCTION} -p ${CF_DEPLOYER_PASSWORD_PRODUCTION}
-            echo ${CIRCLE_TAG} > tock/VERSION
-            cf_deploy.sh tock gsa-18f-tock prod manifest-production.yml
+            curl -o cf-recycle-plugin https://github.com/rogeruiz/cf-recycle-plugin/releases/download/v1.0.0/cf-recycle-plugin.linux64
+            cf install-plugin cf-recycle-plugin -f
+      - run:
+          name: Recycle Tock Production instances
+          command: cf recycle tock
 
 workflows:
   version: 2
@@ -145,3 +159,9 @@ workflows:
               only: /v20[1-9][0-9][0-9]+\.[0-9]+/
             branches:
               ignore: /.*/
+  recycle-prod:
+    jobs:
+      - recycle_production
+    triggers:
+    - schedule:
+        cron: "0 10 * * *"  # Roughly 5am ET

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,7 @@ jobs:
       - run:
           name: Install cf-recycle-plugin 1.0.0 release
           command: |
-            curl -o cf-recycle-plugin https://github.com/rogeruiz/cf-recycle-plugin/releases/download/v1.0.0/cf-recycle-plugin.linux64
+            curl -L -o cf-recycle-plugin https://github.com/rogeruiz/cf-recycle-plugin/releases/download/v1.0.0/cf-recycle-plugin.linux64
             chmod +x cf-recycle-plugin
             cf install-plugin cf-recycle-plugin -f
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,16 @@
 #
 # Check https://circleci.com/docs/2.0/language-python/ for more details
 #
+cf-docker-image: &CF_DOCKER_IMAGE
+  docker:
+    - image: 18fgsa/cloud-foundry-cli
+      environment:
+        - TZ=America/New_York
+        - CF_API: https://api.fr.cloud.gov
+working-directory: &WORKING_DIRECTORY
+  working_directory: ~/repo
+
+
 version: 2
 jobs:
   build:
@@ -21,7 +31,7 @@ jobs:
           - POSTGRES_USER=circleci
           - POSTGRES_DB=tock-test
 
-    working_directory: ~/repo
+    <<: *WORKING_DIRECTORY
 
     steps:
       - checkout
@@ -70,13 +80,10 @@ jobs:
             - ./*
 
   deploy_to_staging:
-    docker:
-      - image: 18fgsa/cloud-foundry-cli
-        environment:
-          - TZ=America/New_York
-          - CF_API: https://api.fr.cloud.gov
+    <<: *CF_DOCKER_IMAGE
 
-    working_directory: ~/repo
+    <<: *WORKING_DIRECTORY
+
     steps:
       - attach_workspace:
           at: .
@@ -88,12 +95,9 @@ jobs:
             cf_deploy.sh tock gsa-18f-tock staging manifest-staging.yml
 
   deploy_to_production:
-    docker:
-      - image: 18fgsa/cloud-foundry-cli
-        environment:
-          - TZ=America/New_York
-          - CF_API: https://api.fr.cloud.gov
-    working_directory: ~/repo
+    <<: *CF_DOCKER_IMAGE
+
+    <<: *WORKING_DIRECTORY
 
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,4 +178,4 @@ workflows:
         cron: "0 10 * * *"  # Roughly 5am ET
         filters:
           branches:
-            only: master
+            only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,3 +175,6 @@ workflows:
     triggers:
     - schedule:
         cron: "0 10 * * *"  # Roughly 5am ET
+        filters:
+          branches:
+            only: master


### PR DESCRIPTION
This work should be recycling the production instances of Tock on a schedule at 5am every day. This should cause no downtime as it uses [the CF Recycle plugin](https://github.com/rogeruiz/cf-recycle-plugin).