### PR TITLE
Render note fields on timecards when there are more than 10 project lines

### DIFF
--- a/tock/tock/static/js/components/timecard.js
+++ b/tock/tock/static/js/components/timecard.js
@@ -242,7 +242,7 @@ function addEntry() {
 
   newEntry.querySelector('.autocomplete__wrapper').remove();
 
-  const previousNumber = parseInt(newEntry.getAttribute('id').match(/\d/)[0]);
+  const previousNumber = parseInt(newEntry.getAttribute('id').match(/\d+/)[0]);
   const nextNumber = entries.length;
 
   if (nextNumber % 2 == 0) {


### PR DESCRIPTION
## Description

Resolves #1244 wherein a friend of Tock noticed that project note fields were not being displayed on timecards when there were 10 or more project lines. 

When incrementing project element ids we now match the whole numeric id of the previous element.