### PR TITLE
Raise PermissionDenied for inactive user accounts

### DIFF
--- a/tock/tock/templates/403.html
+++ b/tock/tock/templates/403.html
@@ -2,5 +2,11 @@
 
 {% block content %}
     <h2>You don't have permission to view this information.</h2>
-    <p>If you need access, please contact your supervisor.</p>
+    <p>
+    {% if exception %}
+        {{exception}}
+    {% else %}
+        If you need access, please contact your supervisor.
+    {% endif %}
+    </p>
 {% endblock %}

--- a/tock/tock/tests/test_remote_user_auth.py
+++ b/tock/tock/tests/test_remote_user_auth.py
@@ -1,12 +1,12 @@
 import datetime
 
 from django.contrib.auth.models import User
-from django.core.exceptions import ValidationError
+from django.core.exceptions import PermissionDenied, ValidationError
 
 from django_webtest import WebTest
-
-from ..remote_user_auth import email_to_username, TockUserBackend
 from employees.models import UserData
+
+from ..remote_user_auth import TockUserBackend, email_to_username
 
 
 class AuthTests(WebTest):
@@ -56,3 +56,14 @@ class AuthTests(WebTest):
         self._login(email)
         user = User.objects.filter(username='tock.tock').first()
         self.assertTrue(hasattr(user, 'user_data'))
+
+    def test_user_can_authenticate_permissiondenied(self):
+        """Users cannot authenticate if their account is inactive"""
+        user = User(is_active=False)
+        with self.assertRaises(PermissionDenied):
+            TockUserBackend().user_can_authenticate(user)
+
+    def test_user_can_authenticate(self):
+        """Active users can authenticate"""
+        user = User(is_active=True)
+        self.assertTrue(TockUserBackend().user_can_authenticate(user))

--- a/tock/tock/tests/test_views.py
+++ b/tock/tock/tests/test_views.py
@@ -1,7 +1,10 @@
 import urllib.parse
+
 from django.conf import settings
-from django.test import TestCase
 from django.contrib.auth.models import User
+from django.test import TestCase
+
+from tock.remote_user_auth import ACCOUNT_INACTIVE_MSG
 
 
 class ViewsTests(TestCase):
@@ -24,3 +27,10 @@ class ViewsTests(TestCase):
             fetch_redirect_response=False
         )
         self.assertTrue(self.client.session.is_empty())
+
+    def test_inactive_user_denied(self):
+        """Inactive users cannot access Tock"""
+        user = User.objects.create_user(username='foo', is_active=False)
+        self.client.force_login(user)
+        r = self.client.get('/')
+        self.assertContains(r, ACCOUNT_INACTIVE_MSG, status_code=403)

--- a/tock/tock/views.py
+++ b/tock/tock/views.py
@@ -1,9 +1,9 @@
 import logging
 import urllib.parse
 
-from django.shortcuts import render, redirect
-from django.conf import settings
 import django.contrib.auth
+from django.conf import settings
+from django.shortcuts import redirect, render
 
 logger = logging.getLogger('tock')
 
@@ -48,11 +48,11 @@ def handler400(request):
 
 # TODO: new function signature for Django 2.0
 # def handler403(request, exception, template_name='403.html'):
-def handler403(request):
+def handler403(request, exception):
     response = render(
         request,
         '403.html',
-        {}
+        {'exception': exception}
     )
     response.status_code = 403
     return response


### PR DESCRIPTION

## Description

For #825, deny access by and provide a help message to users with inactive accounts.

## Additional information

Prevents inactive users from completing authentication w/ tock backend. 
