### PR TITLE
Fix a bug with the CSV downloads

### DIFF
--- a/tock/tock/static/js/components/save_csv.js
+++ b/tock/tock/static/js/components/save_csv.js
@@ -18,7 +18,7 @@ window.addEventListener('DOMContentLoaded', function () {
             var filename_prefix = button.getAttribute('data-csv-name');
 
             button.addEventListener('click', function () {
-                download_table_as_csv(table_id + "-table", filename_prefix);
+                download_table_as_csv(table_id, filename_prefix);
             });
         })();
     }

--- a/tock/utilization/templatetags/analytics.py
+++ b/tock/utilization/templatetags/analytics.py
@@ -20,14 +20,14 @@ def frame_table(frame, name_hint):
             <div class="grid-row">
                 <button
                     class="usa-button usa-button--base float-right margin-bottom-1"
-                    data-csv data-csv-id="{generated_id}" data-csv-name="{name_hint}"
+                    data-csv data-csv-id="table-{generated_id}" data-csv-name="{name_hint}"
                 >Export CSV</button>
             </div>
             <div class="usa-table-container--scrollable grid-row" tabindex=0>
                 """ + frame.to_html(
                     justify="center",
                     classes="usa-table usa-table--compressed",
-                    table_id=generated_id + '-table',
+                    table_id='table-' + generated_id,
                     na_rep=''
                 ) + """
             </div>


### PR DESCRIPTION
## Description

The data tables that can be downloaded are assigned a random ID by Django at runtime. These IDs are five-character alphanumeric strings that are HTML-valid. _However_, they can begin with numbers with makes them _invalid_ CSS selectors, so the `document.querySelectorAll` method rejects those IDs. Clicking the "Export CSV" button triggers a function that selects the table based on its ID; if the ID just happens to start with the number, it will throw an exception. If the ID happens to start with a letter, the CSV will download correctly.

Since the IDs are random, the bug is sporadic. In any case, make the IDs CSV-valid by prepending `table-` to the beginning of the ID instead of appending `-table` to the end. This way they will _always_ begin with a letter and will be queryable.

## Additional information

An alternative might be to use `document.getElementById("{ random }-table")` since that will work even if the ID begins with a number. We could then use the returned element to select all of the child rows. However, since as best I can tell, nothing else relies on those table IDs, it seemed easier to change the IDs to work with `querySelectorAll` and let the browser do all the work of querying the DOM.