### PR TITLE
Add API endpoint for fetching timecard data

### DIFF
--- a/api-docs/README.md
+++ b/api-docs/README.md
@@ -32,7 +32,8 @@ To access similar data in CSV format within Tock, please visit the
 - [Reporting period (audit specific time period)](reporting-period-audit-specific.md): Fetches a list of all users who have not submitted a timecard for the specified period.
 - [Reporting periods](reporting-period-audit.md): Fetches a list of all available reporting periods and basic information about them.
 - [Submissions by range](submissions.md): Fetches a list of users and a count of timecards submitted on or before the last day of each timecard's reporting period.
-- [Timecards](timecards.md): Fetches a list of all submitted timecards and related information.
+- [Timecards](timecards.md): Fetches a list of all submitted timecard objects and related information. Note that a "timecard object" here represents time a person spent on a given project. It's a more granular view of what someone worked on (compared to the "full timecards" endpoint, documented below).
+- [Full timecards](full-timecards.md): Fetches a list of all timecards and related information. Note that a "timecard" here is different from a "timecard object" - a "timecard" is a higher level representation of what a person worked on during a reporting period, which could include many projects for varying periods of time, but that level of granularity is not captuired here. If you want project-level data, don't use this endpoint - use the "Timecards" one above.
 - [User data](user-data.md): Fetches a list of all users, along with organizational information for each.
 - [Users](users.md): Fetches a list of all users, along with basic information about them.
 

--- a/api-docs/full-timecards.md
+++ b/api-docs/full-timecards.md
@@ -1,0 +1,52 @@
+**Full timecard info**
+----
+To fetch a list of timecards and related info.
+
+* **URL**
+
+  /full_timecards.json
+
+* **Method:**
+
+  `GET`
+  
+*  **URL params**
+
+   **Required:**
+   None.
+   
+   **Optional:**
+   - `only_submitted=true` - Returns only timecards that have been submitted.
+   - `earliest_reporting_period_start=YYYY-MM-DD` - Returns only timecards whose reporting period start date was _after_ the provided date. 
+
+* **Success response:**
+
+  * **Code:** `200` <br />
+    **Content:** 
+```
+[
+   {
+      "hours_spent" : 16,
+      "submitted" : false,
+      "billable_hours" : "16.00",
+      "excluded_hours" : "0.00",
+      "submitted_date" : null,
+      "non_billable_hours" : "0.00",
+      "reporting_period_start_date" : "2021-04-18",
+      "target_hours" : "13.00",
+      "billable_expectation" : "0.80",
+      "id" : 4412,
+      "reporting_period_end_date" : "2021-04-24",
+      "user_name" : "nick.user",
+      "utilization" : "1.23"
+   },...
+]
+```
+* **Sample call:**
+
+```
+$ curl localhost:8000/api/full_timecards.json\?earliest_reporting_period_start=2021-04-01 -H 'Authorization: Token N0TaR@elT0k3n'
+```
+
+* **Notes:** The sample call includes all optional parameters.
+ 

--- a/api-docs/full-timecards.md
+++ b/api-docs/full-timecards.md
@@ -1,6 +1,6 @@
 **Full timecard info**
 ----
-To fetch a list of timecards and related info.
+To fetch a list of timecards and related info. By default, only timecards that have already been submitted are returned (see the `submitted` parameter below to change that behavior).
 
 * **URL**
 
@@ -16,8 +16,13 @@ To fetch a list of timecards and related info.
    None.
    
    **Optional:**
-   - `only_submitted=true` - Returns only timecards that have been submitted.
-   - `earliest_reporting_period_start=YYYY-MM-DD` - Returns only timecards whose reporting period start date was _after_ the provided date. 
+   - `submitted=` - By default, only timecards which have been submitted are returned. Pass `no` as the value for this argument to fetch timecards that have _not_ been submitted.
+   - `date=YYYY-MM-DD` — Returns timecard data for the reporting period in which the YYYY-MM-DD value falls.
+   - `after=YYYY-MM-DD` — Returns timecard data for reporting periods whose end date falls on or after YYYY-MM-DD.
+   - `before=YYYY-MM-DD` — Returns timecard data for the reporting periods whose start date falls on or before YYYY-MM-DD.
+   - `user=firstname.lastname` — Returns timecard data for the specified user. Accepts either a username or a user's numeric ID.
+   - `project=id` or `project=name` — Returns timecard data for the specifed project by either the project's database `pk` value or the project's `name` value.
+   - `org=id` - Returns timecard data for users belonging to a specific organization ID. Options: 0 - include all organizations. "none" - include timecards from users who belong to no organizations. Any other number - only return timecards for users belonging to that organization.
 
 * **Success response:**
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -106,6 +106,9 @@ npm run test
 
 If you need help debugging the jest-puppeteer tests, try turning off the `headless` mode in [the puppeteer configuration file](jest-puppeteer.config.js)
 
