### PR TITLE
Add additional utilization tests for common business cases

### DIFF
--- a/tock/projects/fixtures/projects.json
+++ b/tock/projects/fixtures/projects.json
@@ -704,5 +704,35 @@
          "is_weekly_bill": true
       },
       "pk":52
+   },
+   {
+      "model":"projects.project",
+      "fields":{
+         "name":"Weekly Billing 2",
+         "description":"",
+         "accounting_code":15,
+         "is_weekly_bill": true
+      },
+      "pk":53
+   },
+   {
+      "model":"projects.project",
+      "fields":{
+         "name":"Weekly Billing 3",
+         "description":"",
+         "accounting_code":15,
+         "is_weekly_bill": true
+      },
+      "pk":54
+   },
+   {
+      "model":"projects.project",
+      "fields":{
+         "name":"Weekly Billing 4",
+         "description":"",
+         "accounting_code":15,
+         "is_weekly_bill": true
+      },
+      "pk":55
    }
 ]


### PR DESCRIPTION
## Description

Adds additional utilization tests for common business cases:

- Timecard with many weekly billing projects (e.g., an AM)
- Timecards with 40 hours of out of office time
- Timecards with billable expectations < .8

Closes #1607 
