### PR TITLE
An undefined amount of tocking

### DIFF
--- a/docs/utilization.md
+++ b/docs/utilization.md
@@ -37,9 +37,13 @@ TARGET_BILLABLE_HOURS = (BILLABLE_HOURS + NON_BILLABLE_HOURS) * BILLING_EXPECTAT
 ```
 
 ### BILLING EXPECTATION
-
 The percent of `TOTAL HOURS` which are expected to be billable for a given reporting period. Set per user, per timecard, and will vary as an individual's role, position, or organization change. See [the handbook](https://handbook.tts.gsa.gov/tock/#weekly-billable-hour-expectations) for additional details on billing expectations.
 
+### NON-BILLABLE
+An employee is considered `Non billable` if their `TARGET BILLABLE HOURS` over a time period is 0. Utilization is not calculated for these individuals because
+we're currently unable to <a href="https://en.wikipedia.org/wiki/Division_by_zero">divide by zero</a>.
+
+All `BILLABLE HOURS` tocked by `Non billable` employees are included in aggregations for their respective business unit and organization.
 
 **Default: 80%**
 
@@ -131,3 +135,30 @@ Out of Office| 0.0 |
 Billable | 50.0 |
 Non-Billable | 16.0 |
 
+
+## What if I'm non-billable but worked on a billable project?
+
+All billable hours count towards unit and organizational targets.
+
+### Example
+
+Stacey is a `non-billable` employee, their billing expectation is 0 hours per week.
+Leslie's billing expectation is 32 hours per week.
+Stacey and Leslie are in the same Business unit: `Tockonauts`
+
+The `Tockonauts` utilization for week 1 is 100%
+
+Leslie's utilization for week 1 is 97%
+
+Stacey's utilization for week 1 is `undefined` but their 1 billable hour contributes to the overall calculations and utilization for `Tockonauts`.
+
+
+
+Employee | Project      | Week 1 |
+---------|--------------|--------|
+Stacey   | Billable     | 1.0 |
+Stacey   | Non-Billable | 39.0 |
+---------|--------------|----|
+Leslie   | Billable     | 31.0 |
+Leslie   | Non-Billable | 9.0 |
+---------|--------------|----|

--- a/tock/hours/models.py
+++ b/tock/hours/models.py
@@ -281,9 +281,9 @@ class Timecard(models.Model):
         return min(this_weeks_target, self.max_target_hours())
 
     def calculate_utilization(self):
-        if self.target_hours:
-            return self.billable_hours / self.target_hours
-        return 0
+        if self.target_hours == 0:
+            return None
+        return self.billable_hours / self.target_hours
 
     def max_target_hours(self):
         return round(self.billable_expectation * settings.HOURS_IN_A_REGULAR_WORK_WEEK)

--- a/tock/tock/templates/utilization/group_utilization.html
+++ b/tock/tock/templates/utilization/group_utilization.html
@@ -6,13 +6,9 @@
 {% block content %}
   <h2>Utilization by Unit</h2>
   <p>
-    This report contains active billable 18F employees by their current business unit.
+    This report contains active 18F employees by their current business unit.
   </p>
-  <p>
-    Utilization is calculated by dividing the total number of hours submitted on
-    projects that are marked "billable" in Tock, divided by the total number of
-    hours submitted on all projects for the given period. Out-of-Office project lines
-    are excluded from all calculations.
+    Checkout the <a href="https://github.com/18F/tock/blob/master/docs/utilization.md">utilization page of the documentation</a> for details on what these numbers represent and how they are calculated!
   </p>
   <p>
     This is the latest iteration in utilization reporting and an active <u>work

--- a/tock/tock/templates/utilization/includes/unit_utilization_cell.html
+++ b/tock/tock/templates/utilization/includes/unit_utilization_cell.html
@@ -1,6 +1,6 @@
 <td>
     {{ data.utilization }}<br>
-    {% if data.denominator %}
+    {% if data.denominator is not None  %}
         ({{ data.billable }} / {{ data.denominator }})
     {% endif %}
 </td>


### PR DESCRIPTION
## Description

Resolves #1036 by differentiating between situations where no timecard data is available
and the available timecard data indicates a `target_hours` of 0. Target hours of zero indicates a `non-billable` staff member, denote as such but still render counts as they contribute to overall numbers.

## Additional information
**Note: Targeting `billable-as-property` branch, re-target to master if that is merged first**

Included a documentation update w/ example to help clarify.
