### PR TITLE
removed un-needed $ from commands

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -13,10 +13,10 @@
 1. Run:
 
   ```shell
-  $ docker-compose build
-  $ docker-compose run app python manage.py migrate
-  $ docker-compose run app python manage.py loaddata test_data/data-update-deduped.json
-  $ docker-compose run app \
+  docker-compose build
+  docker-compose run app python manage.py migrate
+  docker-compose run app python manage.py loaddata test_data/data-update-deduped.json
+  docker-compose run app \
     python manage.py \
         createsuperuser \
         --username admin.user \


### PR DESCRIPTION

## Description

Copying the commands with $ at the start does not work. In other examples, $ is not added to represent shell.

