### PR TITLE
upgrade db version only for development branch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ app:
     - "8000:8000"
   command: "python manage.py runserver 0.0.0.0:8000"
 db:
-  image: postgres:9.6.8
+  image: postgres:9.6.17
   environment:
     - POSTGRES_DB=tock
     - POSTGRES_USER=tock_user


### PR DESCRIPTION
postgresql 9.6.17 incorporates fixes referenced here: https://github.com/18F/tock/issues/993
purpose of this is to stick closer to current db fixes for 9.6 rather than falling too far behind