### PR TITLE
Validate billing based on project weekly/hourly status

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -88,7 +88,7 @@ that case, restart the `tock_app` container with a `docker-compose up` command.
 
 ### Testing locally
 
-The easiest, most reliable way to test locally is from within the docker container, 
+The easiest, most reliable way to test locally is from within the docker container,
 which lets you access `manage.py`:
 
 ```

--- a/tock/hours/forms.py
+++ b/tock/hours/forms.py
@@ -173,8 +173,8 @@ class TimecardObjectForm(forms.ModelForm):
     def clean(self):
         if 'project' in self.cleaned_data:
             if self.cleaned_data['project'].is_weekly_bill:
-                if ('hours_spent' in self.cleaned_data and
-                    self.cleaned_data['hours_spent'] > 0):
+                if ('hours_spent' in self.cleaned_data and \
+                   self.cleaned_data['hours_spent'] > 0):
                     self.add_error(
                         'project',
                         forms.ValidationError(
@@ -183,8 +183,8 @@ class TimecardObjectForm(forms.ModelForm):
                         ),
                     )
             else:
-                if ('project_allocation' in self.cleaned_data and
-                    self.cleaned_data['project_allocation'] != ''):
+                if ('project_allocation' in self.cleaned_data and \
+                   self.cleaned_data['project_allocation'] != ''):
                     self.add_error(
                         'project',
                         forms.ValidationError(

--- a/tock/hours/forms.py
+++ b/tock/hours/forms.py
@@ -171,6 +171,27 @@ class TimecardObjectForm(forms.ModelForm):
         return self.cleaned_data.get('hours_spent') or 0
 
     def clean(self):
+        if 'project' in self.cleaned_data:
+            if self.cleaned_data['project'].is_weekly_bill:
+                if ('hours_spent' in self.cleaned_data and
+                    self.cleaned_data['hours_spent'] > 0):
+                    self.add_error(
+                        'project',
+                        forms.ValidationError(
+                            'You cannot submit hourly billing '
+                            'for a project under weekly billing'
+                        ),
+                    )
+            else:
+                if ('project_allocation' in self.cleaned_data and
+                    self.cleaned_data['project_allocation'] != ''):
+                    self.add_error(
+                        'project',
+                        forms.ValidationError(
+                            'You cannot submit weekly billing '
+                            'for a project under hourly billing'
+                        ),
+                    )
         if 'notes' in self.cleaned_data and 'project' in self.cleaned_data:
             self.cleaned_data['notes'] = bleach.clean(
                 self.cleaned_data['notes'],

--- a/tock/hours/tests/test_forms.py
+++ b/tock/hours/tests/test_forms.py
@@ -369,6 +369,28 @@ class TimecardInlineFormSetTests(TestCase):
     def test_smallest_project_allocation(self):
         """Should be able to make a timecard with 12.5% project allocation"""
         form_data = self.form_data()
+        del form_data['timecardobjects-0-hours_spent']
+        form_data['timecardobjects-0-project'] = 51
         form_data['timecardobjects-0-project_allocation'] = '0.125'
         formset = TimecardFormSet(form_data, instance=self.timecard)
         self.assertTrue(formset.is_valid())
+
+    def test_weekly_allocation_to_a_hourly_project(self):
+        """Should not be able to assign weekly values to a hourly billing project"""
+        form_data = self.form_data()
+        form_data['timecardobjects-0-project_allocation'] = '0.5'
+        formset = TimecardFormSet(form_data, instance=self.timecard)
+        self.assertFalse(formset.is_valid())
+        self.assertEqual(formset.errors[0]['project'][0],
+                         'You cannot submit weekly billing for a '
+                         'project under hourly billing')
+
+    def test_hourly_allocation_to_a_weekly_project(self):
+        """Should not be able to assign hourly values to a weekly billing project"""
+        form_data = self.form_data()
+        form_data['timecardobjects-0-project'] = 51
+        formset = TimecardFormSet(form_data, instance=self.timecard)
+        self.assertFalse(formset.is_valid())
+        self.assertEqual(formset.errors[0]['project'][0],
+                         'You cannot submit hourly billing for a '
+                         'project under weekly billing')

--- a/tock/hours/tests/test_integration.py
+++ b/tock/hours/tests/test_integration.py
@@ -134,6 +134,7 @@ class TestSubmit(ProtectedViewTestCase, WebTest):
         form = res.form  # only one form on the page?
         form["timecardobjects-0-project"] = self.projects[0].id
         form["timecardobjects-0-hours_spent"] = 40
+        form["timecardobjects-0-project_allocation"].force_value(None)
         res = form.submit("submit-timecard").follow()
         self.assertEqual(200, res.status_code)
         self.assertNotContains(res, "usa-alert--error")
@@ -146,6 +147,7 @@ class TestSubmit(ProtectedViewTestCase, WebTest):
         form = self.app.get(url, user=self.user).form  # only one form on the page
         form["timecardobjects-0-project"] = self.projects[0].id
         form["timecardobjects-0-hours_spent"] = 40
+        form["timecardobjects-0-project_allocation"].force_value(None)
         form.submit("submit-timecard").follow()
 
         date2 = self.reporting_period2.start_date.strftime('%Y-%m-%d')
@@ -154,9 +156,10 @@ class TestSubmit(ProtectedViewTestCase, WebTest):
         form = self.app.get(url, user=self.user).form  # only one form on the page
         form["timecardobjects-0-project"] = self.projects[0].id
         form["timecardobjects-0-hours_spent"] = 40
+        form["timecardobjects-0-project_allocation"].force_value(None)
         # timecard.js would set this field to be unselected, but since WebTest
-        # runs no Javascript, force this field to be the empty string
-        form["timecardobjects-1-project_allocation"].force_value("")
+        # runs no Javascript, force this field to be unset
+        form["timecardobjects-1-project_allocation"].force_value(None)
         res = form.submit("submit-timecard")
 
         # successful POST will give a 302 redirect


### PR DESCRIPTION
## Description

Partially fixes https://github.com/18F/tock/issues/1575 by adjusting the backend (and tests) to fail form submission if hourly data is submitted for a weekly project, or vice versa. 

## Additional information

Ideally the user should never see this message, as the front end will clean up project selection values, but _if_ the javascript fails and the user happens to submit mixed hourly/weekly data, here are the error(s) they will see:

![2023-04-03_11-17](https://user-images.githubusercontent.com/3013175/229595848-96285ec5-8507-4926-8470-fbdf41cd7e01.png)

![2023-04-03_11-22](https://user-images.githubusercontent.com/3013175/229595890-9686f87e-cf64-4d8a-b04d-59c85a1b981c.png)
