### PR TITLE
Correct billable target updating management command and admin tweak

### DIFF
--- a/tock/employees/admin.py
+++ b/tock/employees/admin.py
@@ -61,6 +61,7 @@ class UserDataAdmin(admin.ModelAdmin):
         'organization',
         'unit',
     )
+    list_editable = ('expected_billable_hours',)
     search_fields = ('user__username',)
 
     def unit_info(self, obj):

--- a/tock/tock/management/commands/update_billable_expectations.py
+++ b/tock/tock/management/commands/update_billable_expectations.py
@@ -58,7 +58,7 @@ class Command(BaseCommand):
                         [self._update_timecard(timecard, target_billable_expectation) for timecard in timecards]
 
                         if update_user_data:
-                            self._update_userdata(username, target_billable_expectation)
+                            self._update_userdata(username, target)
                             self.stdout.write(f'Updated UserData.billable_expectation for {username} to target hours {target}')
 
             except FileNotFoundError:


### PR DESCRIPTION
## Description

In https://github.com/18F/tock/pull/1189 we updated a management command to update `UserData.expected_billable_hours` but we did not _also_ update the value which was being saved there.

This PR changes the management command such that an integer is saved to `UserData.expected_billable_hours` as opposed to a decimal percentage of billable expectations. Allowing us to resolve https://github.com/18F/tock/issues/1183.

Also enables list-editing of billable targets in the UserAdmin list view.