### PR TITLE
Use our custom decimal choice widget on timecard entry page

### DIFF
--- a/tock/hours/admin.py
+++ b/tock/hours/admin.py
@@ -26,6 +26,17 @@ class ReportingPeriodListFilter(admin.SimpleListFilter):
         return queryset
 
 
+def safe_float(value):
+    """Convert a string to a float with no exceptions.
+
+    Return NaN if the conversion fails.
+    """
+    try:
+        return float(value)
+    except ValueError:
+        return float("NaN")
+
+
 class DecimalChoiceWidget(Select):
 
     """A choice widget for decimal typed data.
@@ -63,7 +74,7 @@ class DecimalChoiceWidget(Select):
             for subvalue, sublabel in choices:
                 selected = (
                     # instead of string comparison, use numerical comparison here
-                    any(isclose(float(subvalue), float(v)) for v in value)
+                    any(isclose(safe_float(subvalue), safe_float(v)) for v in value)
                     and (not has_selected or self.allow_multiple_selected)
                 )
                 has_selected |= selected

--- a/tock/hours/forms.py
+++ b/tock/hours/forms.py
@@ -11,6 +11,7 @@ from decimal import Decimal
 from projects.models import AccountingCode, Project
 
 from .models import ReportingPeriod, Timecard, TimecardObject
+from .admin import DecimalChoiceWidget
 
 
 class ReportingPeriodForm(forms.ModelForm):
@@ -143,7 +144,7 @@ class TimecardObjectForm(forms.ModelForm):
     project_allocation = forms.ChoiceField(
         choices=settings.PROJECT_ALLOCATION_CHOICES,
         required=False,
-        widget=forms.Select(attrs={'onchange' : "populateHourTotals();"})
+        widget=DecimalChoiceWidget(attrs={'onchange' : "populateHourTotals();"})
     )
     hours_spent = forms.DecimalField(
         min_value=0,


### PR DESCRIPTION
## Description

#1373 describes a problem with allocation percentages not showing up when people save their time cards before submitting. The underlying issue is the same as in #1363. The new Decimal-type choice widget that we introduced for the admin page in #1371 should also be used on the timecard page to fix the problem. 

This PR does that and adds a test with a saved timecard to be sure that things are displayed correctly after saving.