### PR TITLE
Add weekly allocation hours to csv exports

### DIFF
--- a/tock/hours/models.py
+++ b/tock/hours/models.py
@@ -578,6 +578,7 @@ class TimecardObject(models.Model):
             self.timecard.user.username,
             self.project,
             self.hours_spent,
+            self.timecard.total_allocation_hours,
             self.timecard.user.user_data.organization_name,
             self.project.organization_name
         ]

--- a/tock/hours/views.py
+++ b/tock/hours/views.py
@@ -764,6 +764,7 @@ def ReportingPeriodCSVView(request, reporting_period):
         'User',
         'Project',
         'Number of Hours',
+        'Weekly Allocation Hours',
         'Employee Organization',
         'Project Organization',
     ])


### PR DESCRIPTION
## Description

Include Weekly Allocation Hours in csv exports 

## Additional information

New column called "Weekly Allocation Hours" which corresponds to timecard `total_allocation_hours`
