### PR TITLE
setup egress environment vars

### DIFF
--- a/.profile
+++ b/.profile
@@ -1,0 +1,5 @@
+##
+# Cloud Foundry app initialization script
+# https://docs.cloudfoundry.org/devguide/deploy-apps/deploy-app.html#profile
+##
+export https_proxy=$egress_proxy

--- a/manifest-staging.yml
+++ b/manifest-staging.yml
@@ -14,6 +14,7 @@ applications:
     NEW_RELIC_CONFIG_FILE: /home/vcap/app/newrelic.ini
     NEW_RELIC_ENV: staging
     NEW_RELIC_LOG: stdout
+    REQUESTS_CA_BUNDLE: "/etc/ssl/certs/ca-certificates.crt"
   instances: 1
   services:
   - tock-database


### PR DESCRIPTION
## Description

Trying to simplify the current egress workflow by adding two environment variables:

- `https_proxy` will be set to `egress_proxy` when the app launches
- `REQUESTS_CA_BUNDLE` will force the python libraries to load system ca certificates
