### PR TITLE
explictly set csp for scripts so can have nonce add to list

### DIFF
--- a/tock/tock/settings/production.py
+++ b/tock/tock/settings/production.py
@@ -32,6 +32,7 @@ allowed_sources = (
     'tock.18f.gov/'
 )
 CSP_DEFAULT_SRC = allowed_sources
+CSP_SCRIPT_SRC = allowed_sources
 CSP_IMG_SRC = allowed_sources
 CSP_MEDIA_SRC = allowed_sources
 CSP_FRAME_SRC = allowed_sources


### PR DESCRIPTION
## Description

The last PR made it so the `script-src` CSP policy was just the nonce rather than the allowed sources AND the nonce (which is needed to handle inline values.