+### Manually testing API endpoints
+All endpoints require a token in the request header. You can generate a token for yourself locally in the Django admin console, [under Auth Token](http://localhost:8000/admin/authtoken/), using any user. API endpoints can be tested manually using that token - see the [API docs for more detail](../api-docs/README.md).
+
 ### Making CSS changes
 
 `docker-compose up` will also launch a [Node] machine that compiles the [Sass]

--- a/tock/api/tests.py
+++ b/tock/api/tests.py
@@ -345,3 +345,31 @@ class ReportingPeriodList(WebTest):
             )
         ).data
         self.assertEqual(len(res), 0)
+
+class FullTimecardsAPITests(WebTest):
+    fixtures = FIXTURES
+
+    def test_with_no_filters(self):
+        res = client().get(reverse('FullTimecardList')).data
+        self.assertEqual(len(res), 3)
+
+    def test_only_submitted_filter(self):
+        res = client().get(
+            reverse('FullTimecardList'), {'only_submitted': True}
+        ).data
+        self.assertEqual(len(res), 2)
+        self.assertTrue(all(tc['submitted'] for tc in res))
+
+    def test_earliest_reporting_period_start_filter(self):
+        res = client().get(
+            reverse('FullTimecardList'),
+            {'earliest_reporting_period_start': '2016-06-08'}
+        ).data
+        self.assertEqual({2, 3}, set(tc['id'] for tc in res))
+
+    def test_bad_date_format_returns_400(self):
+        res = client().get(
+            reverse('FullTimecardList'),
+            {'earliest_reporting_period_start': 'N0T-A-D8'}
+        )
+        self.assertEqual(res.status_code, 400)

--- a/tock/api/urls.py
+++ b/tock/api/urls.py
@@ -3,7 +3,7 @@
 from django.urls import path, re_path
 
 from api.views import ProjectList, ProjectInstanceView, UserList, ReportingPeriodList, ReportingPeriodAudit, \
-    Submissions, TimecardList, hours_by_quarter, hours_by_quarter_by_user, UserDataView
+    Submissions, TimecardList, hours_by_quarter, hours_by_quarter_by_user, UserDataView, FullTimecardList
 
 urlpatterns = [
     path('projects.json', ProjectList.as_view(), name='ProjectList'),
@@ -19,7 +19,11 @@ urlpatterns = [
         Submissions.as_view(),
         name='Submissions'
     ),
+    # Note that this endpoint returns TimecardObjects
     path('timecards.json', TimecardList.as_view(), name='TimecardList'),
+    # ...and this one returns Timecards (referred to as "full timecards" to disambiguate
+    # from existing endpoints / naming conventions)
+    path('full_timecards.json', FullTimecardList.as_view(), name='FullTimecardList'),
     path('hours/by_quarter.json', hours_by_quarter, name='HoursByQuarter'),
     path('hours/by_quarter_by_user.json', hours_by_quarter_by_user, name='HoursByQuarterByUser'),
     path('users.json', UserList.as_view(), name='UserList'),

--- a/tock/api/views.py
+++ b/tock/api/views.py
@@ -3,7 +3,7 @@ import datetime
 
 from django.contrib.auth import get_user_model
 from django.db import connection
-from django.db.models import Count, F, Sum
+from django.db.models import Count, F
 
 from rest_framework import serializers, generics
 from rest_framework.exceptions import ParseError

--- a/tock/hours/models.py
+++ b/tock/hours/models.py
@@ -229,6 +229,12 @@ class ReportingPeriod(ValidateOnSaveMixin, models.Model):
 
 
 class Timecard(models.Model):
+    """
+    A Timecard is a top-level representation of what a user worked on during a reporting period.
+
+    For details on what projects they worked on and for how long, you'll want to access the
+    associated `TimecardObject` objects, which store that level of detail.
+    """
     user = models.ForeignKey(User, related_name='timecards', on_delete=models.CASCADE)
     reporting_period = models.ForeignKey(ReportingPeriod, on_delete=models.CASCADE)
     time_spent = models.ManyToManyField(Project, through='TimecardObject')
@@ -455,6 +461,12 @@ class TimecardNote(models.Model):
         super(TimecardNote, self).save(*args, **kwargs)
 
 class TimecardObject(models.Model):
+    """
+    Not to be confused with a Timecard, a TimecardObject can be thought of as one "entry" in a Timecard,
+    i.e. for a given billing period, one person generally has one Timecard, but many TimecardObjects ("entries"). Each
+    represents a project that person worked on, and the amount of time (and some other data defined
+    below).
+    """
     timecard = models.ForeignKey(Timecard, related_name='timecardobjects', on_delete=models.CASCADE)
     project = models.ForeignKey(Project, on_delete=models.CASCADE)
     hours_spent = models.DecimalField(decimal_places=2,


### PR DESCRIPTION
## Description

This addresses #1259 by adding a new endpoint to fetch Timecard data. It's ready for review, but I'm expecting we'll want to discuss some of the details of what exact data and query parameters to include.

## Additional information
This is based on some initial conversation in #1259. I didn't attempt to refactor any of the "timecard" vs "timecard object" verbiage in various API endpoints, serializers, or API views, though I'm definitely open to that idea. I did add some documentation around that in hopes of making that distinction clearer to future code readers and writers. As-is, I used "full timecard" to mean `Timecard` to disambiguate from the existing use of "timecard" referring to `TimecardObject`s (e.g. the existing `/timecards.json` endpoint returns `TimecardObject`s). 