### PR TITLE
Provide static app for maintenance mode

### DIFF
--- a/docs/deployment-process.md
+++ b/docs/deployment-process.md
@@ -159,7 +159,7 @@ cf zero-downtime-push tock-staging -f manifest-staging.yml
 
 Production deploys are also automated. They rely on the creation of a Git tag to
 be made against the `master` branch following the [_Automated Releases to
-Production_](#automated-releases-to-production) workflow. 
+Production_](#automated-releases-to-production) workflow.
 
 In some cases, you may need to make a manual deployment to production. If this is the case, please make
 sure you're using the Cloud Foundry [autopilot plugin](https://github.com/contraband/autopilot).
@@ -311,3 +311,27 @@ number after the period (e.g., `v20180131.1` turns into `v20180131.2`).
 Once you push this tag up to GitHub, draft or assign it to an already
 drafted release in GitHub. CircleCI will deploy this tag to the Production
 instance of Tock using CF Autopilot.
+
+
+## Maintenance Mode
+A simple static application exists to display a maintenance
+page if/when Tock needs to be taken offline.
+
+To show the maintenance page you will need to manually map Tock's production
+route to this application.
+```sh
+cf target -o gsa-18f-tock -s prod
+cf map-route tock-maintenance tock.18f.gov
+```
+
+Upon a new automatic release, the production route will be mapped back to the production app.
+
+To manually re-map the route and exit "maintenance mode":
+```sh
+cf target -o gsa-18f-tock -s prod
+cf map-route tock tock.18f.gov
+```
+To deploy this static application:
+
+1. `cd` into ./tock/maintenance_page/
+2. run `cf push`

--- a/tock/maintenance_page/index.html
+++ b/tock/maintenance_page/index.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+  <head>
+    <title>Tock - Down for Maintenance</title>
+    <body>
+      <p>Tock is down for scheduled maintenance and will be back shortly.</p>
+      <p>Visit us in the #tock-dev Slack channel for updates.</p>
+    </body>
+</html>

--- a/tock/maintenance_page/manifest.yml
+++ b/tock/maintenance_page/manifest.yml
@@ -1,0 +1,8 @@
+---
+applications:
+- name: tock-maintenance
+  buildpack: staticfile_buildpack
+  stack: cflinuxfs2
+  memory: 64M
+  disk_quota: 64M
+  instances: 1


### PR DESCRIPTION
## Description

For #806, providing a simple static app, `tock-maintenance` , to be deployed in the `prod` space which displays a barebones page for maintenance mode.

## Additional information

Maintenance mode will need to be enabled manually by re-mapping the production route to this static app. Disabling maintenance mode will be done by an automatic release which maps the production route or again manually.

Displayed maintenance page:
<img width="509" alt="screen shot 2018-10-02 at 1 10 20 pm" src="https://user-images.githubusercontent.com/3485564/46364695-8c605780-c644-11e8-887a-f017b835a7ee.png">


