### PR TITLE
Minor grammatical/stylistic edits

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -7,9 +7,9 @@
 authentication.
 
 During development, a ["fake" cloud.gov UAA server][fakeUAA] is used for
-authentication. Here you can actually enter any email address; if the
+authentication. Here, you can enter any email address. If the
 address is `@gsa.gov`, then a non-staff account will automatically
-be created for the user and you'll be logged-in, but otherwise access
+be created for that user. They'll be logged in, but otherwise their access
 will be denied.
 
 The easiest way to create an administrative user is to follow the instructions
@@ -19,7 +19,7 @@ Development](local-development.md#getting-started-with-local-tock-development).
 [UAA]: https://cloud.gov/docs/apps/leveraging-authentication/
 [fakeUAA]: http://cg-django-uaa.readthedocs.io/en/latest/quickstart.html#using-the-fake-cloud-gov-server
 
-### Creating UAA Clients for Tock
+### Creating UAA clients for Tock
 
 Tock leverages [UAA authentication provided by cloud.gov][cg-uaa-auth] to
 authenticate users. This document talks about how to create and rotate these UAA
@@ -31,14 +31,14 @@ clients using the [cf-cli][]. The following documentation assumes you are
 
 #### Creating a UAA client
 
-Go read the [cloud.gov identity provider documentation][cg-uaa-auth] to learn
+We encourage you to read the [cloud.gov identity provider documentation][cg-uaa-auth] to learn
 about creating the oAuth client. The Tock application only requires the `openid`
 scope for the oAuth client.
 
-Tock uses the following naming convention for oAuth clients Service Instances
-and Service Keys.
+Tock uses the following naming convention for oAuth clients' Service Instances
+and Service Keys:
 
-##### Production oAuth client Service Name Example
+##### Production oAuth client Service Name example
 
 ```shell
 ${APP_NAME}-${SERVICE_PLAN_NAME}
@@ -46,7 +46,7 @@ ${APP_NAME}-${SERVICE_PLAN_NAME}
 
 For instance, the Production oAuth client Service is called `tock-oauth-client`.
 
-##### Production oAuth client Service Key Example
+##### Production oAuth client Service Key example
 
 ```shell
 ${APP_NAME}-${SERVICE_PLAN_NAME}-${YEARMONTHDAY}
@@ -57,12 +57,12 @@ For instance, the Production oAuth client Service Key is called
 
 [cg-uaa-auth]: https://cloud.gov/docs/services/cloud-gov-identity-provider/
 
-#### Setting the Redirect URI
+#### Setting the redirect URI
 
 The redirect URI for Tock is whatever the URL is for the application with a path
-of `/auth/callback`
+of `/auth/callback`.
 
-##### Production Redirect URI Example
+##### Production redirect URI example
 
 ```shell
 # ...


### PR DESCRIPTION
A few minor grammatical/stylistic edits to the Authentication page. Note: For all of this documentation, I'm keeping main page titles in title case, subheads in sentence case.

