### PR TITLE
Only recycle based on tags instead of all branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,5 +182,7 @@ workflows:
     - schedule:
         cron: "0 10 * * *"  # Roughly 5am ET
         filters:
+          tags:
+            only: /v20[1-9][0-9][0-9]+\.[0-9]+/
           branches:
-            only: /.*/
+            ignore: /.*/


### PR DESCRIPTION
## Description

We're having an issue with #772 where it's consuming too many containers because it gets stuck. This tries to limit recycling production instances based on changes to the Tock release tag. So instead of running on all branches, it'll only target one tag at a time.

## Additional information

- n/a