### PR TITLE
All users can access Reports navigation item

### DIFF
--- a/tock/tock/templates/_navigation.html
+++ b/tock/tock/templates/_navigation.html
@@ -10,7 +10,6 @@
           <span>Projects</span>
         </a>
       </li>
-      {% if request.user.is_staff %}
       <li class="usa-nav__primary-item">
         <button class="usa-accordion__button usa-nav__link" aria-expanded="false" aria-controls="reports-nav">
           <span>Reports</span>
@@ -26,7 +25,6 @@
           </li>
         </ul>
       </li>
-      {% endif %}
       <li class="usa-nav__primary-item">
         <a href="{% url 'employees:UserListView' %}" class="usa-nav__link">
           <span>Users</span>


### PR DESCRIPTION
## Description
 For #1112, we remove the `is_staff` check when rendering the `Reports` item in the navigation menu. All users have been able to access these reports but, until this PR the links to access them have been hidden to all but admins.