### PR TITLE
Removed s from _header and _navigation.

### DIFF
--- a/tock/tock/templates/_header.html
+++ b/tock/tock/templates/_header.html
@@ -4,7 +4,7 @@
   <div class="usa-logo" id="logo">
     <em class="usa-logo__text">
       <img src="{% static 'img/18F-Logo.svg' %}" alt="18F logo" />
-      <a href="/" accesskey="1" title="Home" aria-label="Home">Tock</a>
+      <a href="/" title="Home" aria-label="Home">Tock</a>
     </em>
   </div>
 </div>

--- a/tock/tock/templates/_navigation.html
+++ b/tock/tock/templates/_navigation.html
@@ -6,7 +6,7 @@
     </button>
     <ul class="usa-nav__primary usa-accordion">
       <li class="usa-nav__primary-item">
-        <a href="/" accesskey="1" title="Home" aria-label="Home">Tock your time</a>
+        <a href="/" title="Home" aria-label="Home">Tock your time</a>
       </li>
       <li class="usa-nav__primary-item">
         <a class="usa-nav__link" href="{{ x_tock_change_request_form_url }}" target="_blank"  rel="noopener noreferrer">


### PR DESCRIPTION
Related to [#1569 ]

This PR covers removal of `accesskey` attributes from the _header.html and _navigation.html templates.

Updates in this PR:
- Removed `accesskey` attribute from the logo link
- Removed `accesskey` attribute from the `Tock your time` navigation link

![image](https://user-images.githubusercontent.com/106776019/230673966-3f4db322-b2d0-4382-8bd0-ecb3bb649b53.png)
