### PR TITLE
CVE for <=3.2.1 django-debug-toolbar

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -25,7 +25,7 @@ pyjwt = "~=1.7.1"
 [dev-packages]
 bandit = "*"
 coverage = "*"
-django-debug-toolbar = "*"
+django-debug-toolbar = ">=3.2.1"
 django-webtest = "*"
 factory-boy = "*"
 "flake8" = "*"


### PR DESCRIPTION
IonChannel shows a critical-level CVE for django-debug-toolbar. 
The pipfile.lock shows Tock is already using 3.2.1, so this should not change deployed resources at all. 
Recognizing that this is not deployed to production, it's still triggering IonChannel reports, and critical issues have a short fix window.

Updating the pipfile to require >3.2.1 should clear it.
