### PR TITLE
Add is_active property to UserData model

### DIFF
--- a/tock/api/views.py
+++ b/tock/api/views.py
@@ -49,6 +49,7 @@ class UserDataSerializer(serializers.Serializer):
     user = serializers.StringRelatedField()
     current_employee = serializers.BooleanField()
     is_18f_employee = serializers.BooleanField()
+    is_active = serializers.BooleanField()
     is_billable = serializers.BooleanField()
     unit = serializers.StringRelatedField()
     organization = serializers.StringRelatedField()

--- a/tock/employees/models.py
+++ b/tock/employees/models.py
@@ -111,6 +111,10 @@ class UserData(models.Model):
         return '{0}'.format(self.user)
 
     @property
+    def is_active(self):
+        return self.user.is_active
+
+    @property
     def is_billable(self):
         """
         True if user is currently expected to bill more

--- a/tock/employees/tests/test_models.py
+++ b/tock/employees/tests/test_models.py
@@ -50,11 +50,17 @@ class UserDataTests(TestCase):
     def setUp(self):
         # Create regular_user.
         self.regular_user = User.objects.create(
-            username='aaron.snow',
+            username='brian.whittaker',
             is_superuser=True,
             is_staff=True,
             is_active=True
         )
+        self.inactive_user = User.objects.create(
+            username='aaron.snow',
+            is_superuser=True,
+            is_staff=True,
+            is_active=False
+)
         # Create Organization.
         self.regular_user_org = Organization.objects.create(
             name='18F',
@@ -71,6 +77,15 @@ class UserDataTests(TestCase):
         # Create UserData object related to regular_user.
         self.regular_user_userdata = UserData.objects.create(
             user=self.regular_user,
+            start_date= datetime.date(2014, 1, 1),
+            end_date=datetime.date(2100, 1, 1),
+            is_18f_employee=True,
+            current_employee=True,
+            organization=self.regular_user_org,
+            unit=self.regular_user_unit
+        )
+        self.inactive_user_userdata = UserData.objects.create(
+            user=self.inactive_user,
             start_date= datetime.date(2014, 1, 1),
             end_date=datetime.date(2100, 1, 1),
             is_18f_employee=True,
@@ -117,6 +132,12 @@ class UserDataTests(TestCase):
         userdata.billable_expectation = 0
         userdata.save()
         self.assertEqual(userdata.is_late, False)
+
+    def test_is_active(self):
+        userdata = self.regular_user_userdata
+        self.assertEqual(userdata.is_active, True)
+        userdata = self.inactive_user_userdata
+        self.assertEqual(userdata.is_active, False)
 
     def test_organization_name(self):
         """


### PR DESCRIPTION
## Description

Copies the `is_active` property from an associated `User` model into the `UserData` model, and updates the UserData API serializer to include that property. This could help with #1071, per @Jkrzy's comment in Slack.