### PR TITLE
Fix hours field to clear the number when a weekly project is selected

### DIFF
--- a/tock/tock/static/js/components/timecard.js
+++ b/tock/tock/static/js/components/timecard.js
@@ -211,6 +211,7 @@ function toggleNotesField(selectBoxId) {
     handleBillingElementState('hide');
     project_allocation.classList.remove('entry-hidden');
     hours_spent.classList.add('entry-hidden');
+    hours_set.value = '';
   } else {
     const noWeeklyBilledProjectsExist = !weeklyBilledProjectExists();
 


### PR DESCRIPTION
## Description

Clear hours field on the front-end when weekly billing project is selected. It was reported in issue #1575

