### PR TITLE
Issue 680: Fix FY reports to only include specific years

### DIFF
--- a/tock/api/tests.py
+++ b/tock/api/tests.py
@@ -121,6 +121,23 @@ class TimecardsAPITests(WebTest):
                                  params={'project': '22'})
         self.assertEqual(len(queryset), 0)
 
+        # Check with before param
+        queryset = get_timecards(TimecardList.queryset,
+                                 params={'before': '2015-06-01'})
+        self.assertEqual(len(queryset), 1)
+        queryset = get_timecards(TimecardList.queryset,
+                                 params={'before': '2015-05-31'})
+        self.assertEqual(len(queryset), 0)
+
+        # Check with a range using before and after param
+        queryset = get_timecards(TimecardList.queryset,
+                                 params={'after': '2015-06-01', 'before': '2016-05-31'})
+        self.assertEqual(len(queryset), 1)
+        queryset = get_timecards(TimecardList.queryset,
+                                 params={'after': '2015-06-01', 'before': '2016-06-01'})
+        self.assertEqual(len(queryset), 2)
+
+
     def test_get_unsubmitted_timecards(self):
         """ Check that get time cards returns the correct queryset """
         queryset = get_timecards(

--- a/tock/api/views.py
+++ b/tock/api/views.py
@@ -250,6 +250,13 @@ def get_timecards(queryset, params=None):
             project__accounting_code__billable=billable
         )
 
+    if 'before' in params:
+        # get everything before a specified date
+        before_date = params.get('before')
+        queryset = queryset.filter(
+            timecard__reporting_period__start_date__lte=before_date
+        )
+
     return queryset
 
 

--- a/tock/hours/models.py
+++ b/tock/hours/models.py
@@ -179,13 +179,13 @@ class ReportingPeriod(ValidateOnSaveMixin, models.Model):
             # this week belongs to this fiscal year
             # so the Sunday is the start of the fiscal year
             # i.e. if Tuesday, this will subtract 2 days to get the Sunday date
-            return first_date - datetime.timedelta(days=normalized_weekday)
+            return first_date - datetime.timedelta(days = normalized_weekday)
         else:
             # this week belongs to previous fiscal year
             # so the coming Sunday is the start of the fiscal year
             # i.e. if Thursday, this will add 7 - 4 days (3 days) to get the
             # Sunday date
-            return first_date + datetime.timedelta(days=7-normalized_weekday)
+            return first_date + datetime.timedelta(days = 7 - normalized_weekday)
 
     @staticmethod
     def get_fiscal_year_end_date(fiscal_year):
@@ -210,13 +210,13 @@ class ReportingPeriod(ValidateOnSaveMixin, models.Model):
             # so the Saturday before is the end of the fiscal year
             # i.e. if Tuesday, this will subtract 2+1 = 3 days to get the Saturday
             # date
-            return last_date - datetime.timedelta(days=normalized_weekday + 1)
+            return last_date - datetime.timedelta(days = normalized_weekday + 1)
         else:
             # this week belongs to this fiscal year
             # so the coming Saturday is the end of the fiscal year
             # i.e. if Thursday, this will add 6 - 4 days (2 days) to get the
             # Saturday date
-            return last_date + datetime.timedelta(days=6-normalized_weekday)
+            return last_date + datetime.timedelta(days = 6 - normalized_weekday)
 
     @staticmethod
     def get_fiscal_year_from_date(date):

--- a/tock/hours/models.py
+++ b/tock/hours/models.py
@@ -138,7 +138,7 @@ class ReportingPeriod(ValidateOnSaveMixin, models.Model):
         return 'Message Enabled'
 
     def get_fiscal_year(self):
