### PR TITLE
Clear delete inputs for newly added tock lines

### DIFF
--- a/tock/tock/static/js/components/timecard.js
+++ b/tock/tock/static/js/components/timecard.js
@@ -232,16 +232,13 @@ function addEntry() {
   // remove display: none style
   newEntry.querySelector('select').style.display = '';
 
-  let fields = newEntry.querySelectorAll('input, select, textarea');
-  // remove values
-  for (f of fields) {
-    if (f.matches('[type="checkbox"]')) {
-      f.checked = false;
-    }
-    else {
+  let non_checkbox_fields = newEntry.querySelectorAll('input:not([type="checkbox"]), select, textarea');
+  // remove values for fields we've cloned
+  for (f of non_checkbox_fields) {
       f.value = '';
-    }
   }
+  // Uncheck the cloned Delete input
+  newEntry.querySelector('.entry-delete input').checked = false
 
   newEntry.querySelector('.autocomplete__wrapper').remove();
 

--- a/tock/tock/static/js/components/timecard.js
+++ b/tock/tock/static/js/components/timecard.js
@@ -235,7 +235,12 @@ function addEntry() {
   let fields = newEntry.querySelectorAll('input, select, textarea');
   // remove values
   for (f of fields) {
-    f.value = '';
+    if (f.matches('[type="checkbox"]')) {
+      f.checked = false;
+    }
+    else {
+      f.value = '';
+    }
   }
 
   newEntry.querySelector('.autocomplete__wrapper').remove();

--- a/tock/tock/tests/js/integration/timecard.test.js
+++ b/tock/tock/tests/js/integration/timecard.test.js
@@ -29,6 +29,23 @@ describe("Timecard", () => {
       expect(_entries.length).toEqual(length + 1);
     });
 
+    test('added project entry has an unchecked delete input', async () => {
+      const entries = await page.$$(".entry");
+      const length = entries.length;
+      // Find and check the last delete input on the page
+      const last_entry_idx = length - 1
+      const _del = "#id_timecardobjects-" + last_entry_idx + "-DELETE";
+      await page.$$eval(_del, checks => checks.forEach(c => c.checked = true));
+
+      // add new entry
+      await page.click(".add-timecard-entry");
+
+      // Is the newly added input checked? It shouldn't be
+      const _new_delete_input = await page.$("#id_timecardobjects-" + length + "-DELETE");
+      checked = await (await _new_delete_input.getProperty('checked')).jsonValue();
+      expect(checked).toEqual(false);
+    });
+
     test('increments the django management form when "Add Item" is clicked', async () => {
       await page.click(".add-timecard-entry");
       const _entries = await page.$$(".entry");


### PR DESCRIPTION
## Description

When a new project line is added to a timecard the delete input must be unchecked.

### Additional details
My test here feels not great, would appreciate any recommendations to simplify where possible!