### PR TITLE
Clarify timecard validation errors

### DIFF
--- a/tock/hours/forms.py
+++ b/tock/hours/forms.py
@@ -177,7 +177,8 @@ class TimecardObjectForm(forms.ModelForm):
                     self.add_error(
                         'notes',
                         forms.ValidationError(
-                            'Please enter a snippet for this item.'
+                            'Please enter a snippet for your time tocked to '
+                             + self.cleaned_data['project'].name
                         )
                     )
                 elif not self.cleaned_data['project'].notes_displayed:

--- a/tock/tock/templates/hours/timecard_form.html
+++ b/tock/tock/templates/hours/timecard_form.html
@@ -10,6 +10,13 @@
       <div class="usa-alert-body">
         <h3 class="usa-alert-heading">There was an error processing your time card</h3>
         <p class="usa-alert-text">{{ formset.non_form_errors }}</p>
+        {% for form in formset.errors %}
+            {% with form_id=forloop.counter0 %}
+            {% for error_message in form.values %}
+              <a href='#entry-{{form_id}}'>{{error_message}}</a>
+            {% endfor %}
+            {% endwith %}
+          {% endfor %}
       </div>
     </div>
 {% endif %}
@@ -61,7 +68,7 @@
   </div>
 </div>
 
-<form method="post">
+<form method="post" action="{% url 'reportingperiod:UpdateTimesheet' reporting_period=object.reporting_period.start_date %}">
   {% csrf_token %}
   {{ formset.management_form }}
   <div class="entries usa-grid">
@@ -81,7 +88,7 @@
             </div>
             {% endif %}
             <div class="entry-alerts" id="entry-alerts"></div>
-            <div class="entry-hidden" id="entry-notes">
+            <div class="entry-hidden entry-note-field">
               {{ project_entry.notes.label_tag }}
               {{ project_entry.notes.help_text }}
               {% if project_entry.notes.errors %}
@@ -126,27 +133,6 @@
         <button type="button" class="usa-button-secondary save-timecard" id="save-timecard" title="Save your time card for later">Save your time card for later</button>
       </div>
     </div>
-    {% if formset.errors %}
-        <div class="usa-alert usa-alert-error">
-          <div class="usa-alert-body">
-            <h3 class="usa-alert-heading">There was an error processing your time card</h3>
-            <p class="usa-alert-text">{{ formset.non_form_errors }}</p>
-          </div>
-        </div>
-    {% endif %}
-
-    {% if messages %}
-        <div class="usa-grid">
-        {% for message in messages %}
-            <div class="usa-alert usa-alert-{{ message.level_tag }}">
-              <div class="usa-alert-body">
-                <h3 class="usa-alert-heading">{{ message.extra_tags }}</h3>
-                <p class="usa-alert-text">{{ message.message }}</p>
-              </div>
-            </div>
-        {% endfor %}
-        </div>
-    {% endif %}
   </div>
 </form>
 
@@ -203,7 +189,7 @@
   function toggleNotesField(selectBox) {
     var $fieldset = $(selectBox).parents('.entry-project'),
         $selected = $(selectBox).find(':selected'),
-        $notes = $fieldset.find('#entry-notes'),
+        $notes = $fieldset.find('.entry-note-field'),
         notesDisplayed = $selected.data('notes-displayed'),
         notesRequired = $selected.data('notes-required');
 
@@ -325,8 +311,8 @@ $( document ).ready(function() {
           var entry = $(this);
           entry.find('.chosen-container').remove();
           entry.find('#entry-alerts').empty();
-          entry.find('#entry-notes').addClass('entry-hidden').removeClass('entry-notes');
-          entry.find('#entry-notes .invalid').remove();
+          entry.find('.entry-notes').addClass('entry-hidden').removeClass('entry-notes');
+          entry.find('.entry-notes .invalid').remove();
           entry.find('select').show();
           entry.find('input, select, textarea').val('');
           entry.find(':checkbox').prop('checked', false);

--- a/tock/tock/templates/hours/timecard_form.html
+++ b/tock/tock/templates/hours/timecard_form.html
@@ -87,7 +87,7 @@
               {{ project_entry.non_field_errors }}
             </div>
             {% endif %}
-            <div class="entry-alerts" id="entry-alerts"></div>
+            <div class="entry-alerts"></div>
             <div class="entry-hidden entry-note-field">
               {{ project_entry.notes.label_tag }}
               {{ project_entry.notes.help_text }}
@@ -194,16 +194,16 @@
         notesRequired = $selected.data('notes-required');
 
     if (notesRequired || notesDisplayed) {
-        $notes.removeClass('entry-hidden').addClass('entry-notes');
+        $notes.toggleClass('entry-hidden', false);
     } else {
-        $notes.addClass('entry-hidden').removeClass('entry-notes');
+        $notes.toggleClass('entry-hidden', true);
     }
   }
 
   function displayAlerts(selectBox) {
     var $fieldset = $(selectBox).parents('.entry-project'),
         $selected = $(selectBox).find(':selected'),
-        $alerts = $fieldset.find('#entry-alerts'),
+        $alerts = $fieldset.find('.entry-alerts'),
         all_alerts = $selected.data('alerts'),
         alert_text;
 
@@ -310,9 +310,9 @@ $( document ).ready(function() {
         $('div.entry:last').clone().each(function(i) {
           var entry = $(this);
           entry.find('.chosen-container').remove();
-          entry.find('#entry-alerts').empty();
-          entry.find('.entry-notes').addClass('entry-hidden').removeClass('entry-notes');
-          entry.find('.entry-notes .invalid').remove();
+          entry.find('.entry-alerts').empty();
+          entry.find('.entry-note-field').toggleClass('entry-hidden', true);
+          entry.find('.entry-note-field .invalid').remove();
           entry.find('select').show();
           entry.find('input, select, textarea').val('');
           entry.find(':checkbox').prop('checked', false);


### PR DESCRIPTION
## Description

Working towards resolution of #885, we're making incremental improvements to the error messaging on timecard submission.

Specifically:

- Project names are now included in each error message
- Each error message links within-page to the referenced project
- Removed repeated rendering of messages/errors at bottom of the page

## Additional information
<img width="652" alt="Screen Shot 2019-11-25 at 2 42 54 PM" src="https://user-images.githubusercontent.com/3485564/69572804-e469c400-0f92-11ea-996f-9d30f15d29ce.png">

