### PR TITLE
Fix bug with not ignoring empty forms

### DIFF
--- a/tock/hours/forms.py
+++ b/tock/hours/forms.py
@@ -133,8 +133,8 @@ def projects_as_choices(queryset=None):
 class InstrumentedChoiceField(forms.ChoiceField):
 
     def has_changed(self, initial, data):
-        print("has_changed", initial, data)
-        return super().has_changed(initial, data)
+        val = super().has_changed(initial, data)
+        print("has_changed:", initial, data, val)
 
 
 class TimecardObjectForm(forms.ModelForm):
@@ -179,8 +179,7 @@ class TimecardObjectForm(forms.ModelForm):
         return self.cleaned_data.get('hours_spent') or 0
 
     def clean(self):
-        print("In timecard object form clean")
-        print(self.cleaned_data)
+        print("In timecard object form clean:", self.cleaned_data)
         if 'notes' in self.cleaned_data and 'project' in self.cleaned_data:
             self.cleaned_data['notes'] = bleach.clean(
                 self.cleaned_data['notes'],
@@ -245,9 +244,11 @@ class TimecardInlineFormSet(BaseInlineFormSet):
 
     def clean(self):
         super(TimecardInlineFormSet, self).clean()
+        print("In timecard formset clean:", self.forms)
         total_hrs = 0
         total_allocation = 0
         for form in self.forms:
+            print("this form:", form.cleaned_data)
             current_allocation = Decimal(form.cleaned_data.get('project_allocation') or 0)
             if form.cleaned_data:
                 if form.cleaned_data.get('DELETE'):

--- a/tock/hours/tests/test_integration.py
+++ b/tock/hours/tests/test_integration.py
@@ -137,21 +137,21 @@ class TestSubmit(ProtectedViewTestCase, WebTest):
         date = self.reporting_period.start_date.strftime('%Y-%m-%d')
         url = reverse('reportingperiod:UpdateTimesheet',
                       kwargs={'reporting_period': date},)
-        res = self.app.get(url, user=self.user)
-        form = res.form  # only one form on the page?
+        form = self.app.get(url, user=self.user).form  # only one form on the page
         form["timecardobjects-0-project"] = self.projects[0].id
         form["timecardobjects-0-hours_spent"] = 40
-        res = form.submit("submit-timecard").follow()
+        form.submit("submit-timecard").follow()
 
-        date = self.reporting_period2.start_date.strftime('%Y-%m-%d')
+        date2 = self.reporting_period2.start_date.strftime('%Y-%m-%d')
         url = reverse('reportingperiod:UpdateTimesheet',
-                      kwargs={'reporting_period': date},)
-        res = self.app.get(url, user=self.user)
-        print(res.html)
-        form = res.form  # only one form on the page?
+                      kwargs={'reporting_period': date2},)
+        form = self.app.get(url, user=self.user).form  # only one form on the page
+        form["timecardobjects-0-project"] = self.projects[0].id
         form["timecardobjects-0-hours_spent"] = 40
+        # timecard.js would set this field to be unselected, but since WebTest
+        # runs no Javascript, force this field to be the empty string
+        form["timecardobjects-1-project_allocation"].force_value("")
         res = form.submit("submit-timecard")
 
-        print(res.html)
         # successful POST will give a 302 redirect
         self.assertEqual(res.status_code, 302)

--- a/tock/tock/static/js/components/timecard.js
+++ b/tock/tock/static/js/components/timecard.js
@@ -211,11 +211,10 @@ function toggleNotesField(selectBoxId) {
   if (options.is_weekly_bill === 'true') {
     project_allocation.classList.remove('entry-hidden');
     hours_spent.classList.add('entry-hidden');
-    hours_set.value = '0'
   } else {
     project_allocation.classList.add('entry-hidden');
     hours_spent.classList.remove('entry-hidden');
-    project_allocation_set.selectedIndex = '0' 
+    project_allocation_set.selectedIndex = -1;
   }
 }
 


### PR DESCRIPTION
## Description

The weekly billing code introduced a new (usually hidden) field on the timecard form and the Javascript was setting a value for that field which was confusing Django's built-in mechanism for detecting if form fields have changed. The observed bug was that on submitting the second time card, the `extra` field that Django added was giving a "This field is required" error.

This fixes the bug by changing `timecard.js` to leave that field unselected and it adds a test for submitting two time cards to make sure that the second one works.