### PR TITLE
Add “https (443)” to logging connections as per SSP review request.

### DIFF
--- a/docs/diagrams/network.puml
+++ b/docs/diagrams/network.puml
@@ -44,8 +44,8 @@ note on link
 end note
 
 ' Logs flow
-Rel(app, cloudgov_logdrain, "logs to", "stdout/stderr")
-Rel(app_staging, cloudgov_logdrain, "logs to", "stdout/stderr")
+Rel(app, cloudgov_logdrain, "logs to stdout/stderr", "https (443)")
+Rel(app_staging, cloudgov_logdrain, "logs to stdout/stderr", "https (443)")
 
 
 ' User access
@@ -86,5 +86,4 @@ end note
 
 Rel(cloudgov_elb, app, "proxies to", "https GET/POST (variable)")
 Rel(cloudgov_elb, app_staging, "proxies to", "https GET/POST (variable)")
-
 @enduml

--- a/docs/diagrams/network.puml
+++ b/docs/diagrams/network.puml
@@ -86,4 +86,5 @@ end note
 
 Rel(cloudgov_elb, app, "proxies to", "https GET/POST (variable)")
 Rel(cloudgov_elb, app_staging, "proxies to", "https GET/POST (variable)")
+
 @enduml


### PR DESCRIPTION
Without showing ports
How will we know what's secure?
Add the port numbers.

During the SSP review we were asked to add `https (443)` to the logging connection lines in the network diagram. This commit adds that information in as minimal way as I could find.