### PR TITLE
Terminate all UAA sessions at the server level

### DIFF
--- a/tock/tock/settings/base.py
+++ b/tock/tock/settings/base.py
@@ -121,5 +121,6 @@ UAA_CLIENT_ID = env.get_credential('UAA_CLIENT_ID', None)
 UAA_CLIENT_SECRET = env.get_credential('UAA_CLIENT_SECRET', None)
 UAA_AUTH_URL = 'https://login.fr.cloud.gov/oauth/authorize'
 UAA_TOKEN_URL = 'https://uaa.fr.cloud.gov/oauth/token'
+UAA_LOGOUT_URL = 'https://login.fr.cloud.gov/logout.do'
 
 TOCK_CHANGE_REQUEST_FORM = 'https://docs.google.com/a/gsa.gov/forms/d/1EpVTxXgRNgYfoSA2J8Oi-csjhFKqFm5DT542vIlahpU/viewform?edit_requested=true'

--- a/tock/tock/signals.py
+++ b/tock/tock/signals.py
@@ -12,7 +12,7 @@ def successful_login(sender, request, user, **kwargs):
 
 
 def successful_logout(sender, request, user, **kwargs):
-    logger.info(f'Successful logout event for {user.username}.')
+    logger.info(f'Successful logout event for {user}.')
 
 
 def failed_login(sender, credentials, request, **kwargs):

--- a/tock/tock/tests/test_views.py
+++ b/tock/tock/tests/test_views.py
@@ -1,3 +1,5 @@
+import urllib.parse
+from django.conf import settings
 from django.test import TestCase
 from django.contrib.auth.models import User
 
@@ -7,6 +9,18 @@ class ViewsTests(TestCase):
         user = User.objects.create_user(username='foo')
         self.client.force_login(user)
 
+        uaa_redirect_url = settings.UAA_LOGOUT_URL
+        uaa_redirect_url += '?'
+        uaa_redirect_url += urllib.parse.urlencode({
+            'redirect': 'http://testserver/logout',
+            'client_id': settings.UAA_CLIENT_ID,
+        })
+
+        self.assertFalse(self.client.session.is_empty())
         response = self.client.get('/logout')
-        self.assertEqual(response.status_code, 302)
-        self.assertFalse(response.context['user'].is_authenticated())
+        self.assertRedirects(
+            response,
+            uaa_redirect_url,
+            fetch_redirect_response=False
+        )
+        self.assertTrue(self.client.session.is_empty())

--- a/tock/tock/tests/test_views.py
+++ b/tock/tock/tests/test_views.py
@@ -8,5 +8,5 @@ class ViewsTests(TestCase):
         self.client.force_login(user)
 
         response = self.client.get('/logout')
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 302)
         self.assertFalse(response.context['user'].is_authenticated())

--- a/tock/tock/views.py
+++ b/tock/tock/views.py
@@ -1,6 +1,8 @@
 import logging
+import urllib.parse
 
-from django.shortcuts import render
+from django.shortcuts import render, redirect
+from django.conf import settings
 import django.contrib.auth
 
 logger = logging.getLogger('tock')
@@ -18,8 +20,18 @@ def csrf_failure(request, reason=""):
 
 
 def logout(request):
-    django.contrib.auth.logout(request)
-    return render(request, 'logout.html')
+    if request.user.is_authenticated():
+        django.contrib.auth.logout(request)
+        tock_logout_url = request.build_absolute_uri('logout')
+        params = urllib.parse.urlencode({
+            'redirect': tock_logout_url,
+            'client_id': settings.UAA_CLIENT_ID,
+        })
+        return redirect(
+            f'{settings.UAA_LOGOUT_URL}?{params}'
+        )
+    else:
+        return render(request, 'logout.html')
 
 
 # TODO: new function signature for Django 2.0


### PR DESCRIPTION
This addresses #810 with the following solution.

```
If the user is authenticated
  Clear Django user session
  Redirect to UAA server with Client ID and Redirect parameters
  Redirect to application logout page
If the user isn't authenticated
  Show the application logout page
```