### PR TITLE
updates timecard allocation hours calculation

### DIFF
--- a/tock/hours/models.py
+++ b/tock/hours/models.py
@@ -322,6 +322,14 @@ class Timecard(models.Model):
         total_hours_worked = settings.HOURS_IN_A_REGULAR_WORK_WEEK - self.excluded_hours
         return round(self.billable_expectation * total_hours_worked, 0)
 
+    def calculate_total_allocation_hours(self):
+        """
+        Calculates an estimate of the hours spent on projects with a weekly billable
+        allocation by multiplying that allocation against this timecard's target hours.
+        """
+
+        return round(self.target_hours * self.total_weekly_allocation, 0)
+
     def calculate_total_weekly_allocation(self):
         """
         Loops through related time card objects and sums total
@@ -365,10 +373,10 @@ class Timecard(models.Model):
         self.billable_hours = round(timecard.billable, 2)
         self.non_billable_hours = round(timecard.non_billable, 2)
         self.excluded_hours = round(timecard.excluded, 2)
-        self.total_weekly_allocation = self.calculate_total_weekly_allocation()
-        self.total_allocation_hours = settings.FULLTIME_ALLOCATION_HOURS * self.total_weekly_allocation
 
         self.target_hours = self.calculate_target_hours()
+        self.total_weekly_allocation = self.calculate_total_weekly_allocation()
+        self.total_allocation_hours = self.calculate_total_allocation_hours()
         self.utilization = self.calculate_utilization()
 
     def on_time(self):

--- a/tock/hours/tests/test_models.py
+++ b/tock/hours/tests/test_models.py
@@ -165,6 +165,8 @@ class TimecardTests(TestCase):
         self.assertEqual(timecard.billable_expectation, Decimal('0.80'))
         self.assertEqual(timecard.billable_hours, 40)
         self.assertEqual(timecard.target_hours, 32)
+        self.assertEqual(timecard.total_weekly_allocation, 0)
+        self.assertEqual(timecard.total_allocation_hours, 0)
         self.assertEqual(timecard.utilization, Decimal('1.25'))
 
     def test_time_card_submission(self):
@@ -290,7 +292,9 @@ class TimecardTests(TestCase):
         self.timecard.calculate_hours()
 
         self.assertEqual(self.timecard.billable_hours, 40)
-        self.assertEqual(self.timecard.utilization, Decimal('1.75'))
+        self.assertEqual(self.timecard.total_weekly_allocation, Decimal("0.5"))
+        self.assertEqual(self.timecard.total_allocation_hours, 16)
+        self.assertEqual(self.timecard.utilization, Decimal("1.75"))
 
     def test_time_card_utilization_only_weekly_billing(self):
         """Check that utilization is 100% with a 100% weekly billing project
@@ -312,6 +316,8 @@ class TimecardTests(TestCase):
         self.timecard.calculate_hours()
 
         self.assertEqual(self.timecard.billable_hours, 0)
+        self.assertEqual(self.timecard.total_weekly_allocation, Decimal("1"))
+        self.assertEqual(self.timecard.total_allocation_hours, 32)
         self.assertEqual(self.timecard.utilization, Decimal("1"))
 
     def test_time_card_utilization_many_weekly_billing(self):
@@ -356,6 +362,8 @@ class TimecardTests(TestCase):
         self.timecard.calculate_hours()
 
         self.assertEqual(self.timecard.target_hours, 32)
+        self.assertEqual(self.timecard.total_weekly_allocation, Decimal(".875"))
+        self.assertEqual(self.timecard.total_allocation_hours, 28)
         self.assertEqual(self.timecard.utilization, Decimal("1"))
 
     def test_time_card_utilization_no_hours_with_weekly_nonbillable(self):
@@ -376,7 +384,9 @@ class TimecardTests(TestCase):
         self.timecard_object_2.save()
 
         self.timecard.calculate_hours()
-        self.assertEqual(self.timecard.utilization, Decimal('0'))
+        self.assertEqual(self.timecard.total_weekly_allocation, Decimal("0"))
+        self.assertEqual(self.timecard.total_allocation_hours, 0)
+        self.assertEqual(self.timecard.utilization, Decimal("0"))
 
     def test_time_card_utilization_weekly_nonbillable(self):
         """Check that utilization is hourly only when there is a non-billable


### PR DESCRIPTION
## Description

Changes a timecard's `total_allocation_hours` calculation. Previously, this used a hardcoded value from `base.py` (currently 32 hrs). Instead, we start with the timecard's `target_hours` before multiplying that by the (billable) weekly allocation percentage to create an estimate of the allocation hours.

## Additional information

Closes https://github.com/18F/tock/issues/1612

## Concerns

`base.py` still contains `FULLTIME_ALLOCATION_HOURS` as a setting, as it is used in a migration. If not for the migration, it could be removed.