### PR TITLE
Remove additional help banner from timecard page

### DIFF
--- a/tock/tock/templates/hours/timecard_form.html
+++ b/tock/tock/templates/hours/timecard_form.html
@@ -62,15 +62,6 @@
 </div>
 {% endfor %}
 
-<div class="usa-alert usa-alert--info">
-  <div class="usa-alert__body">
-    <p class="usa-alert__text">
-      For additional help and guidance with using Tock and entering hours, please consult the <a
-        href="https://handbook.18f.gov/tock/">TTS Handbook page on Tock</a>.
-    </p>
-  </div>
-</div>
-
 <form method="post"
   action="{% url 'reportingperiod:UpdateTimesheet' reporting_period=object.reporting_period.start_date %}">
   {% csrf_token %}


### PR DESCRIPTION
## Description

The timecard page is getting crowded with informational banners. This removes the "Additional info" banner that links to the Handbook page on tock. Analytics suggests that no one ever clicks on that link.

@colinmurphy01 requested this change .

<img width="963" alt="Screen Shot 2021-10-13 at 1 59 31 PM" src="https://user-images.githubusercontent.com/443389/137193795-ffecbf3b-8e60-4aa0-975e-7e5aac2e7aaa.png">
