### PR TITLE
Filter weekly reports by org

### DIFF
--- a/tock/tock/static/js/components/filter_report_table.js
+++ b/tock/tock/static/js/components/filter_report_table.js
@@ -1,0 +1,46 @@
+(function () {
+  const unfiledTimecardFilter = document.getElementById('unfiled-timecards-org-filter-select');
+  const unfiledTimecardTable = document.getElementById('js-unfiled-timecards');
+  const rows = unfiledTimecardTable.getElementsByTagName('tr');
+
+  const showRow = (row) => {
+    row.style.display = 'table-row';
+  };
+
+  const hideRow = (row) => {
+    row.style.display = 'none';
+  };
+
+  const filterByOrg = (selectedOrg) => {
+    for (i in rows) {
+      // skip the header row, which contains `th`, and other gunk
+      try {
+        const org = rows[i].getElementsByTagName('td')[3];
+        if (org.innerText !== selectedOrg) {
+          hideRow(rows[i]);
+        } else {
+          showRow(rows[i]);
+        }
+      } catch (err) {
+        console.log(err);
+      }
+    }
+  };
+
+  unfiledTimecardFilter.addEventListener('change', (e) => {
+    let selectedOrg = e.target.value;
+    switch (selectedOrg) {
+      case 'all':
+        for (i in rows) {
+          showRow(rows[i]);
+        }
+        break;
+      case 'None':
+        // 'None' shows up as a blank cell in the table
+        filterByOrg('');
+        break;
+      default:
+        filterByOrg(selectedOrg);
+    }
+  });
+})(window);

--- a/tock/tock/static/sass/core.scss
+++ b/tock/tock/static/sass/core.scss
@@ -28,6 +28,9 @@ li {
 }
 .usa-form select {
   @extend .usa-select;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
 }
 .usa-form input[type=text], .usa-form input[type=number] {
   @extend .usa-input;

--- a/tock/tock/templates/hours/reporting_period_detail.html
+++ b/tock/tock/templates/hours/reporting_period_detail.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load static %}
 {% block navigation %}
   {% include "_navigation.html" %}
 {% endblock %}
@@ -10,9 +11,19 @@
 <h1>Reporting Period: {{ reporting_period.start_date }} to {{ reporting_period.end_date }}</h1>
 <a href="{% url 'reports:ReportingPeriodCSVView' reporting_period %}">Download Full CSV Report</a>
 
-<table class="usa-table table-responsive-reflow">
-  <caption>
-    <h2>Users Who Have Not Filed a Timecard!</h2>
+<h2>Users Who Have Not Filed a Timecard!</h2>
+<label for="unfiled-timecards-org-filter-select">
+  Filter users by organization
+</label>
+<select id="unfiled-timecards-org-filter-select">
+  <option value="all">All organizations</option>
+  {% for organization in orgs_without_filed_timecards %}
+    <option value="{{ organization }}">{{ organization }}</option>
+  {% endfor %}
+</select>
+<table class="usa-table table-responsive-reflow" id="js-unfiled-timecards">
+  <caption class="usa-sr-only">
+    Table of users that have not filed a timecard for the reporting period {{ reporting_period.start_date }} to {{ reporting_period.end_date }}
   </caption>
   <thead>
     <tr>
@@ -58,5 +69,5 @@
   {% endfor %}
   </tbody>
 </table>
-
+<script src="{% static 'js/components/filter_report_table.js' %}"></script>
 {% endblock %}

--- a/tock/tock/templates/hours/reporting_period_detail.html
+++ b/tock/tock/templates/hours/reporting_period_detail.html
@@ -12,15 +12,17 @@
 <a href="{% url 'reports:ReportingPeriodCSVView' reporting_period %}">Download Full CSV Report</a>
 
 <h2>Users Who Have Not Filed a Timecard!</h2>
-<label for="unfiled-timecards-org-filter-select">
-  Filter users by organization
-</label>
-<select id="unfiled-timecards-org-filter-select">
-  <option value="all">All organizations</option>
-  {% for organization in orgs_without_filed_timecards %}
-    <option value="{{ organization }}">{{ organization }}</option>
-  {% endfor %}
-</select>
+<form class="usa-form">
+  <label class="usa-label" for="unfiled-timecards-org-filter-select">
+    Filter users by organization
+  </label>
+  <select class="usa-select" name="unfiled-timecards-org-filter-select" id="unfiled-timecards-org-filter-select">
+    <option value="all">All organizations</option>
+    {% for organization in orgs_without_filed_timecards %}
+      <option value="{{ organization }}">{{ organization }}</option>
+    {% endfor %}
+  </select>
+</form>
 <table class="usa-table table-responsive-reflow" id="js-unfiled-timecards">
   <caption class="usa-sr-only">
     Table of users that have not filed a timecard for the reporting period {{ reporting_period.start_date }} to {{ reporting_period.end_date }}


### PR DESCRIPTION
## Description
Closes #968. Makes the unfiled timecards list filterable by their respective orgs. Looks like this...

Unfiltered:
<img width="1015" alt="Screen Shot 2020-05-07 at 9 30 49 PM" src="https://user-images.githubusercontent.com/509309/81367639-0bcccd00-90ab-11ea-890e-7084300ebe8e.png">

Filtered:
<img width="1022" alt="Screen Shot 2020-05-07 at 9 30 57 PM" src="https://user-images.githubusercontent.com/509309/81367652-14bd9e80-90ab-11ea-90fc-214d80288261.png">