### PR TITLE
Update Unit admin to include and filter on Organization

### DIFF
--- a/tock/organizations/admin.py
+++ b/tock/organizations/admin.py
@@ -10,7 +10,8 @@ class OrganizationAdmin(admin.ModelAdmin):
 
 
 class UnitAdmin(admin.ModelAdmin):
-    list_display = ('name', 'description')
+    list_display = ('name', 'description', 'org',)
+    list_filter = ('org', 'active',)
     search_fields = ('name',)
 
 admin.site.register(Organization, OrganizationAdmin)


### PR DESCRIPTION
## Description

Improves business unit admin view by including each BU's Organization in the list view. Units can also be filtered by Organization and `active` status.

https://github.com/18F/tock/issues/1021
