### PR TITLE
calculates timecard utilization including weekly allocation

### DIFF
--- a/tock/projects/fixtures/projects.json
+++ b/tock/projects/fixtures/projects.json
@@ -694,5 +694,15 @@
          "is_weekly_bill": true
       },
       "pk":51
+   },
+   {
+      "model":"projects.project",
+      "fields":{
+         "name":"Weekly Non-billing",
+         "description":"",
+         "accounting_code":1,
+         "is_weekly_bill": true
+      },
+      "pk":52
    }
 ]

--- a/tock/utilization/tests/test_views.py
+++ b/tock/utilization/tests/test_views.py
@@ -310,9 +310,10 @@ class TestGroupUtilizationView(WebTest):
         Checks the utilization value for the previous week when a user
         has weekly allocation and billable hours.
 
-        NOTE: Currently utilization does not consider weekly allocation,
-        therefore the values below reflect the mistaken assumption that
-        the user only worked the hourly billable and non-billable total.
+        NOTE: Currently utilization only considers weekly allocation when
+        calculating target hours (aka `denominator`). Therefore the billable
+        and utilization values below reflect the mistaken assumption the
+        user only billed what they tocked to an hourly billable project.
         """
         response = self.app.get(
             url=reverse('utilization:GroupUtilizationView'),
@@ -322,14 +323,15 @@ class TestGroupUtilizationView(WebTest):
         last_week_data = response.context['object_list'][0]['utilization']['last_week_data']
 
         data = [item for item in last_week_data if item['username'] == 'user.weekly.hourly'][0]
+
         self.assertEqual(data['denominator'],
-            Decimal('13.0')
+            Decimal('32.0')
         )
         self.assertEqual(data['billable'],
             Decimal('12.0')
         )
         self.assertEqual(data['utilization'],
-            '92.3%'
+            '37.5%'
         )
 
     def test_user_detail_with_utilization(self):


### PR DESCRIPTION
## Description

Incorporates weekly allocation into the `Timecard.utilization` field calculation. Closes https://github.com/18F/tock/issues/1591. Follow-on work is planned for utilizing this new calculation in reports and views (#1592).

Changes the following logic in the `Timecard` model:
- `total_weekly_allocation` considers billable weekly projects only
- `target_hours` is now based on the `HOURS_IN_A_REGULAR_WORK_WEEK` setting and no longer on the sum of billable and non-billable hours (which could be zero for users on weekly billing projects)
- `utilization` calculation sums `total_weekly_allocation` and hourly utilization (`billable_hours`/`target_hours`)

Updates existing tests to accomodate utilization changes and adds:
- test fixture for non-billable weekly project
- test for no billable hours nor weekly allocation
- test for no billable hours and non-billable weekly allocation
- test for billable hours and non-billable weekly allocation
- tests for combinations of excluded hours (i.e., OOO) and weekly/hourly projects

## Additional information

There are a couple changes/questions we especially want to highlight for review:
- After these changes, users who tock to weekly billing projects will have timecards with different (we believe _correct_) target hours numbers. E.g., a user with no OOO and tocking only to weekly billing projects would have 0 target hours before these changes and 40 * .8 = 32 target hours after these changes. All tests pass after this change, but we're unsure if there are critical areas where the target hours number is used that we aren't aware of.
- `utilization.utils.calculate_utilization` [checks for a case where `target_hours` is `None`](https://github.com/18F/tock/blob/9817837b3b80bb9ec4b3057e5e009f0eddd4b85e/tock/utilization/utils.py#L11-L19), but this is no longer possible after these changes. It doesn't appear this was possible _before_ these changes either, but we want to make sure we aren't missing a critical scenario where `target_hours` really should be `None`.

Tagging @alexbielen for awareness.

(Post updated by @kingcomma on 5/8)