### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ cg-django-uaa==2.0.0
 chardet==3.0.4
 dj-database-url==0.5.0
 django-webtest==1.9.7
-django==2.2.14
+django==2.2.15
 djangorestframework-csv==2.1.0
 djangorestframework==3.11.0
 furl==2.1.0
@@ -17,12 +17,15 @@ gunicorn==20.0.4
 idna==2.10; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 markdown==3.2.2
 newrelic==5.14.1.144
+numpy==1.19.1; python_version >= '3.6'
 orderedmultidict==1.0.1
 packaging==20.4; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+pandas==1.1.0
 plotly==4.9.0
 psycopg2-binary==2.8.5
 pyjwt==1.7.1
 pyparsing==2.4.7; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'
+python-dateutil==2.8.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 pytz==2020.1
 requests==2.24.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 retrying==1.3.3


### PR DESCRIPTION
## Description

We're still hanging on to requirements.txt and although the cloudfoundry python buildpack supports `pipenv`,  the requirements file is picked up first. 

Including a few updates here to match the current `Pipfile.lock`