### PR TITLE
Update UserData serializer for Unit obj

### DIFF
--- a/tock/api/views.py
+++ b/tock/api/views.py
@@ -50,7 +50,7 @@ class UserDataSerializer(serializers.Serializer):
     current_employee = serializers.BooleanField()
     is_18f_employee = serializers.BooleanField()
     is_billable = serializers.BooleanField()
-    unit = serializers.SerializerMethodField()
+    unit = serializers.StringRelatedField()
     organization = serializers.StringRelatedField()
 
     def get_unit(self,obj):


### PR DESCRIPTION
## Description

Unblocking progress on #1052, this fixes the UserData API endpoint by properly handling serialization of the `Unit` attribute as it was recently moved from a string to it's own table in the database.