### PR TITLE
api: escape query params when emitting error

### DIFF
--- a/tock/api/views.py
+++ b/tock/api/views.py
@@ -4,6 +4,7 @@ import datetime
 from django.contrib.auth import get_user_model
 from django.db import connection
 from django.db.models import Count, F
+from django.utils.html import escape
 
 from rest_framework import serializers, generics
 from rest_framework.exceptions import ParseError
@@ -257,7 +258,7 @@ def date_from_iso_format(date_str):
     except ValueError:
         raise ParseError(
             detail='Invalid date format. Got {}, expected ISO format (YYYY-MM-DD)'.format(
-                date_str
+                escape(date_str)
             )
         )
 

--- a/tock/hours/tests/test_views.py
+++ b/tock/hours/tests/test_views.py
@@ -1,5 +1,6 @@
 import csv
 import datetime
+import urllib.parse
 from decimal import Decimal
 
 import hours.models
@@ -903,6 +904,17 @@ class ReportTests(WebTest):
             expect_errors=True
         )
         self.assertEqual(response.status_code, 404)
+
+    def test_ReportingPeriodDetailView_escape_invalid_date_404(self):
+        query={'after': '"><fish>', 'before': '2019-09-28'}
+        url = reverse('reports:BulkTimecardList')
+        response = self.app.get(
+            f'{url}?{urllib.parse.urlencode(query)}',
+            user=self.regular_user,
+            expect_errors=True
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json['detail'], 'Invalid date format. Got &quot;&gt;&lt;fish&gt;, expected ISO format (YYYY-MM-DD)')
 
     def test_ReportingPeriodDetailView_add_submitted_time(self):
         """


### PR DESCRIPTION
## Description

when the API emits an error, escape all user input (query params).

## Additional information

this behavior was flagged in a netsparker scan, but it's a false warning. nonetheless, let's fix anyway in the name of sanitizing output.