### PR TITLE
Fix our use of PermissionMixin

### DIFF
--- a/tock/hours/views.py
+++ b/tock/hours/views.py
@@ -674,6 +674,7 @@ class ReportsList(PermissionMixin, ListView):
 class ReportingPeriodDetailView(PermissionMixin, ListView):
     template_name = 'hours/reporting_period_detail.html'
     context_object_name = 'timecard_list'
+    permission_classes = (IsAuthenticated, )
 
     def dispatch(self, *args, **kwargs):
         """

--- a/tock/projects/views.py
+++ b/tock/projects/views.py
@@ -1,15 +1,15 @@
 from collections import defaultdict
 
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db.models import Sum
 from django.views.generic import ListView
 from django.views.generic.detail import DetailView
 
 from hours.models import TimecardObject
 from .models import Project
-from tock.utils import PermissionMixin
 
 
-class ProjectListView(PermissionMixin, ListView):
+class ProjectListView(LoginRequiredMixin, ListView):
     """ View for listing all of the projects, sort projects by name """
     model = Project
     template_name = 'projects/project_list.html'
@@ -21,7 +21,7 @@ class ProjectListView(PermissionMixin, ListView):
         return context
 
 
-class ProjectView(PermissionMixin, DetailView):
+class ProjectView(LoginRequiredMixin, DetailView):
     """ View for listing the details of a specific project """
     model = Project
     template_name = 'projects/project_detail.html'

--- a/tock/tock/utils.py
+++ b/tock/tock/utils.py
@@ -27,7 +27,7 @@ class PermissionMixin(LoginRequiredMixin, object):
             self.request = request
             self.args = args
             self.kwargs = kwargs
-            for permission_class in getattr(cls, 'permission_classes', ()):
+            for permission_class in getattr(cls, 'permission_classes'):
                 if not permission_class().has_permission(request, self):
                     if isinstance(permission_class(), IsAuthenticated):
                         logger.info('User not authenticated, redirecting to UAA.')

--- a/tock/utilization/views.py
+++ b/tock/utilization/views.py
@@ -1,10 +1,10 @@
 from datetime import date
 
 from django.contrib.auth import get_user_model
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.views.generic import ListView, TemplateView
 from hours.models import ReportingPeriod
 from organizations.models import Unit
-from tock.utils import PermissionMixin
 
 from .org import org_billing_context
 from .unit import unit_billing_context
@@ -18,7 +18,7 @@ from .analytics import (
 
 User = get_user_model()
 
-class GroupUtilizationView(PermissionMixin, ListView):
+class GroupUtilizationView(LoginRequiredMixin, ListView):
     template_name = 'utilization/group_utilization.html'
     requested_periods = 4
 
@@ -61,7 +61,7 @@ class GroupUtilizationView(PermissionMixin, ListView):
         return context
 
 
-class UtilizationAnalyticsView(PermissionMixin, TemplateView):
+class UtilizationAnalyticsView(LoginRequiredMixin, TemplateView):
     template_name = "utilization/utilization_analytics.html"
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
## Description

In  #1138  @jkrzy noticed that we were mis-using the `PermissionMixin` class with no `permission_classes` which restricts nothing. This corrects that by using `LoginRequiredMixin` in those cases and prevents it from happening again by making it an exception to use `PermissionMixin` without defining the `permission_classes` attribute.

## Additional information

We could go further with this and replace all of the correct uses of `PermissionMixin` with `permission_classes = (IsAuthenticated, )` by `LoginRequiredMixin` but I haven't done that here. I'm willing though if people would prefer it.