### PR TITLE
Contextual copy + punctuation updates

### DIFF
--- a/docs/offboarding.md
+++ b/docs/offboarding.md
@@ -4,19 +4,17 @@
 
 ## Offboarding
 
-When you leave the Tock team, these checklist items will be completed either by
-remaining Tock Developers or the Tock System Owner on the team. For some of the
-more technical items, a Tock Developer must perform them.
+When you leave the Tock team, the remaining Tock developers or your team's Tock system owner will complete the following checklist items. (**Note**: Some of the more technical items must be completed by a Tock developer.)
 
 ## Checklist
 
-[Create a new issue](https://github.com/18f/tock/issues/new) with the following
-checklist. Swapping out {TockDeveloper} with the name of the offboarding developer.
+To offboard a team member, [create a new issue](https://github.com/18f/tock/issues/new) with the following
+checklist. Replace {TockDeveloper} with the name of the offboarding developer.
 
-- [ ] {TockDeveloper} no longer has access to New Relic
+- [ ] {TockDeveloper} no longer has access to New Relic.
 - [ ] {TockDeveloper} no longer has access to SpaceDeveloper roles in Cloud
   Foundry for spaces `staging` and `prod`.
-- [ ] Rotating of secrets {TockDeveloper} had access to
-  - [ ] Rotation of cloud.gov service provider Service Keys
-  - [ ] Rotating of cloud.gov identity provider Service Keys
-  - [ ] Rotation of New Relic API key
+- [ ] Rotating of secrets {TockDeveloper} had access to:
+  - [ ] Rotation of cloud.gov service provider Service Keys.
+  - [ ] Rotation of cloud.gov identity provider Service Keys.
+  - [ ] Rotation of New Relic API key.


### PR DESCRIPTION
Standardizing punctuation within the checklist + adding one little bit to the contextual copy preceding the checklist.
