### PR TITLE
Utilization detail view

### DIFF
--- a/tock/hours/tests/test_views.py
+++ b/tock/hours/tests/test_views.py
@@ -3,7 +3,6 @@ import datetime
 from decimal import Decimal
 
 import hours.models
-import projects.models
 from api.tests import client
 from api.views import ProjectSerializer, UserDataSerializer
 from django.conf import settings
@@ -17,6 +16,7 @@ from hours.utils import number_of_hours
 from hours.views import (GeneralSnippetsTimecardSerializer, ReportsList,
                          TimecardView)
 from organizations.models import Organization, Unit
+from projects.models import AccountingCode, Project
 
 User = get_user_model()
 
@@ -71,7 +71,7 @@ class CSVTests(TestCase):
 
     def test_general_snippets(self):
         """Test that snippets are returned in correct CSV format."""
-        project = projects.models.Project.objects.get_or_create(
+        project = Project.objects.get_or_create(
             name='General'
         )[0]
         tco = hours.models.TimecardObject.objects.first()
@@ -212,10 +212,10 @@ class UserReportsTest(TestCase):
         self.nonbillable_project = hours.models.Project.objects.filter(
             accounting_code__billable=False
         )[0]
-        self.billable_project = projects.models.Project.objects.filter(
+        self.billable_project = Project.objects.filter(
             accounting_code__billable=True
         )[0]
-        self.excluded_project = projects.models.Project.objects.filter(
+        self.excluded_project = Project.objects.filter(
             exclude_from_billability=True
         )[0]
         self.timecard_obj_0 = hours.models.TimecardObject.objects.create(
@@ -268,9 +268,8 @@ class ReportTests(WebTest):
             user=self.user,
             submitted=True,
             reporting_period=self.reporting_period)
-        self.project_1 = projects.models.Project.objects.get(name="openFEC")
-        self.project_2 = projects.models.Project.objects.get(
-            name="Peace Corps")
+        self.project_1 = Project.objects.get(name="openFEC")
+        self.project_2 = Project.objects.get(name="Peace Corps")
         self.timecard_object_1 = hours.models.TimecardObject.objects.create(
             timecard=self.timecard,
             project=self.project_1,
@@ -498,23 +497,23 @@ class ReportTests(WebTest):
         org_coe = Organization.objects.create(name='CoE')
         org_coe.save()
 
-        accounting_code = projects.models.AccountingCode.objects.get(pk=1)
+        accounting_code = AccountingCode.objects.get(pk=1)
 
-        project_18f = projects.models.Project.objects.create(
+        project_18f = Project.objects.create(
             name='an 18f project',
             accounting_code=accounting_code,
             organization=org_18f
         )
         project_18f.save()
 
-        project_coe = projects.models.Project.objects.create(
+        project_coe = Project.objects.create(
             name='a coe project',
             accounting_code=accounting_code,
             organization=org_coe
         )
         project_coe.save()
 
-        project_none = projects.models.Project.objects.create(
+        project_none = Project.objects.create(
             name='a project with no org assignment',
             accounting_code=accounting_code,
         )
@@ -687,7 +686,7 @@ class ReportTests(WebTest):
             submitted=False,
             reporting_period=new_period
         )
-        new_project = projects.models.Project.objects.get(name="Midas")
+        new_project = Project.objects.get(name="Midas")
         new_tco = hours.models.TimecardObject.objects.create(
             timecard=new_timecard,
             project=new_project,
@@ -1013,9 +1012,9 @@ class PrefillDataViewTests(WebTest):
             user=self.user
         )
 
-        self.project_1 = projects.models.Project.objects.first()
+        self.project_1 = Project.objects.first()
         self.project_1.save()
-        self.project_2 = projects.models.Project.objects.last()
+        self.project_2 = Project.objects.last()
         self.project_2.save()
 
         self.pfd1 = hours.models.TimecardPrefillData.objects.create(

--- a/tock/hours/views.py
+++ b/tock/hours/views.py
@@ -802,6 +802,7 @@ class ReportingPeriodUserDetailView(PermissionMixin, DetailView):
         context = super(
             ReportingPeriodUserDetailView, self).get_context_data(**kwargs)
         context['user_billable_hours'] = timecard.billable_hours
+        context['user_weekly_allocation'] = timecard.total_weekly_allocation
         context['user_non_billable_hours'] = timecard.non_billable_hours
         context['user_excluded_hours'] = timecard.excluded_hours
         context['user_target_hours'] = timecard.target_hours

--- a/tock/tock/templates/employees/user_recent_tocks.html
+++ b/tock/tock/templates/employees/user_recent_tocks.html
@@ -26,7 +26,7 @@
   <tfoot>
     <tr><th scope="row"><b>Totals</b></th></tr>
     <tr>
-    <th scope="row"><b>Billable</b></th>
+    <th scope="row"><b>Billable Hours</b></th>
       {% for i in recent_timecards %}
         {% with recent_timecards|index:forloop.counter0 as tc %}
           <td>{{tc.billable_hours}}</td>
@@ -34,14 +34,22 @@
       {% endfor %}
     </tr>
     <tr>
-    <th scope="row"><b>Non-Billable</b></th>
+    <tr>
+    <th scope="row"><b>Billable Allocation</b></th>
+      {% for i in recent_timecards %}
+      {% with recent_timecards|index:forloop.counter0 as tc %}
+        <td>{% widthratio tc.total_weekly_allocation 1 100 %}%</td>
+      {% endwith %}
+    {% endfor %}
+    </tr>
+    <tr>
+    <th scope="row"><b>Non-Billable Hours</b></th>
       {% for i in recent_timecards %}
       {% with recent_timecards|index:forloop.counter0 as tc %}
         <td>{{tc.non_billable_hours}}</td>
       {% endwith %}
     {% endfor %}
     </tr>
-    <tr>
     <th scope="row"><b>Excluded from Utilization</b></th>
     {% for i in recent_timecards %}
       {% with recent_timecards|index:forloop.counter0 as tc %}

--- a/tock/tock/templates/hours/reporting_period_user_detail.html
+++ b/tock/tock/templates/hours/reporting_period_user_detail.html
@@ -30,7 +30,8 @@
       {% endif %}
       </td>
       <td data-title="Hours spent">{{ entry.hours_spent }}</td>
-      <td data-title="Project Allocation">{{ entry.project_allocation }}</td>
+      <td data-title="Project Allocation">{% widthratio entry.project_allocation 1 100 %}%
+      </td>
       <td data-title="Notes">
         {% for note in entry.notes_list %}
           <p>{{ note }}</p>
@@ -58,6 +59,7 @@
   <thead>
     <tr>
       <th>Billable Hours</th>
+      <th>Billable Allocation</th>
       <th>Non-Billable Hours</th>
       <th>Excluded Hours</th>
       <th>Target Hours</th>
@@ -67,6 +69,7 @@
   <tbody>
     <tr>
       <td data-title="Billable hours"> {{ user_billable_hours }} </td>
+      <td data-title="Billable allocation">{% widthratio user_weekly_allocation 1 100 %}% </td>
       <td data-title="Non-Billable hours"> {{ user_non_billable_hours }} </td>
       <td data-title="Excluded hours"> {{ user_excluded_hours }} </td>
       <td data-title="Target hours"> {{ user_target_hours }} </td>


### PR DESCRIPTION
## Description

adds or updates a timecard's weekly allocation amount to the UI
updates view test to include allocation total

## Additional information

On the recent timecards view, I added weekly allocation which ONLY includes billable weekly allocation (comes from the timecard model).

![image](https://github.com/18F/tock/assets/2480492/a774b53c-a745-44ba-b680-7ca475a6c238)


Note: there was already an existing allocation field on the `reporting_period_user_detail` page which includes both billable and non-billable allocation (the info comes from the timecardobject model).  However, at the bottom where information is provided to explain the utilization calculation, only billable allocation is included. To distinguish, I left the top "project allocation" and made the bottom "billable allocation"

![image](https://github.com/18F/tock/assets/2480492/4bfc696e-a0b4-4893-8472-be2edc8c0e45)

