### PR TITLE
Project allocation percentages to show in timecard admin

### DIFF
--- a/tock/hours/admin.py
+++ b/tock/hours/admin.py
@@ -1,9 +1,11 @@
 from decimal import Decimal
+from math import isclose
 
 from django.conf import settings
 from django.contrib import admin
 from django.core.exceptions import ValidationError
 from django.forms import DecimalField, ModelForm
+from django.forms.widgets import Select
 from django.forms.models import BaseInlineFormSet
 from employees.models import UserData
 
@@ -24,8 +26,68 @@ class ReportingPeriodListFilter(admin.SimpleListFilter):
         return queryset
 
 
+class DecimalChoiceWidget(Select):
+
+    """A choice widget for decimal typed data.
+
+    The Select widget when used with a form's TypedChoiceField that has an
+    underlying `DecimalField` in the model is very sensitive to formatting because
+    it uses string comparison (as is natural for a Select widget on a web page that
+    deals in strings).
+
+    This modifies the method in a `Select` widget where equality is checked so that
+    it uses numerical equality. This should make it much better behaved with the
+    numeric data type.
+    """
+
+    def optgroups(self, name, value, attrs=None):
+        """Change the baseclass's method to use numerical comparison."""
+        groups = []
+        has_selected = False
+
+        for index, (option_value, option_label) in enumerate(self.choices):
+            if option_value is None:
+                option_value = ''
+
+            subgroup = []
+            if isinstance(option_label, (list, tuple)):
+                group_name = option_value
+                subindex = 0
+                choices = option_label
+            else:
+                group_name = None
+                subindex = None
+                choices = [(option_value, option_label)]
+            groups.append((group_name, subgroup, index))
+
+            for subvalue, sublabel in choices:
+                selected = (
+                    # instead of string comparison, use numerical comparison here
+                    any(isclose(float(subvalue), float(v)) for v in value) and
+                    (not has_selected or self.allow_multiple_selected)
+                )
+                has_selected |= selected
+                subgroup.append(self.create_option(
+                    name, subvalue, sublabel, selected, index,
+                    subindex=subindex, attrs=attrs,
+                ))
+                if subindex is not None:
+                    subindex += 1
+        return groups
+
+
+class TimecardObjectForm(ModelForm):
+
+    class Meta:
+        model = TimecardObject
+        fields = "__all__"
+        widgets = {"project_allocation": DecimalChoiceWidget}
+
 
 class TimecardObjectFormset(BaseInlineFormSet):
+
+    form = TimecardObjectForm
+
     def clean(self):
         """
         Check to ensure the proper number of hours are entered.
@@ -73,6 +135,7 @@ class ReportingPeriodAdmin(admin.ModelAdmin):
 
 class TimecardObjectInline(admin.TabularInline):
     formset = TimecardObjectFormset
+    form = TimecardObjectForm
     model = TimecardObject
     readonly_fields = [
         'grade',

--- a/tock/hours/tests/test_integration.py
+++ b/tock/hours/tests/test_integration.py
@@ -182,3 +182,24 @@ class TestAdmin(ProtectedViewTestCase, WebTest):
         res = form.submit("submit-timecard").follow()
         self.assertEqual(res.status_code, 200)
         self.assertContains(res, "was added successfully")
+
+    def test_admin_weekly_bill_project_allocation(self):
+        """Test project allocation in the admin interface"""
+        weekly_billed_project = projects.models.Project.objects.get(name='Weekly Billing')
+        timecard = hours.models.Timecard.objects.first()
+        change_url = reverse(
+            'admin:hours_timecard_change',
+            args=[timecard.id],
+        )
+
+        # save a timecard with project allocation set.
+        form = self.app.get(change_url, user=self.user).form
+        form["timecardobjects-0-project"] = weekly_billed_project.id
+        form["timecardobjects-0-hours_spent"] = ''
+        form["timecardobjects-0-project_allocation"] = "1.0"
+        form.submit("submit-timecard")
+
+        # now visit the change page and make sure that 100% is selected
+        change_page = self.app.get(change_url, user=self.user)
+        form = change_page.form
+        self.assertEqual(form["timecardobjects-0-project_allocation"].value, "1.0")


### PR DESCRIPTION
## Description

#1363 reports that the select widget in the timecard admin page doesn't display the allocation percentage correctly, even when it is set in the database. The issue ended up being a problem with a DecimalField that specifies a restricted set of choices and so gets rendered on the page with Django's `Select` widget.

The `Select` widget determines if a value is selected by string comparing the list of values against the current value of the widget. This doesn't work for numeric values because the string comparison gives different things depending on formatting. The fix here is to use a custom widget where the selection logic is overridden to use numeric comparison instead of string comparison.

## Additional information
<img width="707" alt="Screen Shot 2021-10-07 at 12 55 58" src="https://user-images.githubusercontent.com/443389/136451675-435f7f54-0e4a-41c3-9020-9cb00623aeef.png">


