### PR TITLE
Use cf-rolling-restart over cf-recycle-plugin.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,14 +123,11 @@ jobs:
           name: Login to cloud.gov Production
           command: cf login -a ${CF_API} -u ${CF_DEPLOYER_USERNAME_PRODUCTION} -p ${CF_DEPLOYER_PASSWORD_PRODUCTION}
       - run:
-          name: Install cf-recycle-plugin 1.0.0 release
-          command: |
-            curl -L -o cf-recycle-plugin https://github.com/rogeruiz/cf-recycle-plugin/releases/download/v1.0.0/cf-recycle-plugin.linux64
-            chmod +x cf-recycle-plugin
-            cf install-plugin cf-recycle-plugin -f
+          name: Install cf-rolling-restart
+          command: cf install-plugin -f -r CF-Community "cf-rolling-restart"
       - run:
-          name: Recycle Tock Production instances
-          command: cf recycle tock
+          name: Performing a rolling restart of Tock Production instances
+          command: cf rolling-restart tock
 
 workflows:
   version: 2


### PR DESCRIPTION
Related to #943.

Rolling-restart is more recently maintained, is the original fork, and works with the latest CF CLI for when we upgrade. 

It’s a bit of a shot-in-the-dark here since I don’t 100% understand what’s going on — the `cf-recycle-plugin` plugin isn’t correctly detecting process restarts. I had thought this was due to conflicting recycle jobs — one job was recycling a process out from the other — but since removing the concurrent jobs, the issue is not fixed. 

Looking at [this morning’s run](https://circleci.com/gh/18F/tock/5417), the CircleCI job output seems to indicate that Instance 0 was never restarted, which caused the job to timeout. However, looking [at the cell restart logs](https://logs.fr.cloud.gov/app/kibana#/dashboard/App-Overview?_g=(refreshInterval:(pause:!t,value:0),time:(from:'2020-01-08T10:09:18.122Z',mode:absolute,to:'2020-01-08T10:11:07.511Z'))&_a=(description:'',filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logs-app*',key:'@cf.app',negate:!f,params:(query:tock,type:phrase),type:phrase,value:tock),query:(match:('@cf.app':(query:tock,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logs-app*',key:'@source.type',negate:!f,params:(query:CELL,type:phrase),type:phrase,value:CELL),query:(match:('@source.type':(query:CELL,type:phrase))))),fullScreenMode:!f,options:(darkTheme:!f),panels:!((embeddableConfig:(vis:(legendOpen:!t)),gridData:(h:5,i:'1',w:36,x:0,y:0),id:App-links,panelIndex:'1',type:visualization,version:'6.8.1'),(gridData:(h:10,i:'2',w:36,x:0,y:5),id:'App-logs-by-source-type-(top-10)',panelIndex:'2',type:visualization,version:'6.8.1'),(embeddableConfig:(vis:(params:(sort:(columnIndex:!n,direction:!n)))),gridData:(h:15,i:'3',w:12,x:36,y:0),id:App-names,panelIndex:'3',type:visualization,version:'6.8.1'),(embeddableConfig:(columns:!('@cf.org','@cf.space','@cf.app','@source.job','@source.component','@source.type','@level','@message'),sort:!('@timestamp',desc)),gridData:(h:25,i:'4',w:48,x:0,y:15),id:app-all-overview,panelIndex:'4',type:search,version:'6.8.1')),query:(language:lucene,query:(query_string:(analyze_wildcard:!t,default_field:'*',query:'*'))),timeRestore:!f,title:'App%20-%20Overview',viewMode:view)), we can see that it was correctly restarted: 

| Timestamp | Message |
|-----------|--------|
| 05:09:33.047 | Cell 7e7732c4-f516-4420-a8b9-fb94ccea7405 stopping instance f3c7fa65-22e8-4792-7f95-4141
| 05:09:49.396 | Cell 7e7732c4-f516-4420-a8b9-fb94ccea7405 destroying container for instance f3c7fa65-22e8-4792-7f95-4141
| 05:09:52.034 | Cell 7e7732c4-f516-4420-a8b9-fb94ccea7405 successfully destroyed container for instance f3c7fa65-22e8-4792-7f95-4141
| 05:10:15.651 | Cell 7e7732c4-f516-4420-a8b9-fb94ccea7405 creating container for instance 1c8832a7-4445-4c50-55e7-409e
| 05:10:16.530 | Cell 7e7732c4-f516-4420-a8b9-fb94ccea7405 successfully created container for instance 1c8832a7-4445-4c50-55e7-409e
| 05:10:16.913 | Downloading droplet...
| 05:10:22.451 | Downloaded droplet (69.8M)
| 05:10:22.451 | Starting health monitoring of container
| 05:10:31.906 | Container became healthy

This leads me to believe that this is an issue with the plugin — hence the PR. I’m pretty comfortable just trying something newer and seeing if it works, and moving on with our lives if it does. 🤷‍♂ 