### PR TITLE
Remove hourly summation elements if weekly billable project exists on timecard

### DIFF
--- a/tock/tock/static/js/components/timecard.js
+++ b/tock/tock/static/js/components/timecard.js
@@ -208,6 +208,7 @@ function toggleNotesField(selectBoxId) {
   const options = document.querySelector('#' + selectBoxId + '-select')
     .selectedOptions[0].dataset;
   if (options.is_weekly_bill === 'true') {
+    setHourSummationVisibility('hide');
     project_allocation.classList.remove('entry-hidden');
     hours_spent.classList.add('entry-hidden');
   } else {

--- a/tock/tock/static/js/components/timecard.js
+++ b/tock/tock/static/js/components/timecard.js
@@ -370,7 +370,8 @@ function handleConfirm(val) {
  * */
 function setHourSummationVisibility(visibility) {
   const showBillingHourSummationElements = visibility === 'show';
-  const [totalReportedElement, totalBillableElement] = Array.from(document.querySelectorAll('.entries-total .grid-col-2'));
+  const totalReportedElement = document.querySelector('#total-reported-div');
+  const totalBillableElement = document.querySelector('#total-billable-div');
 
   if (showBillingHourSummationElements) {
     totalReportedElement.classList.remove('entry-hidden');

--- a/tock/tock/static/js/components/timecard.js
+++ b/tock/tock/static/js/components/timecard.js
@@ -362,6 +362,24 @@ function handleConfirm(val) {
   }
 }
 
+/** @function
+ * Show or hide the billing hour summation elements in the footer
+ * @name setHourSummationVisibility
+ * @param {string} visibility
+ * */
+function setHourSummationVisibility(visibility) {
+  const showBillingHourSummationElements = visibility === 'show';
+  const [totalReportedElement, totalBillableElement] = Array.from(document.querySelectorAll('.entries-total .grid-col-2'));
+
+  if (showBillingHourSummationElements) {
+    totalReportedElement.classList.remove('entry-hidden');
+    totalBillableElement.classList.remove('entry-hidden');
+  } else {
+    totalReportedElement.classList.add('entry-hidden');
+    totalBillableElement.classList.add('entry-hidden');
+  }
+}
+
 //////////////////////////////////////////////////////////////
 // EVENT HANDLERS
 

--- a/tock/tock/static/js/components/timecard.js
+++ b/tock/tock/static/js/components/timecard.js
@@ -208,10 +208,15 @@ function toggleNotesField(selectBoxId) {
   const options = document.querySelector('#' + selectBoxId + '-select')
     .selectedOptions[0].dataset;
   if (options.is_weekly_bill === 'true') {
-    setHourSummationVisibility('hide');
+    handleBillingElementState('hide');
     project_allocation.classList.remove('entry-hidden');
     hours_spent.classList.add('entry-hidden');
   } else {
+    const noWeeklyBilledProjectsExist = !weeklyBilledProjectExists();
+
+    if (noWeeklyBilledProjectsExist) {
+      handleBillingElementState('show');
+    }
     project_allocation.classList.add('entry-hidden');
     hours_spent.classList.remove('entry-hidden');
     project_allocation_set.selectedIndex = -1;
@@ -365,15 +370,20 @@ function handleConfirm(val) {
 
 /** @function
  * Show or hide the billing hour summation elements in the footer
- * @name setHourSummationVisibility
+ * @name handleBillingElementState
  * @param {string} visibility
  * */
-function setHourSummationVisibility(visibility) {
+function handleBillingElementState(visibility) {
   const showBillingHourSummationElements = visibility === 'show';
   const totalReportedElement = document.querySelector('#total-reported-div');
   const totalBillableElement = document.querySelector('#total-billable-div');
 
   if (showBillingHourSummationElements) {
+    const weeklyBillingAlertElement = document.querySelector('#weekly-billing-alert');
+    const addItemWrapper = document.querySelector('#add-item-wrapper');
+    addItemWrapper.classList.remove('grid-col-2');
+    addItemWrapper.classList.add('grid-col-8');
+    weeklyBillingAlertElement.classList.add('entry-hidden');
     totalReportedElement.classList.remove('entry-hidden');
     totalBillableElement.classList.remove('entry-hidden');
   } else {
@@ -385,6 +395,27 @@ function setHourSummationVisibility(visibility) {
     totalReportedElement.classList.add('entry-hidden');
     totalBillableElement.classList.add('entry-hidden');
   }
+}
+
+/** @function
+ * Examine all of the timecard entries and determine if any of them are weekly billing
+ * @name weeklyBilledProjectExists
+ * */
+function weeklyBilledProjectExists() {
+  const selects = document.querySelectorAll('.entry-project select');
+  let weeklyBilledProjectSeen = false;
+  for (let i = 0; i < selects.length; i++) {
+    const currentSelect = selects[i];
+    const project = currentSelect.selectedOptions[0];
+    const projectIsWeeklyBilled = (project.dataset || {}).is_weekly_bill === 'true';
+    // Flip our 'state' so we know we've encountered at least one weekly billed project
+    // Get out of the loop as soon as we've found one weekly billed project
+    if (projectIsWeeklyBilled && !weeklyBilledProjectSeen) {
+      weeklyBilledProjectSeen = true;
+      break;
+    }
+  }
+  return weeklyBilledProjectSeen;
 }
 
 //////////////////////////////////////////////////////////////
@@ -472,6 +503,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Hide our billable hour summation elements
   if (weeklyBilledProjectSeen) {
-    setHourSummationVisibility('hide');
+    handleBillingElementState('hide');
   }
 });

--- a/tock/tock/static/js/components/timecard.js
+++ b/tock/tock/static/js/components/timecard.js
@@ -377,6 +377,11 @@ function setHourSummationVisibility(visibility) {
     totalReportedElement.classList.remove('entry-hidden');
     totalBillableElement.classList.remove('entry-hidden');
   } else {
+    const weeklyBillingAlertElement = document.querySelector('#weekly-billing-alert');
+    const addItemWrapper = document.querySelector('#add-item-wrapper');
+    addItemWrapper.classList.remove('grid-col-8');
+    addItemWrapper.classList.add('grid-col-2');
+    weeklyBillingAlertElement.classList.remove('entry-hidden');
     totalReportedElement.classList.add('entry-hidden');
     totalBillableElement.classList.add('entry-hidden');
   }

--- a/tock/tock/static/js/components/timecard.js
+++ b/tock/tock/static/js/components/timecard.js
@@ -30,7 +30,6 @@ function getFormData() {
     const isBillable = project
       ? !isExcluded && !nonBillableProjects.includes(project)
       : null;
-    //const isWeeklyBill = project
     const hours =
       parseFloat(entry.querySelector('.entry-amount input').value) || 0.0;
    const project_allocation =

--- a/tock/tock/static/js/components/timecard.js
+++ b/tock/tock/static/js/components/timecard.js
@@ -444,7 +444,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // adds accessible autocomplete to existing <select> fields
   const selects = document.querySelectorAll('.entry-project select');
+  let weeklyBilledProjectSeen = false;
   selects.forEach((select) => {
+    const [project] = select.selectedOptions;
+    const projectIsWeeklyBilled = project.dataset.is_weekly_bill === 'true';
+    // Flip our 'state' so we know we've encountered at least one weekly billed project
+    if (projectIsWeeklyBilled && !weeklyBilledProjectSeen) {
+      weeklyBilledProjectSeen = true;
+    }
+
     accessibleAutocomplete.enhanceSelectElement({
       showAllValues: true,
       defaultValue: '',
@@ -455,4 +463,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // make sure any necessary notes or alerts are present
     updateDisplays(select.id.replace('-select', ''));
   });
+
+  // Hide our billable hour summation elements
+  if (weeklyBilledProjectSeen) {
+    setHourSummationVisibility('hide');
+  }
 });

--- a/tock/tock/static/sass/_entries.scss
+++ b/tock/tock/static/sass/_entries.scss
@@ -226,9 +226,6 @@
 	background: $theme-color-accent-cool-light;
 	padding: 1em;
 	.add-timecard-entry,
-	.add-timecard-entry:first-child  {
-		margin-top: 1em;
-	}
 	.entries-total-reported {
 		text-align:left;
     .usa-button-outline {
@@ -243,6 +240,17 @@
       margin-top: 0.5em;
     }
 	}
+  .weekly-bill-header {
+    font-weight: bold;
+  }
+  #footer-controls-container {
+    align-items: center;
+    #add-item-wrapper {
+      display: flex;
+      padding-top: 0.5em;
+      padding-bottom: 0.5em;
+    }
+  }
 }
 
 .form-error,

--- a/tock/tock/templates/hours/timecard_form.html
+++ b/tock/tock/templates/hours/timecard_form.html
@@ -134,7 +134,7 @@
         <div class="grid-col-8">
           <button type="button" class="add-timecard-entry usa-button usa-button--base">Add item</button>
         </div>
-        <div class="grid-col-2">
+        <div class="grid-col-2" id="total-reported-div">
           <span class="text-label">Total hours</span>
           <span class="entries-total-reported-amount">
             <svg class="circular-graph">
@@ -144,7 +144,7 @@
             <span class="number-label">0</span>
           </span>
         </div>
-        <div class="grid-col-2">
+        <div class="grid-col-2" id="total-billable-div">
           <span class="text-label"><a href="https://handbook.18f.gov/tock/#weekly-billable-hour-expectations"
               target="_blank" rel="noopener noreferrer">Billable hours</a></span>
           <span class="entries-total-billable-amount">

--- a/tock/tock/templates/hours/timecard_form.html
+++ b/tock/tock/templates/hours/timecard_form.html
@@ -130,9 +130,13 @@
   </div>
   <div class="grid-container timecard-footer">
     <div class="entries-total">
-      <div class="grid-row grid-gap">
-        <div class="grid-col-8">
+      <div class="grid-row grid-gap" id="footer-controls-container">
+        <div class="grid-col-8" id="add-item-wrapper">
           <button type="button" class="add-timecard-entry usa-button usa-button--base">Add item</button>
+        </div>
+        <div class="grid-col-8 entry-hidden" id="weekly-billing-alert">
+          <div class="weekly-bill-header">Do not work more than 40 hours.</div>
+          <div class="Weekly-bill-body">Under weekly billing, you are still expected to work a 40-hour work week. For those on AWS, this translates to 44 hours one week and 36 hours the following week.</div>
         </div>
         <div class="grid-col-2" id="total-reported-div">
           <span class="text-label">Total hours</span>

--- a/tock/tock/tests/js/integration/timecard.test.js
+++ b/tock/tock/tests/js/integration/timecard.test.js
@@ -93,7 +93,7 @@ describe("Timecard", () => {
       });
 
       // @TODO: Seed database with a weekly billing project and know the ID for this test
-      await page.type(`#id_timecardobjects-0-project`, "125 - WB Test Project");
+      await page.type(`#id_timecardobjects-0-project`, "125 - Weekly Billing Test");
       await page.keyboard.press("Enter");
 
       await page.waitForSelector(
@@ -133,7 +133,7 @@ describe("Timecard", () => {
 
       expect(bothSummationElementsVisible).toBe(true);
       
-      await page.type(`#id_timecardobjects-0-project`, "125 - WB Test Project");
+      await page.type(`#id_timecardobjects-0-project`, "125 - Weekly Billing Test");
       await page.keyboard.press("Enter");
 
       await page.waitForSelector(


### PR DESCRIPTION
## Description

Remove hourly summation elements if weekly billable project exists on timecard

## Additional information

The hourly summation elements in the footer should hide upon selection of a weekly billable project as well as being hidden when coming into a saved timecard that has a weekly billable project on it. Removing any weekly billable projects from the timecard either by deleting it or updating it should restore the hourly summation elements.

JS tests were added and were passing on my local machine but seem to fail when ran inside the docker instance, that probably needs its own issue.