### PR TITLE
Specify npm version for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
 
       - run:
           name: update npm
-          command: sudo npm install -g npm
+          command: sudo npm install -g npm@latest-6
 
       - run:
           name: install dependencies


### PR DESCRIPTION
## Description

Update the circle ci config to pin npm to latest-6.

## Additional information

Reference: https://github.com/npm/cli/issues/2599