-        """Determines the Fiscal Year (Oct 1 - Sept 31) of a given
+        """Determines the Fiscal Year (Oct 1 - Sept 30) of a given
             ReportingPeriod. Oct, Nov, Dec are part of the *next* FY """
         next_calendar_year_months = [10, 11, 12]
         if self.start_date.month in next_calendar_year_months:

--- a/tock/hours/tests/test_models.py
+++ b/tock/hours/tests/test_models.py
@@ -83,6 +83,40 @@ class ReportingPeriodTests(TestCase):
             exact_working_hours=32)
         self.assertEqual(2016, reporting_period_2.get_fiscal_year())
 
+        # Testing the week that spans two FYs
+        reporting_period_3 = ReportingPeriod(
+            start_date=datetime.date(2014, 9, 28),
+            end_date=datetime.date(2014, 10, 4),
+            exact_working_hours=32)
+        self.assertEqual(2015, reporting_period_3.get_fiscal_year())
+        reporting_period_4 = ReportingPeriod(
+            start_date=datetime.date(2015, 9, 27),
+            end_date=datetime.date(2015, 10, 3),
+            exact_working_hours=32)
+        self.assertEqual(2015, reporting_period_4.get_fiscal_year())
+
+    def test_get_fiscal_year_start_date(self):
+        # test more October date than September date
+        self.assertEqual(datetime.date(2014, 9, 28),
+            ReportingPeriod.get_fiscal_year_start_date(2015))
+        # test more September date than October date
+        self.assertEqual(datetime.date(2015, 10, 4),
+            ReportingPeriod.get_fiscal_year_start_date(2016))
+        # test fiscal year starts right on 10/1
+        self.assertEqual(datetime.date(2017, 10, 1),
+            ReportingPeriod.get_fiscal_year_start_date(2018))
+
+    def test_get_fiscal_year_end_date(self):
+        # test more October date than September date
+        self.assertEqual(datetime.date(2014, 9, 27),
+            ReportingPeriod.get_fiscal_year_end_date(2014))
+        # test more September date than October date
+        self.assertEqual(datetime.date(2015, 10, 3),
+            ReportingPeriod.get_fiscal_year_end_date(2015))
+        # test fiscal year ends right on 9/30
+        self.assertEqual(datetime.date(2017, 9, 30),
+            ReportingPeriod.get_fiscal_year_end_date(2017))
+
 
 class TimecardTests(TestCase):
     fixtures = [

--- a/tock/hours/tests/test_views.py
+++ b/tock/hours/tests/test_views.py
@@ -610,6 +610,15 @@ class ReportTests(WebTest):
         response = response.content.decode('utf-8')
         self.assertTrue(response.index('2016') < response.index('2015'))
 
+    def test_ReportList_get_context_data(self):
+        response = self.app.get(reverse('reports:ListReports'), user=self.user)
+        act_fiscal_years = response.context['fiscal_years']
+        self.assertNotEqual(0, act_fiscal_years)
+        # check at least first item
+        self.assertEqual({'year': 2017,
+            'start_date': datetime.date(2016, 10, 2),
+            'end_date': datetime.date(2017, 9, 30)}, act_fiscal_years[0])
+
     def test_report_list_authenticated(self):
         """ Check that main page loads with reporting periods for authenticated
         user with with userdata """

--- a/tock/hours/views.py
+++ b/tock/hours/views.py
@@ -943,12 +943,21 @@ class ReportsList(PermissionMixin, ListView):
         sorted_fiscal_years = sorted(fiscal_years.items(), reverse=True)
         return sorted_fiscal_years
 
+
     def get_context_data(self, **kwargs):
         # Call the base implementation first to get a context
         context = super().get_context_data(**kwargs)
+        # Get today's date to figure out the fiscal year it is in
         today = localdate()
-        year = today.year + 2 if today.month >= 10 else today.year + 1
-        context['fiscal_years'] = range(2017, year)
+        # The year will be used to determine which year reporting to end with
+        year = ReportingPeriod.get_fiscal_year_from_date(today)
+        context['fiscal_years'] = []
+        for year in range(2017, year + 1):
+            year_dates = dict()
+            year_dates['year'] = year
+            year_dates['start_date'] = ReportingPeriod.get_fiscal_year_start_date(year)
+            year_dates['end_date'] = ReportingPeriod.get_fiscal_year_end_date(year)
+            context['fiscal_years'].append(year_dates)
 
         return context
 

--- a/tock/hours/views.py
+++ b/tock/hours/views.py
@@ -13,6 +13,7 @@ from django.db.models import Sum
 from django.http import Http404, HttpResponse
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
+from django.utils.timezone import localdate
 from django.views.generic import DetailView, ListView, TemplateView
 from django.views.generic.edit import CreateView, FormView, UpdateView
 from rest_framework import serializers
@@ -942,6 +943,14 @@ class ReportsList(PermissionMixin, ListView):
         sorted_fiscal_years = sorted(fiscal_years.items(), reverse=True)
         return sorted_fiscal_years
 
+    def get_context_data(self, **kwargs):
+        # Call the base implementation first to get a context
+        context = super().get_context_data(**kwargs)
+        today = localdate()
+        year = today.year + 2 if today.month >= 10 else today.year + 1
+        context['fiscal_years'] = range(2017, year)
+
+        return context
 
 class ReportingPeriodDetailView(PermissionMixin, ListView):
     template_name = 'hours/reporting_period_detail.html'

--- a/tock/hours/views.py
+++ b/tock/hours/views.py
@@ -951,9 +951,9 @@ class ReportsList(PermissionMixin, ListView):
         today = localdate()
         # The year will be used to determine which year reporting to end with
         year = ReportingPeriod.get_fiscal_year_from_date(today)
-        context['fiscal_years'] = [ 
+        context['fiscal_years'] = [
             {
-                'year': fy, 
+                'year': fy,
                 'start_date': ReportingPeriod.get_fiscal_year_start_date(fy),
                 'end_date': ReportingPeriod.get_fiscal_year_end_date(fy)
             } for fy in range(2017, year + 1)

--- a/tock/hours/views.py
+++ b/tock/hours/views.py
@@ -951,13 +951,13 @@ class ReportsList(PermissionMixin, ListView):
         today = localdate()
         # The year will be used to determine which year reporting to end with
         year = ReportingPeriod.get_fiscal_year_from_date(today)
-        context['fiscal_years'] = []
-        for year in range(2017, year + 1):
-            year_dates = dict()
-            year_dates['year'] = year
-            year_dates['start_date'] = ReportingPeriod.get_fiscal_year_start_date(year)
-            year_dates['end_date'] = ReportingPeriod.get_fiscal_year_end_date(year)
-            context['fiscal_years'].append(year_dates)
+        context['fiscal_years'] = [ 
+            {
+                'year': fy, 
+                'start_date': ReportingPeriod.get_fiscal_year_start_date(fy),
+                'end_date': ReportingPeriod.get_fiscal_year_end_date(fy)
+            } for fy in range(2017, year + 1)
+        ]
 
         return context
 

--- a/tock/tock/templates/hours/reporting_period_detail.html
+++ b/tock/tock/templates/hours/reporting_period_detail.html
@@ -19,6 +19,7 @@
       <th>First Name</th>
       <th>Last Name</th>
       <th>Email</th>
+      <th>Organization</th>
     </tr>
   </thead>
   <tbody>
@@ -27,6 +28,7 @@
       <td data-title="First name">{{ user.first_name }}</td>
       <td data-title="Last name">{{ user.last_name }}</td>
       <td><a href="mailto:{{ user.email }}">{{ user.email }}</td>
+      <td data-title="Organization">{{ user.organization_name }}</td>
     </tr>
   {% endfor %}
   </tbody>

--- a/tock/tock/templates/hours/reports_list.html
+++ b/tock/tock/templates/hours/reports_list.html
@@ -10,31 +10,35 @@
 	<div class="usa-width-one-half">
 		<h2>Regular Reports</h2>
 	<ul>
-
 		<li>Complete timecard data:
 			<a href="{% url 'reports:BulkTimecardList' %}">All</a>
-			<a href="{% url 'reports:BulkTimecardList' %}?after=2016-10-02&before=2017-10-01">FY2017</a>
-            <a href="{% url 'reports:BulkTimecardList' %}?after=2017-10-01&before=2018-09-30">FY2018</a>
+			{% for year in fiscal_years %}
+				<a href="{% url 'reports:BulkTimecardList' %}?after{{ year|add:"-1" }}-10-01&before={{ year }}-09-30">FY{{ year }}</a>
+			{% endfor %}
 		</li>
 		<li>Complete timecard data with fewer fields:
 			<a href="{% url 'reports:SlimBulkTimecardList' %}">All</a>
-			<a href="{% url 'reports:SlimBulkTimecardList' %}?after=2016-10-02&before=2017-10-01">FY2017</a>
-            <a href="{% url 'reports:SlimBulkTimecardList' %}?after=2017-10-01&before=2018-09-30">FY2018</a>
+			{% for year in fiscal_years %}
+				<a href="{% url 'reports:SlimBulkTimecardList' %}?after{{ year|add:"-1" }}-10-01&before={{ year }}-09-30">FY{{ year }}</a>
+			{% endfor %}
 		</li>
 		<li>Complete snippet data for '18F Non-Billable':
 				<a href="{% url 'reports:GeneralSnippetsView' %}">All</a>
-				<a href="{% url 'reports:GeneralSnippetsView' %}?after=2016-10-02&before=2017-10-01">FY2017</a>
-                <a href="{% url 'reports:GeneralSnippetsView' %}?after=2017-10-01&before=2018-09-30">FY2018</a>
+			{% for year in fiscal_years %}
+				<a href="{% url 'reports:GeneralSnippetsView' %}?after{{ year|add:"-1" }}-10-01&before={{ year }}-09-30">FY{{ year }}</a>
+			{% endfor %}
 		</li>
 		<li>Aggregate hourly data by project and reporting period:
 			<a href="{% url 'reports:ProjectTimelineView' %}">All</a>
-			<a href="{% url 'reports:ProjectTimelineView' %}?after=2016-10-02&before=2017-10-01">FY2017</a>
-            <a href="{% url 'reports:ProjectTimelineView' %}?after=2017-10-01&before=2018-09-30">FY2018</a>
+			{% for year in fiscal_years %}
+				<a href="{% url 'reports:ProjectTimelineView' %}?after{{ year|add:"-1" }}-10-01&before={{ year }}-09-30">FY{{ year }}</a>
+			{% endfor %}
 		</li>
 		<li>Aggregate hourly data by user, reporting period, and project billable status:
 			<a href="{% url 'reports:UserTimelineView' %}">All</a>
-			<a href="{% url 'reports:UserTimelineView' %}?after=2016-10-02&before=2017-10-01">FY2017</a>
-            <a href="{% url 'reports:UserTimelineView' %}?after=2017-10-01&before=2018-09-30">FY2018</a>
+			{% for year in fiscal_years %}
+				<a href="{% url 'reports:UserTimelineView' %}?after{{ year|add:"-1" }}-10-01&before={{ year }}-09-30">FY{{ year }}</a>
+			{% endfor %}
 		</li>
 		<li><a href="{% url 'reports:ProjectList' %}">Download list of all projects</a></li>
 		<li><a href="{% url 'reports:UserDataView' %}">Download list of all users</a></li>
@@ -47,8 +51,9 @@
     <h2 class="usa-alert-heading">Superuser Reports</h2>
     <p class="usa-alert-text">Complete timecard data with grade info:<br>
 				<a href="{% url 'reports:AdminBulkTimecardList' %}">All</a>
-				<a href="{% url 'reports:AdminBulkTimecardList' %}?after=2016-10-01&before=2017-09-30">FY2017</a>
-                <a href="{% url 'reports:AdminBulkTimecardList' %}?after=2017-10-01&before=2018-09-30">FY2018</a></p>
+				{% for year in fiscal_years %}
+					<a href="{% url 'reports:AdminBulkTimecardList' %}?after{{ year|add:"-1" }}-10-01&before={{ year }}-09-30">FY{{ year }}</a>
+				{% endfor %}
   </div>
 </div>
 

--- a/tock/tock/templates/hours/reports_list.html
+++ b/tock/tock/templates/hours/reports_list.html
@@ -12,32 +12,32 @@
 	<ul>
 		<li>Complete timecard data:
 			<a href="{% url 'reports:BulkTimecardList' %}">All</a>
-			{% for year in fiscal_years %}
-				<a href="{% url 'reports:BulkTimecardList' %}?after{{ year|add:"-1" }}-10-01&before={{ year }}-09-30">FY{{ year }}</a>
+			{% for fy in fiscal_years %}
+				<a href="{% url 'reports:BulkTimecardList' %}?after={{ fy.start_date|date:'Y-m-d' }}&before={{ fy.end_date|date:'Y-m-d' }}">FY{{ fy.year }}</a>
 			{% endfor %}
 		</li>
 		<li>Complete timecard data with fewer fields:
 			<a href="{% url 'reports:SlimBulkTimecardList' %}">All</a>
-			{% for year in fiscal_years %}
-				<a href="{% url 'reports:SlimBulkTimecardList' %}?after{{ year|add:"-1" }}-10-01&before={{ year }}-09-30">FY{{ year }}</a>
+			{% for fy in fiscal_years %}
+				<a href="{% url 'reports:SlimBulkTimecardList' %}?after={{ fy.start_date|date:'Y-m-d' }}&before={{ fy.end_date|date:'Y-m-d' }}">FY{{ fy.year }}</a>
 			{% endfor %}
 		</li>
 		<li>Complete snippet data for '18F Non-Billable':
 				<a href="{% url 'reports:GeneralSnippetsView' %}">All</a>
-			{% for year in fiscal_years %}
-				<a href="{% url 'reports:GeneralSnippetsView' %}?after{{ year|add:"-1" }}-10-01&before={{ year }}-09-30">FY{{ year }}</a>
+			{% for fy in fiscal_years %}
+				<a href="{% url 'reports:GeneralSnippetsView' %}?after={{ fy.start_date|date:'Y-m-d' }}&before={{ fy.end_date|date:'Y-m-d' }}">FY{{ fy.year }}</a>
 			{% endfor %}
 		</li>
 		<li>Aggregate hourly data by project and reporting period:
 			<a href="{% url 'reports:ProjectTimelineView' %}">All</a>
-			{% for year in fiscal_years %}
-				<a href="{% url 'reports:ProjectTimelineView' %}?after{{ year|add:"-1" }}-10-01&before={{ year }}-09-30">FY{{ year }}</a>
+			{% for fy in fiscal_years %}
+				<a href="{% url 'reports:ProjectTimelineView' %}?after={{ fy.start_date|date:'Y-m-d' }}&before={{ fy.end_date|date:'Y-m-d' }}">FY{{ fy.year }}</a>
 			{% endfor %}
 		</li>
 		<li>Aggregate hourly data by user, reporting period, and project billable status:
 			<a href="{% url 'reports:UserTimelineView' %}">All</a>
-			{% for year in fiscal_years %}
-				<a href="{% url 'reports:UserTimelineView' %}?after{{ year|add:"-1" }}-10-01&before={{ year }}-09-30">FY{{ year }}</a>
+			{% for fy in fiscal_years %}
+				<a href="{% url 'reports:UserTimelineView' %}?after={{ fy.start_date|date:'Y-m-d' }}&before={{ fy.end_date|date:'Y-m-d' }}">FY{{ fy.year }}</a>
 			{% endfor %}
 		</li>
 		<li><a href="{% url 'reports:ProjectList' %}">Download list of all projects</a></li>
@@ -51,8 +51,8 @@
     <h2 class="usa-alert-heading">Superuser Reports</h2>
     <p class="usa-alert-text">Complete timecard data with grade info:<br>
 				<a href="{% url 'reports:AdminBulkTimecardList' %}">All</a>
-				{% for year in fiscal_years %}
-					<a href="{% url 'reports:AdminBulkTimecardList' %}?after{{ year|add:"-1" }}-10-01&before={{ year }}-09-30">FY{{ year }}</a>
+				{% for fy in fiscal_years %}
+					<a href="{% url 'reports:AdminBulkTimecardList' %}?after={{ fy.start_date|date:'Y-m-d' }}&before={{ fy.end_date|date:'Y-m-d' }}">FY{{ fy.year }}</a>
 				{% endfor %}
   </div>
 </div>

--- a/tock/tock/templates/hours/reports_list.html
+++ b/tock/tock/templates/hours/reports_list.html
@@ -4,75 +4,75 @@
 {% endblock %}
 
 {% block content %}
-<h1>Tock Reports</h1>
-<!--TODO: use URLconf to link to the API URLs as opposed to hard coding. -->
-<div class="usa-grid">
-	<div class="usa-width-one-half">
-		<h2>Regular Reports</h2>
-	<ul>
-		<li>Complete timecard data:
-			<a href="{% url 'reports:BulkTimecardList' %}">All</a>
-			{% for fy in fiscal_years %}
-				<a href="{% url 'reports:BulkTimecardList' %}?after={{ fy.start_date|date:'Y-m-d' }}&before={{ fy.end_date|date:'Y-m-d' }}">FY{{ fy.year }}</a>
-			{% endfor %}
-		</li>
-		<li>Complete timecard data with fewer fields:
-			<a href="{% url 'reports:SlimBulkTimecardList' %}">All</a>
-			{% for fy in fiscal_years %}
-				<a href="{% url 'reports:SlimBulkTimecardList' %}?after={{ fy.start_date|date:'Y-m-d' }}&before={{ fy.end_date|date:'Y-m-d' }}">FY{{ fy.year }}</a>
-			{% endfor %}
-		</li>
-		<li>Complete snippet data for '18F Non-Billable':
-				<a href="{% url 'reports:GeneralSnippetsView' %}">All</a>
-			{% for fy in fiscal_years %}
-				<a href="{% url 'reports:GeneralSnippetsView' %}?after={{ fy.start_date|date:'Y-m-d' }}&before={{ fy.end_date|date:'Y-m-d' }}">FY{{ fy.year }}</a>
-			{% endfor %}
-		</li>
-		<li>Aggregate hourly data by project and reporting period:
-			<a href="{% url 'reports:ProjectTimelineView' %}">All</a>
-			{% for fy in fiscal_years %}
-				<a href="{% url 'reports:ProjectTimelineView' %}?after={{ fy.start_date|date:'Y-m-d' }}&before={{ fy.end_date|date:'Y-m-d' }}">FY{{ fy.year }}</a>
-			{% endfor %}
-		</li>
-		<li>Aggregate hourly data by user, reporting period, and project billable status:
-			<a href="{% url 'reports:UserTimelineView' %}">All</a>
-			{% for fy in fiscal_years %}
-				<a href="{% url 'reports:UserTimelineView' %}?after={{ fy.start_date|date:'Y-m-d' }}&before={{ fy.end_date|date:'Y-m-d' }}">FY{{ fy.year }}</a>
-			{% endfor %}
-		</li>
-		<li><a href="{% url 'reports:ProjectList' %}">Download list of all projects</a></li>
-		<li><a href="{% url 'reports:UserDataView' %}">Download list of all users</a></li>
-	</ul>
-	</div>
-	<div class="usa-width-one-half">
-		{% if user.is_superuser %}
-		<div class="usa-alert usa-alert-info">
-  <div class="usa-alert-body">
-    <h2 class="usa-alert-heading">Superuser Reports</h2>
-    <p class="usa-alert-text">Complete timecard data with grade info:<br>
-				<a href="{% url 'reports:AdminBulkTimecardList' %}">All</a>
-				{% for fy in fiscal_years %}
-					<a href="{% url 'reports:AdminBulkTimecardList' %}?after={{ fy.start_date|date:'Y-m-d' }}&before={{ fy.end_date|date:'Y-m-d' }}">FY{{ fy.year }}</a>
-				{% endfor %}
+  <h1>Tock Reports</h1>
+  <!--TODO: use URLconf to link to the API URLs as opposed to hard coding. -->
+  <div class="usa-grid">
+    <div class="usa-width-one-half">
+      <h2>Regular Reports</h2>
+      <ul>
+        <li>Complete timecard data:
+          <a href="{% url 'reports:BulkTimecardList' %}">All</a>
+          {% for fy in fiscal_years %}
+            <a href="{% url 'reports:BulkTimecardList' %}?after={{ fy.start_date|date:'Y-m-d' }}&before={{ fy.end_date|date:'Y-m-d' }}">FY{{ fy.year }}</a>
+          {% endfor %}
+        </li>
+        <li>Complete timecard data with fewer fields:
+          <a href="{% url 'reports:SlimBulkTimecardList' %}">All</a>
+          {% for fy in fiscal_years %}
+            <a href="{% url 'reports:SlimBulkTimecardList' %}?after={{ fy.start_date|date:'Y-m-d' }}&before={{ fy.end_date|date:'Y-m-d' }}">FY{{ fy.year }}</a>
+          {% endfor %}
+        </li>
+        <li>Complete snippet data for '18F Non-Billable':
+            <a href="{% url 'reports:GeneralSnippetsView' %}">All</a>
+          {% for fy in fiscal_years %}
+            <a href="{% url 'reports:GeneralSnippetsView' %}?after={{ fy.start_date|date:'Y-m-d' }}&before={{ fy.end_date|date:'Y-m-d' }}">FY{{ fy.year }}</a>
+          {% endfor %}
+        </li>
+        <li>Aggregate hourly data by project and reporting period:
+          <a href="{% url 'reports:ProjectTimelineView' %}">All</a>
+          {% for fy in fiscal_years %}
+            <a href="{% url 'reports:ProjectTimelineView' %}?after={{ fy.start_date|date:'Y-m-d' }}&before={{ fy.end_date|date:'Y-m-d' }}">FY{{ fy.year }}</a>
+          {% endfor %}
+        </li>
+        <li>Aggregate hourly data by user, reporting period, and project billable status:
+          <a href="{% url 'reports:UserTimelineView' %}">All</a>
+          {% for fy in fiscal_years %}
+            <a href="{% url 'reports:UserTimelineView' %}?after={{ fy.start_date|date:'Y-m-d' }}&before={{ fy.end_date|date:'Y-m-d' }}">FY{{ fy.year }}</a>
+          {% endfor %}
+        </li>
+        <li><a href="{% url 'reports:ProjectList' %}">Download list of all projects</a></li>
+        <li><a href="{% url 'reports:UserDataView' %}">Download list of all users</a></li>
+      </ul>
+    </div>
+    <div class="usa-width-one-half">
+    {% if user.is_superuser %}
+      <div class="usa-alert usa-alert-info">
+        <div class="usa-alert-body">
+        <h2 class="usa-alert-heading">Superuser Reports</h2>
+        <p class="usa-alert-text">Complete timecard data with grade info:</p>
+            <a href="{% url 'reports:AdminBulkTimecardList' %}">All</a>
+            {% for fy in fiscal_years %}
+              <a href="{% url 'reports:AdminBulkTimecardList' %}?after={{ fy.start_date|date:'Y-m-d' }}&before={{ fy.end_date|date:'Y-m-d' }}">FY{{ fy.year }}</a>
+            {% endfor %}
+        </div>
+      </div>
+
+    {% endif %}
+    </div>
   </div>
-</div>
-
-	{% endif %}
-	</div>
-</div>
 
 
 
 
-<div class="reporting-periods clearfix">
-	<h2>Reports by weekly reporting period</h2>
-	{% for fiscal_year, reporting_periods in object_list %}
-	<h3>Fiscal Year {{ fiscal_year }}</h3>
-	<ul>
-	{% for reporting_period in reporting_periods %}
-	    <li><a href="{% url 'reports:ReportingPeriodDetailView' reporting_period %}">{{ reporting_period.start_date | date:"F j, Y" }} to {{ reporting_period.end_date | date:"F j, Y" }}</a> (<em><a href="{% url 'reports:ReportingPeriodCSVView' reporting_period %}">CSV</a></em>)</li>
-	{% endfor %}
-	</ul>
-	{% endfor %}
-</div>
+  <div class="reporting-periods clearfix">
+    <h2>Reports by weekly reporting period</h2>
+    {% for fiscal_year, reporting_periods in object_list %}
+      <h3>Fiscal Year {{ fiscal_year }}</h3>
+      <ul>
+      {% for reporting_period in reporting_periods %}
+        <li><a href="{% url 'reports:ReportingPeriodDetailView' reporting_period %}">{{ reporting_period.start_date | date:"F j, Y" }} to {{ reporting_period.end_date | date:"F j, Y" }}</a> (<em><a href="{% url 'reports:ReportingPeriodCSVView' reporting_period %}">CSV</a></em>)</li>
+      {% endfor %}
+      </ul>
+    {% endfor %}
+  </div>
 {% endblock %}

--- a/tock/tock/templates/hours/reports_list.html
+++ b/tock/tock/templates/hours/reports_list.html
@@ -10,30 +10,31 @@
 	<div class="usa-width-one-half">
 		<h2>Regular Reports</h2>
 	<ul>
+
 		<li>Complete timecard data:
 			<a href="{% url 'reports:BulkTimecardList' %}">All</a>
-			<a href="{% url 'reports:BulkTimecardList' %}?after=2016-10-02">FY2017</a>
-            <a href="{% url 'reports:BulkTimecardList' %}?after=2017-10-01">FY2018</a>
+			<a href="{% url 'reports:BulkTimecardList' %}?after=2016-10-02&before=2017-10-01">FY2017</a>
+            <a href="{% url 'reports:BulkTimecardList' %}?after=2017-10-01&before=2018-09-30">FY2018</a>
 		</li>
 		<li>Complete timecard data with fewer fields:
 			<a href="{% url 'reports:SlimBulkTimecardList' %}">All</a>
-			<a href="{% url 'reports:SlimBulkTimecardList' %}?after=2016-10-02">FY2017</a>
-            <a href="{% url 'reports:SlimBulkTimecardList' %}?after=2017-10-01">FY2018</a>
+			<a href="{% url 'reports:SlimBulkTimecardList' %}?after=2016-10-02&before=2017-10-01">FY2017</a>
+            <a href="{% url 'reports:SlimBulkTimecardList' %}?after=2017-10-01&before=2018-09-30">FY2018</a>
 		</li>
 		<li>Complete snippet data for '18F Non-Billable':
 				<a href="{% url 'reports:GeneralSnippetsView' %}">All</a>
-				<a href="{% url 'reports:GeneralSnippetsView' %}?after=2016-10-02">FY2017</a>
-                <a href="{% url 'reports:GeneralSnippetsView' %}?after=2017-10-01">FY2018</a>
+				<a href="{% url 'reports:GeneralSnippetsView' %}?after=2016-10-02&before=2017-10-01">FY2017</a>
+                <a href="{% url 'reports:GeneralSnippetsView' %}?after=2017-10-01&before=2018-09-30">FY2018</a>
 		</li>
 		<li>Aggregate hourly data by project and reporting period:
 			<a href="{% url 'reports:ProjectTimelineView' %}">All</a>
-			<a href="{% url 'reports:ProjectTimelineView' %}?after=2016-10-02">FY2017</a>
-            <a href="{% url 'reports:ProjectTimelineView' %}?after=2017-10-01">FY2018</a>
+			<a href="{% url 'reports:ProjectTimelineView' %}?after=2016-10-02&before=2017-10-01">FY2017</a>
+            <a href="{% url 'reports:ProjectTimelineView' %}?after=2017-10-01&before=2018-09-30">FY2018</a>
 		</li>
 		<li>Aggregate hourly data by user, reporting period, and project billable status:
 			<a href="{% url 'reports:UserTimelineView' %}">All</a>
-			<a href="{% url 'reports:UserTimelineView' %}?after=2016-10-02">FY2017</a>
-            <a href="{% url 'reports:UserTimelineView' %}?after=2017-10-01">FY2018</a>
+			<a href="{% url 'reports:UserTimelineView' %}?after=2016-10-02&before=2017-10-01">FY2017</a>
+            <a href="{% url 'reports:UserTimelineView' %}?after=2017-10-01&before=2018-09-30">FY2018</a>
 		</li>
 		<li><a href="{% url 'reports:ProjectList' %}">Download list of all projects</a></li>
 		<li><a href="{% url 'reports:UserDataView' %}">Download list of all users</a></li>
@@ -46,8 +47,8 @@
     <h2 class="usa-alert-heading">Superuser Reports</h2>
     <p class="usa-alert-text">Complete timecard data with grade info:<br>
 				<a href="{% url 'reports:AdminBulkTimecardList' %}">All</a>
-				<a href="{% url 'reports:AdminBulkTimecardList' %}?after=2016-10-01">FY2017</a>
-                <a href="{% url 'reports:AdminBulkTimecardList' %}?after=2017-10-01">FY2018</a></p>
+				<a href="{% url 'reports:AdminBulkTimecardList' %}?after=2016-10-01&before=2017-09-30">FY2017</a>
+                <a href="{% url 'reports:AdminBulkTimecardList' %}?after=2017-10-01&before=2018-09-30">FY2018</a></p>
   </div>
 </div>
 


### PR DESCRIPTION
## Description

See Issue #680 

- [x] Added `before` parameter for `get_timecards` function to allow getting a list of timecards before and include a specific date.  This can now be used with `after` parameter to get a specific date range of timecards
- [x] Added corresponding tests for `before` parameter as well as using it in conjunction with `after parameter
- [x] Added `before` parameters to the current reports so it is filtered with a range
- [x] Iterate through fiscal years to create reports instead of hardcoding every single year
- [x] user.organization shows in the output table

I also added a few static methods to figure out the actual fiscal year start and end date based on the discussion I have with Jackie.
>During the week that spans two fiscal years, with the five work days, charging will happen to the year that has more days in it. So, if there are three or more September work days, the week will belong to the year September is in, else, if there are more October work days (three or more), this week will belong to the year October is in.

## Additional information

Include any of the following (as necessary):

* Relevant research and support documents
* Screenshot images
* Notes
  * ~~There seems to be an inconsistency with the date in the report for FY2016.  The superuser report starts with 10/1/2016, but other reports starts with 10/2/2016.  10/1/2016 is a Saturday so I am not sure if this is an exception or not for fiscal years.  I changed it back to FY starts on 10/1 and ends with 9/30 unless there are exceptions, please let me know.~~
  * I hardcoded "2017" as the first fiscal year for reporting because that was what's already there, if I should use something else, let me know.
