### PR TITLE
Fix the stack being referenced by the maintenance page

### DIFF
--- a/tock/maintenance_page/manifest.yml
+++ b/tock/maintenance_page/manifest.yml
@@ -2,7 +2,7 @@
 applications:
 - name: tock-maintenance
   buildpack: staticfile_buildpack
-  stack: cflinuxfs2
+  stack: cflinuxfs3
   memory: 64M
   disk_quota: 64M
   instances: 1


### PR DESCRIPTION
## Description

The `manifest.yml` for the Tock maintenance page currently specifies the `cflinuxfs2` build stack, but that hasn't been supported in cloud.gov for a while, so `cf push` fails. This PR updates the stack to `cflinuxfs3` to we can push this app again.