### PR TITLE
[wip] Initial draft for Alert markdown extension

### DIFF
--- a/tock/markdown_extensions/add_alert_header_class.py
+++ b/tock/markdown_extensions/add_alert_header_class.py
@@ -1,0 +1,8 @@
+import re
+
+
+def set_alert_heading_class(self, element):
+    for child in element:
+        if re.search('h\d', child.tag, re.IGNORECASE):
+            child.set('class', 'usa-alert-heading')
+        set_alert_heading_class(child)

--- a/tock/markdown_extensions/alerts.py
+++ b/tock/markdown_extensions/alerts.py
@@ -1,0 +1,5 @@
+from markdown.extensions import Extension
+
+
+class AlertExtensions(Extension):
+


### PR DESCRIPTION
This PR is to be merged onto #808. This work adds an extension for the Markdown library to allow for class on heading elements to contain the `usa-alert-heading` class in order to render properly in the `<div class="usa-alert-body">`.