### PR TITLE
changes weekly allocation hour estimate calculation

### DIFF
--- a/tock/hours/models.py
+++ b/tock/hours/models.py
@@ -325,10 +325,21 @@ class Timecard(models.Model):
     def calculate_total_allocation_hours(self):
         """
         Calculates an estimate of the hours spent on projects with a weekly billable
-        allocation by multiplying that allocation against this timecard's target hours.
-        """
+        allocation.
 
-        return round(self.target_hours * self.total_weekly_allocation, 0)
+        This calculation does not use self.target_hours, which incorporates
+        self.billable_expectation, because the allocation % indicated by users
+        is a reflection of the proportion of their total week, not as a proportion
+        of their expected billable hours.
+
+        For example: a supervisor has a .4 (40%) billable_expectation. If they spend
+        half of their time on a billable project, they would indicate 50% weekly allocation
+        in Tock and work out to an
+        estimated 16 hours ((40 - OOO time) * .8 billable_expectation * .5 allocation)
+        """
+        total_hours_worked = settings.HOURS_IN_A_REGULAR_WORK_WEEK - self.excluded_hours
+        default_expectation = Decimal(settings.DEFAULT_BILLABLE_EXPECTATION) * total_hours_worked
+        return round(default_expectation * self.total_weekly_allocation, 0)
 
     def calculate_total_weekly_allocation(self):
         """


### PR DESCRIPTION
## Description

Previously, we changed `total_allocation_hours` (an estimate of how many hours a person with weekly allocation % spent working on the project) to use `target_hours` in its calculation. This worked great for individuals with a .8 billable expectation, but not so well for folks like supervisors with a .4 billable expectation, as it then halved their potentially contributed hours.

Here is a new proposal for the `total_allocation_hours` estimate that returns to the assumption that there is a set number of hours that people would be likely to bill during the week (current values are 32 hours / .8 billable expectation, set in `base.py`), and that a person's allocation % is a percentage of THAT time.  Therefore, we use the default billable expectation to compare allocation %s against.

This adds a test for a lower billable expectation (.4) with out of office time, and checks the allocation hour estimate in several other tests.

## Additional information

We have gone back and forth a little on how to consider utilization for supervisors.  Is a supervisor with a .4 expectation (16 hours a week) who bills 50% (16 hours) to a weekly project considered 50% utilized or 100% utilized?  The current utilization behavior is that a supervisor billing 50% would be 50% utilized (out of their entire week), but if this is incorrect, then we need to revisit how utilization is being calculated.
