### PR TITLE
Add support for additional non-billable projects for the snippets report

### DIFF
--- a/tock/hours/views.py
+++ b/tock/hours/views.py
@@ -48,6 +48,9 @@ from .forms import (
 from utilization.utils import calculate_utilization, get_fy_first_day
 
 
+NON_BILLABLE_PROJECT_IDS = [2, 669,]
+
+
 class DashboardReportsList(PermissionMixin, ListView):
     template_name = 'hours/dashboard_list.html'
     permission_classes = (IsAuthenticated, )
@@ -519,7 +522,7 @@ def general_snippets_only_timecard_list(request):
     Stream all timecard data that is for General and has a snippet.
     """
     objects = TimecardObject.objects.filter(
-        project__name='General',
+        project__id__in=NON_BILLABLE_PROJECT_IDS,
         notes__isnull=False
     )
     queryset = get_timecards(objects, request.GET)

--- a/tock/tock/templates/hours/reports_list.html
+++ b/tock/tock/templates/hours/reports_list.html
@@ -20,7 +20,7 @@
 			<a href="{% url 'reports:SlimBulkTimecardList' %}?after=2016-10-02">FY2017</a>
             <a href="{% url 'reports:SlimBulkTimecardList' %}?after=2017-10-01">FY2018</a>
 		</li>
-		<li>Complete snippet data for 'General':
+		<li>Complete snippet data for '18F Non-Billable':
 				<a href="{% url 'reports:GeneralSnippetsView' %}">All</a>
 				<a href="{% url 'reports:GeneralSnippetsView' %}?after=2016-10-02">FY2017</a>
                 <a href="{% url 'reports:GeneralSnippetsView' %}?after=2017-10-01">FY2018</a>


### PR DESCRIPTION
This changeset adds a bit of flexibility to the snippets report to include additional project line items instead of just the old General line item.  The reason for this is once the General project was retired in favor of the newer non-billable project line items, the report lost its usefulness and would not display any of the new information.  If we ever want to add additional projects to this report, it should just be a matter of including the project ID with the newly defined constant.