### PR TITLE
Render user organizations on ReportDetail page

### DIFF
--- a/tock/hours/views.py
+++ b/tock/hours/views.py
@@ -991,6 +991,7 @@ class ReportingPeriodDetailView(PermissionMixin, ListView):
         ).select_related(
             'user',
             'reporting_period',
+            "user__user_data"
         ).distinct().order_by('user__last_name', 'user__first_name')
 
     def get_context_data(self, **kwargs):
@@ -1006,11 +1007,14 @@ class ReportingPeriodDetailView(PermissionMixin, ListView):
         filed_users = Timecard.objects.filter(
                 reporting_period=self.report_period,
                 submitted=True
-            ).distinct().values_list('user__id', flat=True)
+            ).select_related('user', 'reporting_period', "user__user_data") \
+            .distinct().values_list('user__id', flat=True)
+
         unfiled_users = get_user_model().objects \
             .exclude(user_data__start_date__gte=self.report_period.end_date) \
             .exclude(id__in=filed_users) \
             .filter(user_data__current_employee=True) \
+            .select_related('user_data') \
             .order_by('last_name', 'first_name')
 
         context.update({

--- a/tock/tock/templates/hours/reporting_period_detail.html
+++ b/tock/tock/templates/hours/reporting_period_detail.html
@@ -28,7 +28,7 @@
       <td data-title="First name">{{ user.first_name }}</td>
       <td data-title="Last name">{{ user.last_name }}</td>
       <td><a href="mailto:{{ user.email }}">{{ user.email }}</td>
-      <td data-title="Organization">{{ user.organization_name }}</td>
+      <td data-title="Organization">{{ user.user_data.organization_name }}</td>
     </tr>
   {% endfor %}
   </tbody>
@@ -44,6 +44,7 @@
       <th>First Name</th>
       <th>Last Name</th>
       <th>View Timecard</th>
+      <th>Organization</th>
     </tr>
   </thead>
   <tbody>
@@ -52,6 +53,7 @@
       <td data-title="First name">{{ timecard.user.first_name }}</td>
       <td data-title="Last name">{{ timecard.user.last_name }}</td>
       <td><a href="{% url 'reports:ReportingPeriodUserDetailView' reporting_period=timecard.reporting_period username=timecard.user.username %}">View Timecard</a></td>
+      <td data-title="Organization">{{ timecard.user.user_data.organization_name }}</td>
     </tr>
   {% endfor %}
   </tbody>


### PR DESCRIPTION
## Description

For #854, display the organization name of each user when rendered on the ReportDetails page.

Includes:
* An additional test to confirm presence of `Organization name` on the rendered ReportDetails template. 
* Minor refactoring to reduce number of db calls
* Modified existing tests to accommodate template changes 
