### PR TITLE
Include all active users in utilization reports

### DIFF
--- a/tock/utilization/tests/test_views.py
+++ b/tock/utilization/tests/test_views.py
@@ -106,3 +106,15 @@ class TestGroupUtilizationView(WebTest):
             utilization_data['last_week_data'][0]['billable'],
             self.b_timecard_object.hours_spent
         )
+
+    def test_user_detail_with_utilization(self):
+        """UserDetail view is visible for non-billable users"""
+        self.user_data.is_billable = False
+        self.user_data.save()
+
+        response = self.app.get(
+            url=reverse('employees:UserDetailView', args=[self.user.username]),
+            user=self.user
+        )
+
+        self.assertEqual(response.status_code, 200)

--- a/tock/utilization/utils.py
+++ b/tock/utilization/utils.py
@@ -64,8 +64,7 @@ def users_to_include_for_utilization():
     """
     Limit to users which should be included in utilization reports
     """
-    return Q(user_data__is_billable=True,
-             is_active=True,
+    return Q(is_active=True,
              user_data__current_employee=True)
 
 def utilization_users_queryset(qs):


### PR DESCRIPTION
## Description

Resolves #1033 and part of #1034 by removing the check for `is_billable=True` when generating utilization data.

Also includes a minor tweak to reduce number of database queries when rendering UserDetail view.