### PR TITLE
Utilization test util view

### DIFF
--- a/tock/utilization/tests/test_views.py
+++ b/tock/utilization/tests/test_views.py
@@ -296,7 +296,7 @@ class TestGroupUtilizationView(WebTest):
 
         last_week_data = response.context['object_list'][0]['utilization']['last_week_data']
 
-        data = next(item for item in last_week_data if item['username'] == 'user.weekly.only')
+        data = [item for item in last_week_data if item['username'] == 'user.weekly.only'][0]
         self.assertIsNone(data['denominator'])
         self.assertEqual(data['billable'],
             Decimal('0')
@@ -321,7 +321,7 @@ class TestGroupUtilizationView(WebTest):
 
         last_week_data = response.context['object_list'][0]['utilization']['last_week_data']
 
-        data = next(item for item in last_week_data if item['username'] == 'user.weekly.hourly')
+        data = [item for item in last_week_data if item['username'] == 'user.weekly.hourly'][0]
         self.assertEqual(data['denominator'],
             Decimal('13.0')
         )


### PR DESCRIPTION
## Description

Adds tests to `utilization/tests/test_views.py` that incorporate weekly billing. Currently, the calculation of an individual / organization's utilization does not take into account billable weekly allocation. These tests are intended to confirm the expected behavior of utilization ignoring weekly billing.

- adds more setup by way of projects, users, and timecards
- amends unsubmitted test to include newly added timecards
- tests that a billable weekly project with no additional hours will consider utilization as 'No hours submitted.'
- tests that weekly + hourly calculates utilization only with hours

Closes https://github.com/18F/tock/issues/1590 
This is part of the [utilization epic](https://github.com/18F/tock/issues/1500)

(Tagging @alexbielen and @kingcomma from the TLC crew for their awareness)