### PR TITLE
Utilization should use target hours as denominator

### DIFF
--- a/tock/tock/templates/utilization/includes/unit_utilization_cell.html
+++ b/tock/tock/templates/utilization/includes/unit_utilization_cell.html
@@ -1,6 +1,6 @@
 <td>
     {{ data.utilization }}<br>
-    {% if data.total %}
-        ({{ data.billable }} / {{ data.total }})
+    {% if data.denominator %}
+        ({{ data.billable }} / {{ data.denominator }})
     {% endif %}
 </td>

--- a/tock/utilization/employee.py
+++ b/tock/utilization/employee.py
@@ -29,12 +29,12 @@ def _get_employee_billing_data(user, recent_periods=None, fiscal_year=False):
         else:
             start, end, utilization = utilization_report(user_qs)
 
-        data = utilization.values('username', 'billable', 'total')[0]
+        data = utilization.values('username', 'billable', 'target')[0]
 
         totals = {
             'billable': data['billable'],
-            'total': data['total'],
-            'utilization': calculate_utilization(data['billable'], data['total'])
+            'denominator': data['target'],
+            'utilization': calculate_utilization(data['billable'], data['target'])
         }
         return {'start_date': start, 'end_date': end, 'totals': totals}
     except AttributeError:

--- a/tock/utilization/org.py
+++ b/tock/utilization/org.py
@@ -29,11 +29,11 @@ def _get_18f_billing_data(recent_periods=None, fiscal_year=False):
     else:
         start, end, utilization = utilization_report(user_qs)
 
-    org_totals = utilization.values('billable', 'total').aggregate(Sum('billable'), Sum('total'))
+    org_totals = utilization.values('billable', 'target').aggregate(Sum('billable'), Sum('target'))
 
     totals = {
         'billable': org_totals['billable__sum'],
-        'total': org_totals['total__sum'],
-        'utilization': calculate_utilization(org_totals['billable__sum'], org_totals['total__sum'])
+        'denominator': org_totals['target__sum'],
+        'utilization': calculate_utilization(org_totals['billable__sum'], org_totals['target__sum'])
     }
     return {'start_date': start, 'end_date': end, 'totals': totals}

--- a/tock/utilization/tests/test_views.py
+++ b/tock/utilization/tests/test_views.py
@@ -94,12 +94,12 @@ class TestGroupUtilizationView(WebTest):
             url=reverse('utilization:GroupUtilizationView'),
             user=self.user
         )
+
         utilization_data = response.context['object_list'][0]['utilization']
 
         self.assertEqual(
-            utilization_data['last_week_data'][0]['total'],
-            (self.b_timecard_object.hours_spent + \
-            self.nb_timecard_object.hours_spent)
+            utilization_data['last_week_data'][0]['denominator'],
+            self.timecard.target_hours
         )
 
         self.assertEqual(

--- a/tock/utilization/unit.py
+++ b/tock/utilization/unit.py
@@ -39,22 +39,22 @@ def _get_unit_billing_data(unit, recent_periods=None, fiscal_year=False):
     else:
         start, end, utilization = utilization_report(users)
 
-    data = utilization.values('username', 'billable', 'total')
+    data = utilization.values('username', 'billable', 'target')
 
     # Build context for each employee
     output_data = [{
             'username': employee['username'],
-            'total': employee['total'],
+            'denominator': employee['target'],
             'billable': employee['billable'],
-            'utilization': calculate_utilization(employee['billable'], employee['total'])
+            'utilization': calculate_utilization(employee['billable'], employee['target'])
             } for employee in data]
 
     # Get totals for unit
-    unit_totals = data.aggregate(Sum('billable'), Sum('total'))
+    unit_totals = data.aggregate(Sum('billable'), Sum('target'))
 
     totals = {'billable': unit_totals['billable__sum'],
-    'total': unit_totals['total__sum'],
-    'utilization': calculate_utilization(unit_totals['billable__sum'],unit_totals['total__sum'])
+    'denominator': unit_totals['target__sum'],
+    'utilization': calculate_utilization(unit_totals['billable__sum'],unit_totals['target__sum'])
     }
 
     return {'start_date': start, 'end_date': end, 'data': output_data, 'totals': totals}


### PR DESCRIPTION
## Description

Resolves #1022, correcting utilization aggregations and display to render `target` hours as the denominator and for use in utilization calculations.