### PR TITLE
Deploy to tock-staging in staging

### DIFF
--- a/manifest-staging.yml
+++ b/manifest-staging.yml
@@ -1,6 +1,6 @@
 ---
 applications:
-- name: tock
+- name: tock-staging
   buildpack: python_buildpack
   memory: 512M
   path: .


### PR DESCRIPTION
## Description

Currently, staging deployments use the app name `tock` instead of `tock-staging`. The documentation says to use `tock-staging`, and for safety's sake, that's what we'll do. This PR updates the manifest to use `tock-staging`.