### PR TITLE
Default to graphing past 12 months

### DIFF
--- a/tock/tock/templates/utilization/utilization_analytics.html
+++ b/tock/tock/templates/utilization/utilization_analytics.html
@@ -11,25 +11,25 @@
 
   <h2>Analytics</h2>
 
-	<form class="usa-form">
-		<div class="usa-form-group">
-		<label class="usa-label" id="start-date-label" for="start">Start date</label>
-		<div class="usa-hint" id="start-date-hint">YYYY-MM-DD</div>
-		<div class="usa-date-picker">
-			<input class="usa-input usa-input--inline" id="start" name="start" type="text" aria-describedby="start-date-label start-date-hint" value="{{start_date}}">
-		</div>
-		</div>
+    <form class="usa-form">
+        <div class="usa-form-group">
+        <label class="usa-label" id="start-date-label" for="start">Start date</label>
+        <div class="usa-hint" id="start-date-hint">YYYY-MM-DD (after {{ min_date }})</div>
+        <div class="usa-date-picker">
+            <input class="usa-input usa-input--inline" id="start" name="start" type="text" aria-describedby="start-date-label start-date-hint" value="{{start_date}}">
+        </div>
+        </div>
 
-		<div class="usa-form-group">
-		<label class="usa-label" id="end-date-label" for="end">End date</label>
-		<div class="usa-hint" id="end-date-hint">YYYY-MM-DD</div>
-		<div class="usa-date-picker">
-			<input class="usa-input usa-input--inline" id="end" name="end" type="text" aria-describedby="end-date-label end-date-hint" value="{{end_date}}">
-		</div>
-		</div>
+        <div class="usa-form-group">
+        <label class="usa-label" id="end-date-label" for="end">End date</label>
+        <div class="usa-hint" id="end-date-hint">YYYY-MM-DD</div>
+        <div class="usa-date-picker">
+            <input class="usa-input usa-input--inline" id="end" name="end" type="text" aria-describedby="end-date-label end-date-hint" value="{{end_date}}">
+        </div>
+        </div>
 
-		<input class="usa-button" type="submit" value="Change Dates">
-	</form>
+        <input class="usa-button" type="submit" value="Change Dates">
+    </form>
 
   <h3>Overall Utilization</h3>
   {{utilization_plot|safe}}

--- a/tock/utilization/views.py
+++ b/tock/utilization/views.py
@@ -1,6 +1,5 @@
 from datetime import date
 
-from django.apps import apps
 from django.contrib.auth import get_user_model
 from django.views.generic import ListView, TemplateView
 from hours.models import ReportingPeriod
@@ -75,7 +74,6 @@ class UtilizationAnalyticsView(PermissionMixin, TemplateView):
         context.update({"start_date": start_date, "end_date": end_date})
 
         # give a tip about the oldest possible date
-        ReportingPeriod = apps.get_model("hours", "ReportingPeriod")
         min_date_result = ReportingPeriod.objects.order_by("start_date").values("start_date").first()
         min_date = min_date_result.pop("start_date").isoformat()
         context.update({"min_date": min_date})

--- a/tock/utilization/views.py
+++ b/tock/utilization/views.py
@@ -1,5 +1,6 @@
 from datetime import date
 
+from django.apps import apps
 from django.contrib.auth import get_user_model
 from django.views.generic import ListView, TemplateView
 from hours.models import ReportingPeriod
@@ -67,10 +68,17 @@ class UtilizationAnalyticsView(PermissionMixin, TemplateView):
     def get_context_data(self, **kwargs):
         context = super(UtilizationAnalyticsView, self).get_context_data(**kwargs)
 
-        # use a date before Tock as the default start_date
-        start_date = self.request.GET.get("start", "2014-01-01")
-        end_date = self.request.GET.get("end", date.today().isoformat())
+        # use one year ago as the default start date
+        d = date.today()
+        start_date = self.request.GET.get("start", d.replace(year=d.year - 1).isoformat())
+        end_date = self.request.GET.get("end", d.isoformat())
         context.update({"start_date": start_date, "end_date": end_date})
+
+        # give a tip about the oldest possible date
+        ReportingPeriod = apps.get_model("hours", "ReportingPeriod")
+        min_date_result = ReportingPeriod.objects.order_by("start_date").values("start_date").first()
+        min_date = min_date_result.pop("start_date").isoformat()
+        context.update({"min_date": min_date})
 
         # add the utilization plot to the context
         utilization_data_frame = utilization_data(start_date, end_date)


### PR DESCRIPTION
## Description

Discussion on #1142  suggested using the past 12 months time frame by default. This changes the Analytics page to show the last year of data by default. It also adds a "tip" for the Start Date on what the earliest available data is.

![Screen Shot 2020-08-19 at 11 33 49](https://user-images.githubusercontent.com/443389/90663946-f3bf2a80-e20f-11ea-9351-29700e886b13.png)

## Additional information

"Previous year" is a surprisingly complicated concept (12 months, 365 days, 1 calendar year?). This just subtracts 1 from today's year.