### PR TITLE
Update 'warn' to 'warning' since 'warn' is being deprecated

### DIFF
--- a/tock/tock/remote_user_auth.py
+++ b/tock/tock/remote_user_auth.py
@@ -34,7 +34,7 @@ def verify_userdata(user):
     try:
         user = UserData.objects.get(user=user)
     except UserData.DoesNotExist:
-        logger.warn(
+        logger.warning(
             f'Creating UserData for {user.username}.'
         )
         UserData.objects.create(
@@ -71,7 +71,7 @@ class TockUserBackend(UaaBackend):
             )
             user = User.objects.get(username=username)
         except User.DoesNotExist:
-            logger.warn(
+            logger.warning(
                 f'Creating User for {username}'
             )
             user = User.objects.create_user(username, email)

--- a/tock/tock/utils.py
+++ b/tock/tock/utils.py
@@ -32,7 +32,7 @@ class PermissionMixin(LoginRequiredMixin, object):
                     if isinstance(permission_class(), IsAuthenticated):
                         logger.info('User not authenticated, redirecting to UAA.')
                         return redirect('/auth/login')
-                    logger.warn(
+                    logger.warning(
                         f'User not authorized {request.user.username}, redirecting to 404.'
                     )
                     raise PermissionDenied

--- a/tock/tock/views.py
+++ b/tock/tock/views.py
@@ -12,7 +12,7 @@ logger = logging.getLogger('tock')
 
 
 def csrf_failure(request, reason=""):
-    logger.warn(
+    logger.warning(
         'CSRF Failure for request [%s] for reason [%s]' %
         (
             request.META,


### PR DESCRIPTION
## Description

Resolves 1306

## Additional information

The issue was raised during the test prior to update Django to 3.0 using this command `python -Wa manage.py test` (please see issue 1306). I also did a folder-wide search for `logger.warn`, found one and changed (view.py)
