### PR TITLE
Update project_allocation API scale/precision

### DIFF
--- a/tock/api/tests.py
+++ b/tock/api/tests.py
@@ -243,7 +243,7 @@ class FixturelessTimecardsAPITests(WebTest):
                 project_allocation=0.125
             )
         ]
-    
+
     def test_project_allocation_scale_precision(self):
         """
             project_allocation allows a scale of 6 digits and a precision of 3 digits
@@ -252,7 +252,7 @@ class FixturelessTimecardsAPITests(WebTest):
         all_timecards = client().get(
             reverse('TimecardList'),
             kwargs={'date': '2021-09-01'}).data
-        
+
         full_allocation_timecard = all_timecards[0]
         three_quarter_allocation_timecard = all_timecards[1]
         half_allocation_timecard = all_timecards[2]

--- a/tock/api/views.py
+++ b/tock/api/views.py
@@ -87,7 +87,7 @@ class TimecardSerializer(serializers.Serializer):
         allow_null=True
     )
     hours_spent = serializers.DecimalField(max_digits=5, decimal_places=2)
-    project_allocation = serializers.DecimalField(max_digits=5, decimal_places=2)
+    project_allocation = serializers.DecimalField(max_digits=6, decimal_places=3)
     start_date = serializers.DateField(
         source='timecard.reporting_period.start_date'
     )

--- a/tock/utilization/tests/test_views.py
+++ b/tock/utilization/tests/test_views.py
@@ -43,7 +43,7 @@ class TestGroupUtilizationView(WebTest):
         non_billable_project.accounting_code = non_billable_acct
         non_billable_project.save()
 
-        billable_project = Project.objects.last()
+        billable_project = Project.objects.get(pk=50)
         billable_project.accounting_code = billable_acct
         billable_project.save()
 
@@ -60,8 +60,21 @@ class TestGroupUtilizationView(WebTest):
         self.user_data.unit = test_unit
         self.user_data.save()
 
+        # These utilization tests get weird around fiscal years, this is an attempt
+        # to handle things better inside of the first week to 10 days of October
+        today = datetime.date.today()
+        current_fy = ReportingPeriod.get_fiscal_year_from_date(today)
+        fy_start_date = ReportingPeriod.get_fiscal_year_start_date(current_fy)
+        safe_date = fy_start_date + datetime.timedelta(days=7)
+        adjust_rp_start_date_for_fy_boundary = today < safe_date
+
+        if adjust_rp_start_date_for_fy_boundary:
+            rp_start_date = fy_start_date
+        else:
+            rp_start_date = datetime.date.today() - datetime.timedelta(days=7)
+
         self.reporting_period = ReportingPeriod.objects.create(
-            start_date=datetime.date.today() - datetime.timedelta(days=7),
+            start_date=rp_start_date,
             end_date=datetime.date.today()
         )
 

--- a/tock/utilization/utils.py
+++ b/tock/utilization/utils.py
@@ -77,8 +77,8 @@ def limit_to_fy():
     """
     Filter component to Limit timecard aggregation to the current fiscal year
     """
-    current_fy = ReportingPeriod().get_fiscal_year_from_date(datetime.date.today())
-    fy_start_date = ReportingPeriod().get_fiscal_year_start_date(current_fy)
+    current_fy = ReportingPeriod.get_fiscal_year_from_date(datetime.date.today())
+    fy_start_date = ReportingPeriod.get_fiscal_year_start_date(current_fy)
     return Q(timecards__submitted=True, timecards__reporting_period__start_date__gte=fy_start_date)
 
 def _get_reporting_periods(count):


### PR DESCRIPTION
## Description

Addresses #1369. Update the scale/precision of the `project_allocation` field in the API return for Timecards. The `TimecardSerializer` just needed updated to reflect the scale and precision change that was made to support 12.5% (`0.125`) project allocation.
