### PR TITLE
Refactor the CSV export for CSP reasons

### DIFF
--- a/tock/tock/static/js/components/save_csv.js
+++ b/tock/tock/static/js/components/save_csv.js
@@ -1,8 +1,34 @@
+// Wait until the DOM content is loaded. In testing, it seems this script
+// can be loaded before the DOM is populated, so... wait! In our case, the
+// buttons remain in the DOM forever once they're loaded. This approach does
+// not work if the buttons are removed from the DOM when hidden, but the
+// accordions we have just hide their content when collapsed rather than
+// remove it.
+window.addEventListener('DOMContentLoaded', function () {
+    var downloadButtons = document.querySelectorAll('button[data-csv]');
+
+    for (var i = 0; i < downloadButtons.length; i += 1) {
+        var button = downloadButtons.item(i);
+
+        // Use an IIFE to capture variables. Otherwise all of the button events
+        // will use the values from the last button, which would be wrong. A
+        // classic Javascript quirk...
+        (function () {
+            var table_id = button.getAttribute('data-csv-id');
+            var filename_prefix = button.getAttribute('data-csv-name');
+
+            button.addEventListener('click', function () {
+                download_table_as_csv(table_id + "-table", filename_prefix);
+            });
+        })();
+    }
+});
+
 // Quick and simple export target #table_id into a csv
 // inspired by https://stackoverflow.com/a/56370447
 function download_table_as_csv(table_id, filename_prefix) {
-	var csv_string = table_to_csv(table_id);
-	download(csv_string, filename_prefix);
+    var csv_string = table_to_csv(table_id);
+    download(csv_string, filename_prefix);
 }
 
 function table_to_csv(table_id) {
@@ -11,12 +37,14 @@ function table_to_csv(table_id) {
     // Construct csv
     var output_list = [];
     for (var i = 0; i < rows.length; i++) {
-        var output_row = [], cols = rows[i].querySelectorAll('td, th');
+        var output_row = [];
+        var cols = rows[i].querySelectorAll('td, th');
+
         for (var j = 0; j < cols.length; j++) {
             // Clean innertext to remove line breaks
-            var data = cols[j].innerText.replace(/(\r\n|\n|\r)/gm, '')
+            var data = cols[j].innerText.replace(/(\r\n|\n|\r)/gm, '');
             // Escape double-quote with double-double-quote
-					  // (see https://stackoverflow.com/questions/17808511/properly-escape-a-double-quote-in-csv)
+            // (see https://stackoverflow.com/questions/17808511/properly-escape-a-double-quote-in-csv)
             data = data.replace(/"/g, '""');
             // Push escaped string
             output_row.push('"' + data + '"');

--- a/tock/utilization/templatetags/analytics.py
+++ b/tock/utilization/templatetags/analytics.py
@@ -20,7 +20,7 @@ def frame_table(frame, name_hint):
             <div class="grid-row">
                 <button
                     class="usa-button usa-button--base float-right margin-bottom-1"
-                    onclick="download_table_as_csv('{generated_id}-table', '{name_hint}')"
+                    data-csv data-csv-id="{generated_id}" data-csv-name="{name_hint}"
                 >Export CSV</button>
             </div>
             <div class="usa-table-container--scrollable grid-row" tabindex=0>


### PR DESCRIPTION
## Description

Tock's CSP policy disallows inline Javascript, so `onclick=""` attributes are forbidden. Those attributes are how CSV exports are triggered on the analytics page. The handler relies on a random pseudo ID that is generated at render time to identify the table being exported.

This PR removes the `onclick` attribute from the button, and adds `data-csv`, `data-csv-id`, and `data-csv-name` attributes. The `data-csv` attribute is just a flag that the button should act as a CSV exporter. `data-csv-id` and `data-csv-name` are populated with the pseudo ID and filename hint, respectively.

Then, after the DOM is loaded, this PR adds code that finds all button elements with a `data-csv` attribute. It iterates over them, pulling out their IDs and names, and adding a click event listener. It uses the ID and name to finally call the `download_table_as_csv` function after the button is cilcked.

## Additional information

- closes #1418