### PR TITLE
Utilization analytics by organization

### DIFF
--- a/tock/api/tests.py
+++ b/tock/api/tests.py
@@ -8,7 +8,7 @@ from django.urls import reverse
 
 from django_webtest import WebTest
 
-from api.views import get_timecards, TimecardList
+from api.views import get_timecardobjects, TimecardList
 from employees.models import UserData, EmployeeGrade
 from hours.factories import (
     UserFactory, ReportingPeriodFactory, TimecardFactory, TimecardObjectFactory,
@@ -83,76 +83,76 @@ class TimecardsAPITests(WebTest):
         self.assertEqual(res[0]['grade'], 4)
 
     # TODO: test with more diverse data
-    def test_get_timecards(self):
+    def test_get_timecardobjects(self):
         """ Check that get time cards returns the correct queryset """
         # Check with no params
-        queryset = get_timecards(TimecardList.queryset)
+        queryset = get_timecardobjects(TimecardList.queryset)
         self.assertEqual(len(queryset), 2)
         # Check with after param
-        queryset = get_timecards(TimecardList.queryset,
+        queryset = get_timecardobjects(TimecardList.queryset,
             params={'after': '2020-12-31'})
         self.assertEqual(len(queryset), 0)
 
         # Check with date param
-        queryset = get_timecards(TimecardList.queryset,
+        queryset = get_timecardobjects(TimecardList.queryset,
                                  params={'date': '2000-01-01'})
         self.assertEqual(len(queryset), 0)
-        queryset = get_timecards(TimecardList.queryset,
+        queryset = get_timecardobjects(TimecardList.queryset,
                                  params={'date': '2015-06-08'})
         self.assertEqual(len(queryset), 1)
         # Check with user param
-        queryset = get_timecards(TimecardList.queryset,
+        queryset = get_timecardobjects(TimecardList.queryset,
                                  params={'user': '1'})
         self.assertEqual(len(queryset), 2)
-        queryset = get_timecards(TimecardList.queryset,
+        queryset = get_timecardobjects(TimecardList.queryset,
                                  params={'user': 'aaron.snow'})
         self.assertEqual(len(queryset), 2)
-        queryset = get_timecards(TimecardList.queryset,
+        queryset = get_timecardobjects(TimecardList.queryset,
                                  params={'user': '22'})
         self.assertEqual(len(queryset), 0)
         # Check with project param
-        queryset = get_timecards(TimecardList.queryset,
+        queryset = get_timecardobjects(TimecardList.queryset,
                                  params={'project': '1'})
         self.assertEqual(len(queryset), 2)
-        queryset = get_timecards(TimecardList.queryset,
+        queryset = get_timecardobjects(TimecardList.queryset,
                                  params={'project': 'Out Of Office'})
         self.assertEqual(len(queryset), 2)
-        queryset = get_timecards(TimecardList.queryset,
+        queryset = get_timecardobjects(TimecardList.queryset,
                                  params={'project': '22'})
         self.assertEqual(len(queryset), 0)
 
         # Check with before param
-        queryset = get_timecards(TimecardList.queryset,
+        queryset = get_timecardobjects(TimecardList.queryset,
                                  params={'before': '2015-06-01'})
         self.assertEqual(len(queryset), 1)
-        queryset = get_timecards(TimecardList.queryset,
+        queryset = get_timecardobjects(TimecardList.queryset,
                                  params={'before': '2015-05-31'})
         self.assertEqual(len(queryset), 0)
 
         # Check with a range using before and after param
-        queryset = get_timecards(TimecardList.queryset,
+        queryset = get_timecardobjects(TimecardList.queryset,
                                  params={'after': '2015-06-01', 'before': '2016-05-31'})
         self.assertEqual(len(queryset), 1)
-        queryset = get_timecards(TimecardList.queryset,
+        queryset = get_timecardobjects(TimecardList.queryset,
                                  params={'after': '2015-06-01', 'before': '2016-06-01'})
         self.assertEqual(len(queryset), 2)
 
 
     def test_get_unsubmitted_timecards(self):
         """ Check that get time cards returns the correct queryset """
-        queryset = get_timecards(
+        queryset = get_timecardobjects(
             TimecardList.queryset,
             params={'submitted': 'no'}
         )
         self.assertEqual(len(queryset), 1)
 
-        queryset = get_timecards(
+        queryset = get_timecardobjects(
             TimecardList.queryset,
             params={'submitted': 'yes'}
         )
         self.assertEqual(len(queryset), 2)
 
-        queryset = get_timecards(
+        queryset = get_timecardobjects(
             TimecardList.queryset,
             params={'submitted': 'foo'}
         )

--- a/tock/api/views.py
+++ b/tock/api/views.py
@@ -187,9 +187,9 @@ class TimecardList(generics.ListAPIView):
     serializer_class = TimecardSerializer
 
     def get_queryset(self):
-        return get_timecards(self.queryset, self.request.query_params)
+        return get_timecardobjects(self.queryset, self.request.query_params)
 
-def get_timecards(queryset, params=None):
+def get_timecardobjects(queryset, params=None):
     """
     Filter a TimecardObject queryset according to the provided GET
     query string parameters:

--- a/tock/api/views.py
+++ b/tock/api/views.py
@@ -237,6 +237,15 @@ def filter_timecards(queryset, params={}):
             reporting_period__start_date__lte=before_date
         )
 
+    if 'org' in params:
+        # filter on organization, "0" to include all orgs, "None" for
+        # "organization IS NULL"
+        org_id = params.get('org')
+        if org_id.isnumeric() and org_id != "0": # 0 indicates all organizations, no filtering then
+            queryset = queryset.filter(user__user_data__organization__id=org_id)
+        elif org_id.lower() == "none":  # the only allowable value that isn't numeric is None
+            queryset = queryset.filter(user__user_data__organization__isnull=True)
+
     return queryset
 
 

--- a/tock/hours/views.py
+++ b/tock/hours/views.py
@@ -7,7 +7,7 @@ from operator import attrgetter
 
 from api.renderers import stream_csv
 from api.views import (ProjectSerializer, TimecardList, UserDataSerializer,
-                       get_timecards)
+                       get_timecardobjects)
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import get_user_model
@@ -197,7 +197,7 @@ def bulk_timecard_list(request):
     """
     Stream all the timecards as CSV.
     """
-    queryset = get_timecards(TimecardList.queryset, request.GET)
+    queryset = get_timecardobjects(TimecardList.queryset, request.GET)
     serializer = BulkTimecardSerializer()
     return stream_csv(queryset, serializer)
 
@@ -207,7 +207,7 @@ def slim_bulk_timecard_list(request):
     """
     Stream a slimmed down version of all the timecards as CSV.
     """
-    queryset = get_timecards(TimecardList.queryset, request.GET)
+    queryset = get_timecardobjects(TimecardList.queryset, request.GET)
     serializer = SlimBulkTimecardSerializer()
     return stream_csv(queryset, serializer)
 
@@ -221,14 +221,14 @@ def general_snippets_only_timecard_list(request):
         project__accounting_code__billable=False,
         notes__isnull=False
     )
-    queryset = get_timecards(objects, request.GET)
+    queryset = get_timecardobjects(objects, request.GET)
     serializer = GeneralSnippetsTimecardSerializer()
     return stream_csv(queryset, serializer)
 
 
 def timeline_view(request, value_fields=(), **field_alias):
     """ CSV endpoint for the project timeline viz. """
-    queryset = get_timecards(TimecardList.queryset, request.GET)
+    queryset = get_timecardobjects(TimecardList.queryset, request.GET)
 
     fields = list(value_fields) + [
         'timecard__reporting_period__start_date',
@@ -299,7 +299,7 @@ def admin_bulk_timecard_list(request):
     if not request.user.is_superuser:
         raise PermissionDenied
 
-    queryset = get_timecards(TimecardList.queryset, request.GET)
+    queryset = get_timecardobjects(TimecardList.queryset, request.GET)
     serializer = AdminBulkTimecardSerializer()
     return stream_csv(queryset, serializer)
 

--- a/tock/tock/templates/utilization/utilization_analytics.html
+++ b/tock/tock/templates/utilization/utilization_analytics.html
@@ -22,18 +22,18 @@
         </div>
 
         <div class="usa-form-group grid-col-2">
-            <label class="usa-label" id="start-date-label" for="start">Start date</label>
+            <label class="usa-label" id="start-date-label" for="after">Start date</label>
             <div class="usa-hint" id="start-date-hint">YYYY-MM-DD (after {{ min_date }})</div>
             <div class="usa-date-picker">
-                <input class="usa-input usa-input--inline" id="start" name="start" type="text" aria-describedby="start-date-label start-date-hint" value="{{start_date}}">
+                <input class="usa-input usa-input--inline" id="after" name="after" type="text" aria-describedby="start-date-label start-date-hint" value="{{start_date}}">
             </div>
         </div>
 
         <div class="usa-form-group grid-col-2">
-            <label class="usa-label" id="end-date-label" for="end">End date</label>
+            <label class="usa-label" id="end-date-label" for="before">End date</label>
             <div class="usa-hint" id="end-date-hint">YYYY-MM-DD</div>
             <div class="usa-date-picker">
-                <input class="usa-input usa-input--inline" id="end" name="end" type="text" aria-describedby="end-date-label end-date-hint" value="{{end_date}}">
+                <input class="usa-input usa-input--inline" id="before" name="before" type="text" aria-describedby="end-date-label end-date-hint" value="{{end_date}}">
             </div>
         </div>
     </div>

--- a/tock/tock/templates/utilization/utilization_analytics.html
+++ b/tock/tock/templates/utilization/utilization_analytics.html
@@ -9,9 +9,19 @@
   <script src="{% static 'js/plotly-1.54.7.min.js' %}"></script>
   <script src="{% static 'js/components/save_csv.js' %}"></script>
 
-  <h2>Analytics</h2>
+  <h2>Analytics ({{ current_org_name }})</h2>
 
     <form class="usa-form">
+
+        <div class="usa-form-group">
+        <label class="usa-label" id="end-date-label" for="org">Organization</label>
+		<select class="usa-select" name="org" id="org">
+		{% for id, name in org_choices %}
+			<option value="{{ id }}"{% if current_org == id %} selected{% endif %}>{{ name }}</option>
+		{% endfor %}
+		</select>
+        </div>
+
         <div class="usa-form-group">
         <label class="usa-label" id="start-date-label" for="start">Start date</label>
         <div class="usa-hint" id="start-date-hint">YYYY-MM-DD (after {{ min_date }})</div>
@@ -28,7 +38,7 @@
         </div>
         </div>
 
-        <input class="usa-button" type="submit" value="Change Dates">
+        <input class="usa-button" type="submit" value="Select Data">
     </form>
 
   <h3>Overall Utilization</h3>

--- a/tock/tock/templates/utilization/utilization_analytics.html
+++ b/tock/tock/templates/utilization/utilization_analytics.html
@@ -9,37 +9,44 @@
   <script src="{% static 'js/plotly-1.54.7.min.js' %}"></script>
   <script src="{% static 'js/components/save_csv.js' %}"></script>
 
-  <h2>Analytics ({{ current_org_name }})</h2>
+    <form class="usa-form maxw-full">
 
-    <form class="usa-form">
-
-        <div class="usa-form-group">
-        <label class="usa-label" id="end-date-label" for="org">Organization</label>
-		<select class="usa-select" name="org" id="org">
-		{% for id, name in org_choices %}
-			<option value="{{ id }}"{% if current_org == id %} selected{% endif %}>{{ name }}</option>
-		{% endfor %}
-		</select>
+    <div class="grid-row grid-gap flex-align-end margin-top-neg-3 ">
+        <div class="usa-form-group grid-col-2 grid-offset-6">
+            <label class="usa-label" id="end-date-label" for="org">Organization</label>
+            <select class="usa-select" name="org" id="org">
+            {% for id, name in org_choices %}
+                <option value="{{ id }}"{% if current_org == id %} selected{% endif %}>{{ name }}</option>
+            {% endfor %}
+            </select>
         </div>
 
-        <div class="usa-form-group">
-        <label class="usa-label" id="start-date-label" for="start">Start date</label>
-        <div class="usa-hint" id="start-date-hint">YYYY-MM-DD (after {{ min_date }})</div>
-        <div class="usa-date-picker">
-            <input class="usa-input usa-input--inline" id="start" name="start" type="text" aria-describedby="start-date-label start-date-hint" value="{{start_date}}">
-        </div>
-        </div>
-
-        <div class="usa-form-group">
-        <label class="usa-label" id="end-date-label" for="end">End date</label>
-        <div class="usa-hint" id="end-date-hint">YYYY-MM-DD</div>
-        <div class="usa-date-picker">
-            <input class="usa-input usa-input--inline" id="end" name="end" type="text" aria-describedby="end-date-label end-date-hint" value="{{end_date}}">
-        </div>
+        <div class="usa-form-group grid-col-2">
+            <label class="usa-label" id="start-date-label" for="start">Start date</label>
+            <div class="usa-hint" id="start-date-hint">YYYY-MM-DD (after {{ min_date }})</div>
+            <div class="usa-date-picker">
+                <input class="usa-input usa-input--inline" id="start" name="start" type="text" aria-describedby="start-date-label start-date-hint" value="{{start_date}}">
+            </div>
         </div>
 
+        <div class="usa-form-group grid-col-2">
+            <label class="usa-label" id="end-date-label" for="end">End date</label>
+            <div class="usa-hint" id="end-date-hint">YYYY-MM-DD</div>
+            <div class="usa-date-picker">
+                <input class="usa-input usa-input--inline" id="end" name="end" type="text" aria-describedby="end-date-label end-date-hint" value="{{end_date}}">
+            </div>
+        </div>
+    </div>
+
+    <div class="grid-row">
+    <div class="grid-col-2 grid-offset-6">
         <input class="usa-button" type="submit" value="Select Data">
+    </div>
+    </div>
     </form>
+
+  <div class="grid-row"><div class="grid-col">
+  <h2>Analytics ({{ current_org_name }})</h2>
 
   <h3>Overall Utilization</h3>
   {{utilization_plot|safe}}
@@ -50,4 +57,7 @@
   {{headcount_plot|safe}}
 
   {% frame_table headcount_data "headcount" as table2 %}{{table2|safe}}
+
+  </div></div>
+
 {% endblock %}

--- a/tock/utilization/analytics.py
+++ b/tock/utilization/analytics.py
@@ -1,4 +1,3 @@
-from django.apps import apps
 from django.db.models import Count, F, Q, Sum
 
 import pandas as pd
@@ -111,22 +110,13 @@ def utilization_plot(data_frame):
     return plot_div
 
 
-def utilization_data(start_date, end_date, org_id):
+def utilization_data(timecard_queryset):
     """Get a data frame of utilization data.
-
-    If org_id is 0, get results for all organizations, otherwise filter
-    to a single organization by id.
 
     Has start_date, billable, and nonbillable columns.
     """
-    org_query = _get_org_query(org_id)
-    Timecard = apps.get_model("hours", "Timecard")
     data = (
-        Timecard.objects.filter(
-            reporting_period__start_date__gte=start_date,
-            reporting_period__end_date__lte=end_date,
-        )
-        .filter(org_query)
+        timecard_queryset
         .values(start_date=F("reporting_period__start_date"))
         .annotate(
             billable=Sum("billable_hours"),
@@ -174,23 +164,13 @@ def headcount_plot(data_frame):
     return plot_div
 
 
-def headcount_data(start_date, end_date, org_id):
+def headcount_data(timecard_queryset):
     """Get a data frame of Tock head count.
-
-    If org_id is 0, get results for all organizations, otherwise filter
-    to a single organization by id.
 
     Result has start_date, headcount and organization columns.
     """
-    Timecard = apps.get_model("hours", "Timecard")
-
-    org_query = _get_org_query(org_id)
     data = (
-        Timecard.objects.filter(
-            reporting_period__start_date__gte=start_date,
-            reporting_period__end_date__lte=end_date,
-        )
-        .filter(org_query)
+        timecard_queryset
         .values(
             start_date=F("reporting_period__start_date"),
             org=F(  # use "org" temporarily to avoid name collision

--- a/tock/utilization/analytics.py
+++ b/tock/utilization/analytics.py
@@ -17,7 +17,6 @@ def compute_utilization(data_frame):
 
 
 def _get_org_query(org_id):
-    Organization = apps.get_model("organizations", "Organization")
     # short circuit this one first
     if org_id is None:
         return Q(user__user_data__organization__id__isnull=True)

--- a/tock/utilization/analytics.py
+++ b/tock/utilization/analytics.py
@@ -93,12 +93,19 @@ def utilization_plot(data_frame):
 
     fig.update_layout(
         autosize=False,
-        width=1000,
-        height=700,
+        width=960,
+        height=720,
         xaxis=dict(autorange=True),
         yaxis=dict(autorange=True),
         title_text="Total Hours recorded vs. Time",
         hovermode="x",
+        legend=dict(
+            orientation="h",
+            yanchor="bottom",
+            y=1.02,
+            xanchor="right",
+            x=1,
+        ),
     )
 
     plot_div = plot(fig, output_type="div", include_plotlyjs=False)
@@ -154,6 +161,13 @@ def headcount_plot(data_frame):
         yaxis_title="",
         title_text="Number of Tockers vs. Time",
         hovermode="x",
+        legend=dict(
+            orientation="h",
+            yanchor="bottom",
+            y=1.02,
+            xanchor="right",
+            x=1,
+        ),
     )
     fig.update_traces(hovertemplate="%{y}")
 

--- a/tock/utilization/tests/test_views.py
+++ b/tock/utilization/tests/test_views.py
@@ -233,7 +233,7 @@ class TestAnalyticsView(TestGroupUtilizationView):
     def test_analytics_start(self):
 
         response = self.app.get(
-            url=reverse('utilization:UtilizationAnalyticsView') + "?start=2020-01-01",
+            url=reverse('utilization:UtilizationAnalyticsView') + "?after=2020-01-01",
             user=self.user
         )
         self.assertEqual(response.status_code, 200)
@@ -241,7 +241,7 @@ class TestAnalyticsView(TestGroupUtilizationView):
     def test_analytics_end(self):
 
         response = self.app.get(
-            url=reverse('utilization:UtilizationAnalyticsView') + "?end=2020-01-01",
+            url=reverse('utilization:UtilizationAnalyticsView') + "?before=2020-01-01",
             user=self.user
         )
         self.assertEqual(response.status_code, 200)

--- a/tock/utilization/tests/test_views.py
+++ b/tock/utilization/tests/test_views.py
@@ -229,3 +229,33 @@ class TestAnalyticsView(TestGroupUtilizationView):
         )
 
         self.assertEqual(response.status_code, 200)
+
+    def test_analytics_start(self):
+
+        response = self.app.get(
+            url=reverse('utilization:UtilizationAnalyticsView') + "?start=2020-01-01",
+            user=self.user
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_analytics_end(self):
+
+        response = self.app.get(
+            url=reverse('utilization:UtilizationAnalyticsView') + "?end=2020-01-01",
+            user=self.user
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_analytics_all_orgs(self):
+        response = self.app.get(
+            url=reverse('utilization:UtilizationAnalyticsView') + "?org=0",
+            user=self.user
+        )
+        self.assertContains(response, "All Organizations")
+
+    def test_analytics_one_org(self):
+        response = self.app.get(
+            url=reverse('utilization:UtilizationAnalyticsView') + "?org=1",
+            user=self.user
+        )
+        self.assertContains(response, " Organization")

--- a/tock/utilization/views.py
+++ b/tock/utilization/views.py
@@ -4,8 +4,8 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db.models import F
 from django.views.generic import ListView, TemplateView
-from hours.models import ReportingPeriod
-from organizations.models import Unit
+from hours.models import ReportingPeriod, Timecard
+from organizations.models import Organization, Unit
 
 from .org import org_billing_context
 from .unit import unit_billing_context
@@ -88,7 +88,6 @@ class UtilizationAnalyticsView(LoginRequiredMixin, TemplateView):
         elif org_id == 0:
             context.update({"current_org_name": "All Organizations"})
         else:
-            Organization = apps.get_model("organizations", "Organization")
             name = Organization.objects.filter(id=org_id).values("name").first()["name"]
             context.update({"current_org_name": name + " Organization"})
 
@@ -98,7 +97,6 @@ class UtilizationAnalyticsView(LoginRequiredMixin, TemplateView):
         context.update({"min_date": min_date})
 
         # organization choices
-        Timecard = apps.get_model("hours", "Timecard")
         org_choices = [
             (item["org_id"], item["name"])
             for item in Timecard.objects.values(

--- a/tock/utilization/views.py
+++ b/tock/utilization/views.py
@@ -4,6 +4,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db.models import F
 from django.views.generic import ListView, TemplateView
+from api.views import filter_timecards
 from hours.models import ReportingPeriod, Timecard
 from organizations.models import Organization, Unit
 
@@ -68,14 +69,21 @@ class UtilizationAnalyticsView(LoginRequiredMixin, TemplateView):
     def get_context_data(self, **kwargs):
         context = super(UtilizationAnalyticsView, self).get_context_data(**kwargs)
 
+        # we need a mutable copy of the request parameters so we can add
+        # defaults that might not be set
+        params = self.request.GET.copy()
+
         # use one year ago as the default start date
         d = date.today()
-        start_date = self.request.GET.get("start", d.replace(year=d.year - 1).isoformat())
-        end_date = self.request.GET.get("end", d.isoformat())
+        # use setdefault here because if these parameters aren't sent, then we
+        # want to add them with these default values so that they will get
+        # used later in filter_timecards
+        start_date = params.setdefault("after", d.replace(year=d.year - 1).isoformat())
+        end_date = params.setdefault("before", d.isoformat())
         context.update({"start_date": start_date, "end_date": end_date})
 
         # get organization ID from the URL and put it in the context
-        org_parameter = self.request.GET.get("org", 0)
+        org_parameter = params.get("org", 0)
         if org_parameter == "None":
             org_id = None
         else:
@@ -88,7 +96,7 @@ class UtilizationAnalyticsView(LoginRequiredMixin, TemplateView):
         elif org_id == 0:
             context.update({"current_org_name": "All Organizations"})
         else:
-            name = Organization.objects.filter(id=org_id).values("name").first()["name"]
+            name = Organization.objects.get(id=org_id).name
             context.update({"current_org_name": name + " Organization"})
 
         # give a tip about the oldest possible date
@@ -108,8 +116,11 @@ class UtilizationAnalyticsView(LoginRequiredMixin, TemplateView):
         org_choices = [(0, 'All')] + org_choices
         context.update({"org_choices": org_choices})
 
+        # Use our common timecard query handling of parameters
+        timecard_queryset = filter_timecards(Timecard.objects, params=params)
+
         # add the utilization plot to the context
-        utilization_data_frame = utilization_data(start_date, end_date, org_id)
+        utilization_data_frame = utilization_data(timecard_queryset)
         utilization_data_frame["utilization_rate"] = (
             100 * compute_utilization(utilization_data_frame)
         ).map("{:,.1f}%".format)
@@ -121,7 +132,7 @@ class UtilizationAnalyticsView(LoginRequiredMixin, TemplateView):
         )
 
         # add the headcount plot to the context
-        headcount_data_frame = headcount_data(start_date, end_date, org_id)
+        headcount_data_frame = headcount_data(timecard_queryset)
         context.update(
             {
                 "headcount_data": headcount_data_frame.pivot(


### PR DESCRIPTION
## Description

This adds the capability to look at Tock data at the level of a single organization. This is especially valuable because utilization rate makes the most sense for the 18F organization without mixing in cloud.gov, login.gov, CoE, etc.

![Screen Shot 2020-08-20 at 12 15 55](https://user-images.githubusercontent.com/443389/90803812-efae0e00-e2de-11ea-9224-b481e377a79b.png)

## Additional information

There is a layout re-design for the form that selects orgs and dates to make it less intrusive on the space available for the graphs.  There is also a pesky `NULL` organization in the oldest tock data that needed special handling.