### PR TITLE
Update PostgreSQL images used in local development

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,10 +24,11 @@ jobs:
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/
-      - image: circleci/postgres:9.6.8
+      - image: cimg/postgres:12.8
         environment:
           - POSTGRES_USER=circleci
           - POSTGRES_DB=tock-test
+          - POSTGRES_PASSWORD=tock-pass
 
     steps:
       - checkout

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     entrypoint: python /tock/docker_entrypoint.py
     environment:
       - PYTHONUNBUFFERED=yup
-      - DATABASE_URL=postgres://tock_user@db/tock
+      - DATABASE_URL=postgres://tock_user:tock_password@db/tock
       - RUNNING_IN_DOCKER=yup
       - DJANGO_SETTINGS_MODULE=tock.settings.dev
       # - NEW_RELIC_LICENSE_KEY=get-from-vcap-user-provided-service (not to be used for local development)
@@ -21,10 +21,11 @@ services:
     command: "python manage.py runserver 0.0.0.0:8000"
 
   db:
-    image: postgres:9.6.8
+    image: postgres:12.8
     environment:
       - POSTGRES_DB=tock
       - POSTGRES_USER=tock_user
+      - POSTGRES_PASSWORD=tock_password
 
   gulp:
     image: node:16.15.0


### PR DESCRIPTION
## Description

On cloud.gov, Tock is using postgres 12.8. This PR finishes the work from #1328 and #1330 by getting the local development environment synced up to the same version as the cloud.gov version.

## Additional information

Somewhere between postgres 9 and 12, they disabled password-less accounts by default. You can either re-enable them explicitly or you can give the default user a password as well. I opted to do the latter thing. It only shows up in the `docker-compose.yml` so it was really easy to do.

- closes #1328
- closes #1330
- closes #1329
- closes #1327