### PR TITLE
Enhance billable_expectation backfill management command

### DIFF
--- a/tock/tock/management/commands/update_billable_expectations.py
+++ b/tock/tock/management/commands/update_billable_expectations.py
@@ -11,7 +11,7 @@ from hours.models import ReportingPeriod, Timecard
 
 @transaction.atomic
 class Command(BaseCommand):
-    help = 'Load CSV file of (username, target_hours, from_date) to bulk update timecard billing expectation values'
+    help = 'Load CSV file of (username, target_hours, from_date) to bulk update timecard, and if desired UserData, billing expectation values'
 
     def add_arguments(self, parser):
         parser.add_argument('csv_path', nargs='+', type=str)

--- a/tock/tock/management/commands/update_billable_expectations.py
+++ b/tock/tock/management/commands/update_billable_expectations.py
@@ -24,9 +24,15 @@ class Command(BaseCommand):
         return 0
 
     def _update_timecard(self, timecard, expectation):
-        """Update billable expectation from provided target hours and save"""
+        """Update Timecard billable expectation w/ provided target hours and save"""
         timecard.billable_expectation = expectation
         timecard.save()
+
+    def _update_userdata(self, username, target):
+        """Update UserData billable expectation w/ provided target hours and save"""
+        userdata = UserData.objects.get(user__username=username)
+        userdata.billable_expectation = target
+        userdata.save()
 
     @transaction.atomic
     def handle(self, *args, **options):
@@ -52,9 +58,7 @@ class Command(BaseCommand):
                         [self._update_timecard(timecard, target_billable_expectation) for timecard in timecards]
 
                         if update_user_data:
-                            userdata = UserData.objects.get(user__username=username)
-                            userdata.billable_expectation = target_billable_expectation
-                            userdata.save()
+                            self._update_userdata(username, target_billable_expectation)
                             self.stdout.write(f'Updated UserData.billable_expectation for {username} to target hours {target}')
 
             except FileNotFoundError:


### PR DESCRIPTION
## Description

For #1119, we expand our management command previously used to backfill billing targets for existing timecards with the ability to update `UserData.billable_expectation`. Also renamed the command to `update_billable_expectations` which is both a bit shorter and I think clearer as to it's purpose.

Example call:
```bash
python manage.py update_billable_expectations  aug20-backfill.csv -u
```

With a csv file structured as below:
```csv
user.name, 36, 07/04/2020
```

Results in all timecards for reporting periods after 7/4/20, as well as UserData.billable_expectation, being set to 36 hours for each `username` provided in the csv.