### PR TITLE
reporting_period_audit API: billable_expectation

### DIFF
--- a/tock/api/tests.py
+++ b/tock/api/tests.py
@@ -481,3 +481,10 @@ class FullTimecardsAPITests(WebTest):
             {'date': 'N0T-A-D8'}
         )
         self.assertEqual(res.status_code, 400)
+
+    def test_billable_expectation_is_present(self):
+        date_to_filter_on = '2016-01-01'
+        res = client().get(
+            reverse('FullTimecardList'), {'after': date_to_filter_on}
+        ).data
+        self.assertTrue('billable_expectation' in res[0].keys())

--- a/tock/api/views.py
+++ b/tock/api/views.py
@@ -104,21 +104,8 @@ class TimecardSerializer(serializers.Serializer):
         source='project.accounting_code.flat_rate'
     )
     notes = serializers.CharField()
-    revenue_profit_loss_account = serializers.CharField(
-        source='revenue_profit_loss_account.accounting_string',
-        allow_null=True
-    )
-    revenue_profit_loss_account_name = serializers.CharField(
-        source='revenue_profit_loss_account.name',
-        allow_null=True
-    )
-    expense_profit_loss_account = serializers.CharField(
-        source='expense_profit_loss_account.accounting_string',
-        allow_null=True
-    )
-    expense_profit_loss_account_name = serializers.CharField(
-        source='expense_profit_loss_account.name',
-        allow_null=True
+    billable_expectation = serializers.CharField(
+        source='timecard.billable_expectation'
     )
     employee_organization = serializers.CharField(
         source='timecard.user.user_data.organization_name'


### PR DESCRIPTION
## Description

Modify the TimecardSerializer in the API to return `billable_expectation`  and also remove some deprecated fields.

Fixes https://github.com/18F/tock/issues/1504