### PR TITLE
Round Total Hours sum to 2 decimal precision.

### DIFF
--- a/tock/tock/templates/hours/timecard_form.html
+++ b/tock/tock/templates/hours/timecard_form.html
@@ -164,7 +164,7 @@
 
       if (!is_checked) hoursTotal += ($(this).val() / 1);
     });
-    return {'hoursTotal': hoursTotal};
+    return {'hoursTotal': parseFloat(hoursTotal.toFixed(2))};
   }
 
   function populateHourTotals(){


### PR DESCRIPTION
Fixes #848.

We shouldn’t need anything more than 2 digits of decimal precision to calculate Total Hours. This fixes common floating point precision issues in JavaScript, most easily seen by adding `0.2 + 0.2 + 0.2` (which should result in `0.6`, as shown below, but results in `0.6000000000000001` without rounding.

![Screenshot showing 0.2 added three times results in 0.6](https://user-images.githubusercontent.com/14930/48491007-9e611880-e7f4-11e8-9a07-3fcd490f8445.png)

This is my first time contributing to a python project, so I’m unsure of how to write a test to cover this — let me know how, and I’d be more than happy to add (pun intended) one! 