### PR TITLE
Enable SecurityMiddleware

### DIFF
--- a/tock/tock/settings/base.py
+++ b/tock/tock/settings/base.py
@@ -75,6 +75,7 @@ MIDDLEWARE = (
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.middleware.security.SecurityMiddleware',
     'uaa_client.middleware.UaaRefreshMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',


### PR DESCRIPTION
## Description

Follow-up for #922, enabling the [SecurityMiddleware](https://docs.djangoproject.com/en/2.2/ref/middleware/#module-django.middleware.security) allowing us to set the HSTS headers as expected.