### PR TITLE
drop memory usage for enough headroom to deploy

### DIFF
--- a/manifest-production.yml
+++ b/manifest-production.yml
@@ -2,7 +2,7 @@
 applications:
 - name: tock
   buildpack: python_buildpack
-  memory: 1536M
+  memory: 1250M
   path: .
   stack: cflinuxfs3
   timeout: 180


### PR DESCRIPTION
## Description

Drop prod usage slightly to allow memory space to deploy application.

## Additional information

* see this: https://gsa-tts.slack.com/archives/C09CR1Q9Z/p1673377439366699 Slack thread for more context.
