### PR TITLE
Remove requirements.txt from .cfignore

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -22,7 +22,6 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
-requirements.txt
 
 # PyInstaller
 #  Usually these files are written by a python script from a template


### PR DESCRIPTION
This changeset restores the `requirements.txt` file to be read by Cloud Foundry with the Python buildpack to account for a `pipenv` issue currently taking place, which breaks deployments.