### PR TITLE
Harmonize app name, so it can actually go

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ jobs:
           command: echo ${CIRCLE_SHA1} > tock/VERSION
       - run:
           name: Deploying Tock Staging to cloud.gov
-          command: cf7 push tock --strategy rolling -f ${CF_MANIFEST}
+          command: cf7 push tock-staging --strategy rolling -f ${CF_MANIFEST}
 
   deploy_to_production:
     docker:


### PR DESCRIPTION
## Description

The `cf push` command in the CI job refers to an app that doesn't exist in the staging manifest file, so it hangs forever. This updates the `cf push` command to reflect the app name from the manifest file.