### PR TITLE
Tweak CircleCI configuration for builds.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,22 +34,26 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "Pipfile" }}-{{ checksum "Pipfile.lock" }}-{{ checksum "package.json" }}
+            - v1-dependencies-{{ checksum "Pipfile" }}-{{ checksum "Pipfile.lock" }}-{{ checksum "package-lock.json" }}
             # fallback to using the latest cache if no exact match is found
             - v1-dependencies-
+
+      - run:
+          name: update npm
+          command: sudo npm install -g npm
 
       - run:
           name: install dependencies
           command: |
             pip install pipenv
             pipenv install --dev --deploy
-            npm install
+            npm ci
 
       - save_cache:
           paths:
             - ./.venv
-            - ./node_modules
-          key: v1-dependencies-{{ checksum "Pipfile" }}-{{ checksum "Pipfile.lock" }}-{{ checksum "package.json" }}
+            - ~/.npm
+          key: v1-dependencies-{{ checksum "Pipfile" }}-{{ checksum "Pipfile.lock" }}-{{ checksum "package-lock.json" }}
 
       # run tests!
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
             python manage.py loaddata test_data/data-update-deduped.json --settings=tock.settings.test
             python manage.py createsuperuser --username admin.user --email admin.user@gsa.gov --noinput --settings=tock.settings.test
             python manage.py runserver 0.0.0.0:8000 --settings=tock.settings.test &
-            sleep 5
+            while ! nc -G 1 -z 0.0.0.0 8000; do sleep 0.1; done;
             cd ..
             npm run test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,6 @@ cf-docker-image: &CF_DOCKER_IMAGE
       environment:
         - TZ=America/New_York
         - CF_API: https://api.fr.cloud.gov
-working-directory: &WORKING_DIRECTORY
-  working_directory: ~/repo
 
 version: 2
 jobs:
@@ -29,8 +27,6 @@ jobs:
         environment:
           - POSTGRES_USER=circleci
           - POSTGRES_DB=tock-test
-
-    <<: *WORKING_DIRECTORY
 
     steps:
       - checkout
@@ -86,8 +82,6 @@ jobs:
   deploy_to_staging:
     <<: *CF_DOCKER_IMAGE
 
-    <<: *WORKING_DIRECTORY
-
     steps:
       - attach_workspace:
           at: .
@@ -104,8 +98,6 @@ jobs:
   deploy_to_production:
     <<: *CF_DOCKER_IMAGE
 
-    <<: *WORKING_DIRECTORY
-
     steps:
       - attach_workspace:
           at: .
@@ -121,8 +113,6 @@ jobs:
 
   recycle_production:
     <<: *CF_DOCKER_IMAGE
-
-    <<: *WORKING_DIRECTORY
 
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
             python manage.py loaddata test_data/data-update-deduped.json --settings=tock.settings.test
             python manage.py createsuperuser --username admin.user --email admin.user@gsa.gov --noinput --settings=tock.settings.test
             python manage.py runserver 0.0.0.0:8000 --settings=tock.settings.test &
-            while ! nc -G 1 -z 0.0.0.0 8000; do sleep 0.1; done;
+            while ! nc -w 1 -z 0.0.0.0 8000; do sleep 0.1; done;
             cd ..
             npm run test
 


### PR DESCRIPTION
Regarding #943.

CircleCI tweaks to simplify, modernize, and improve usage of CircleCI: 

- 86cb3e6: Removes `working_directory` configuration, as it is [no longer required](https://discuss.circleci.com/t/working-directory-is-no-longer-required-defaults-to-project/14363).
- b098d3d: Use `npm ci` over `npm install`.
- 5804efc: Wait for a server on port 8000 instead of sleeping for 5 seconds.

This PR does not address deployment issues, will follow-up with an additional PR around deploys. 