### PR TITLE
Add ID as project search field

### DIFF
--- a/tock/projects/admin.py
+++ b/tock/projects/admin.py
@@ -119,7 +119,7 @@ class ProjectAdmin(admin.ModelAdmin):
     list_editable = (
         'organization',
     )
-    search_fields = ('name', 'accounting_code__code', 'mbnumber',)
+    search_fields = ('name', 'accounting_code__code', 'mbnumber', 'id',)
 
     def get_organization_name(self, obj):
         if obj.organization is not None:


### PR DESCRIPTION
## Description

As requested by Matt Spencer, adding ID as a `Project` search field in the admin panel.

resolves #1173