### PR TITLE
Add GitHub action to run when issues are opened

### DIFF
--- a/.github/workflows/on-add-issue.yml
+++ b/.github/workflows/on-add-issue.yml
@@ -1,0 +1,28 @@
+name: Add new issues to the Delivery Assurance project board
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  initialize:
+    name: Initialize new issue
+    runs-on: ubuntu-latest
+    steps:
+      # Rather than use a personal access token to interact with the project, we
+      # can use this GitHub App. There's an API for exchanging app credentials
+      # for a short-term token, and we use that API here.
+      - name: get token
+        uses: tibdex/github-app-token@v1
+        id: app_token
+        with:
+          app_id: ${{ secrets.PROJECT_APP_ID }}
+          installation_id: ${{ secrets.PROJECT_INSTALLATION_ID }}
+          private_key: ${{ secrets.PROJECT_PRIVATE_KEY }}
+      # Now we can add the issue to the project board.
+      - name: add to project board
+        uses: actions/add-to-project@v0.4.0
+        with:
+          project-url: https://github.com/orgs/18F/projects/41
+          github-token: ${{ steps.app_token.outputs.token }}

--- a/.github/workflows/on-add-issue.yml
+++ b/.github/workflows/on-add-issue.yml
@@ -26,3 +26,5 @@ jobs:
         with:
           project-url: https://github.com/orgs/18F/projects/41
           github-token: ${{ steps.app_token.outputs.token }}
+          labeled: compliance
+          label-operator: NOT

--- a/.github/workflows/on-add-issue.yml
+++ b/.github/workflows/on-add-issue.yml
@@ -26,5 +26,5 @@ jobs:
         with:
           project-url: https://github.com/orgs/18F/projects/41
           github-token: ${{ steps.app_token.outputs.token }}
-          labeled: compliance
+          labeled: compliance, Compliance
           label-operator: NOT


### PR DESCRIPTION
## Description

This code adds a GitHub Action that runs when a new issue is opened in this repo.

The GitHub Action populate the issue onto the Delivery Assurance [projects board](https://github.com/orgs/18F/projects/41) without a status where it will be ready to be prioritized or removed.

This is part of https://github.com/18F/delivery-assurance/issues/9 and closes #1540 


