### PR TITLE
Attempt to handle FY boundaries in utilization tests

### DIFF
--- a/tock/utilization/tests/test_views.py
+++ b/tock/utilization/tests/test_views.py
@@ -43,7 +43,7 @@ class TestGroupUtilizationView(WebTest):
         non_billable_project.accounting_code = non_billable_acct
         non_billable_project.save()
 
-        billable_project = Project.objects.last()
+        billable_project = Project.objects.get(pk=50)
         billable_project.accounting_code = billable_acct
         billable_project.save()
 
@@ -60,8 +60,23 @@ class TestGroupUtilizationView(WebTest):
         self.user_data.unit = test_unit
         self.user_data.save()
 
+        # These utilization tests get weird around fiscal years, this is an attempt
+        # to handle things better inside of the first week to 10 days of October
+        today = datetime.date.today()
+        current_fy = ReportingPeriod().get_fiscal_year_from_date(today)
+        fy_start_date = ReportingPeriod().get_fiscal_year_start_date(current_fy)
+        first_of_october = datetime.date(today.year, 10, 1)
+        seventh_of_october = datetime.date(today.year, 10, 7)
+        adjust_rp_start_date_for_fy_boundary = first_of_october <= today <= seventh_of_october
+        rp_start_date = datetime.date.today() - datetime.timedelta(days=7)
+
+        # We think we're within the first week of October and rewinding back 7 days would cross
+        # a FY boundary, start from the beginning of the FY instead
+        if adjust_rp_start_date_for_fy_boundary:
+            rp_start_date = fy_start_date
+
         self.reporting_period = ReportingPeriod.objects.create(
-            start_date=datetime.date.today() - datetime.timedelta(days=7),
+            start_date=rp_start_date,
             end_date=datetime.date.today()
         )
 

--- a/tock/utilization/tests/test_views.py
+++ b/tock/utilization/tests/test_views.py
@@ -65,13 +65,10 @@ class TestGroupUtilizationView(WebTest):
         today = datetime.date.today()
         current_fy = ReportingPeriod().get_fiscal_year_from_date(today)
         fy_start_date = ReportingPeriod().get_fiscal_year_start_date(current_fy)
-        first_of_october = datetime.date(today.year, 10, 1)
-        seventh_of_october = datetime.date(today.year, 10, 7)
-        adjust_rp_start_date_for_fy_boundary = first_of_october <= today <= seventh_of_october
+        safe_date = fy_start_date + datetime.timedelta(days=7)
+        adjust_rp_start_date_for_fy_boundary = today < safe_date
         rp_start_date = datetime.date.today() - datetime.timedelta(days=7)
 
-        # We think we're within the first week of October and rewinding back 7 days would cross
-        # a FY boundary, start from the beginning of the FY instead
         if adjust_rp_start_date_for_fy_boundary:
             rp_start_date = fy_start_date
 


### PR DESCRIPTION
## Description

The utilization tests in `tock/utilization/tests/test_views.py` seem to get tripped up when the fiscal year changes for the first 7 to 10 days of October. The original behavior was to create a `ReportingPeriod` that had a start date of today minus 7 days. If today's date is in early October and you rewind 7 days back into late September, the resulting reporting period spans two fiscal years.

This attempts to address the issue by checking if "today" is far enough into October that rewinding 7 days would leave the reporting period in the current fiscal year and not cause issues 🤞 

@Jkrzy - Thanks for the mountain of help in figuring out the problem and solution.
