### PR TITLE
Add username to utilization templates

### DIFF
--- a/tock/tock/templates/utilization/includes/unit_utilization_table.html
+++ b/tock/tock/templates/utilization/includes/unit_utilization_table.html
@@ -21,7 +21,7 @@
         {% for employee in unit.utilization.last_week_data %}
         <tr>
             <td>
-                <a href="{% url 'employees:UserDetailView' employee.display_name %}">{{employee.display_name}}</a>
+                <a href="{% url 'employees:UserDetailView' employee.username %}">{{employee.display_name}}</a>
             </td>
             {% with unit.utilization.last_week_data|index:forloop.counter0 as data %}
                 {% include 'utilization/includes/unit_utilization_cell.html' %}

--- a/tock/utilization/unit.py
+++ b/tock/utilization/unit.py
@@ -56,7 +56,8 @@ def _get_unit_billing_data(users, unit, recent_periods=None, fiscal_year=False):
                 'display_name': f"{employee['first_name']} {employee['last_name']}".strip() or employee['username'],
                 'denominator': employee['target'],
                 'billable': employee['billable'],
-                'utilization': calculate_utilization(employee['billable'], employee['target'])
+                'utilization': calculate_utilization(employee['billable'], employee['target']),
+                'username': employee['username']
                 } for employee in data]
 
         # Get totals for unit


### PR DESCRIPTION

## Description

Resolves #1233 by adding `username` back to the report template context so it can be used to render the EmployeeDetail link. 

We're passing raw python structures to the template so we're building the urls in the template as opposed to using Django convenience methods like `.get_absolute_url`
