### PR TITLE
Cleaning up the recent tock table template

### DIFF
--- a/tock/tock/templates/employees/user_recent_tocks.html
+++ b/tock/tock/templates/employees/user_recent_tocks.html
@@ -4,14 +4,10 @@
   <thead>
     <th>Project</th>
     {% for tc in recent_timecards %}
-    {{tc}}
     <th><a
-            href={% url 'reports:ReportingPeriodUserDetailView'
-                    reporting_period=tc.reporting_period.start_date
-                    username=tc.user.username %}
-        >
-            {{tc.reporting_period.start_date}}
-        </a>
+        href={% url "reports:ReportingPeriodUserDetailView" reporting_period=tc.reporting_period.start_date username=tc.user.username %}>
+        {{tc.reporting_period.start_date}}
+      </a>
     </th>
     {% endfor %}
   </thead>


### PR DESCRIPTION
## Description

Continuation of #927, removing errant context variable rendering on page and revising `url` templatetag a bit, it was previously not rendering the expected link.
