### PR TITLE
staging: fix new relic ssl cert errors

### DIFF
--- a/manifest-staging.yml
+++ b/manifest-staging.yml
@@ -14,6 +14,7 @@ applications:
     NEW_RELIC_CONFIG_FILE: /home/vcap/app/newrelic.ini
     NEW_RELIC_ENV: staging
     NEW_RELIC_LOG: stdout
+    NEW_RELIC_CA_BUNDLE_PATH: /etc/ssl/certs
     REQUESTS_CA_BUNDLE: "/etc/ssl/certs/ca-certificates.crt"
   instances: 1
   services:


### PR DESCRIPTION
## Description

As part of our deployment process, we [record the deploy](https://github.com/18F/tock/blob/main/bin/run.sh#L44-L45) for New Relic: 

```sh
# Record deployment using the New Relic Python Admin CLI
newrelic-admin record-deploy "${NEW_RELIC_CONFIG_FILE}" "${DEPLOYMENT_DESCRIPTION}"
```

Unfortunately, it looks like we're getting SSL errors when we use the built-in New Relic certificate located at `/home/vcap/deps/0/python/lib/python3.10/site-packages/newrelic/common/cacert.pem`. I am not sure why this is happening now, but it might be related to New Relic endpoints changing to different IP addresses. Plus, we're already at the latest New Relic version, as far as i can tell. (Although 8.10.1 just came out two days ago). **This SSL error blocks staging from deploying.**

Anyway, we can work around this by setting the `NEW_RELIC_CA_BUNDLE_PATH` ([documentation](https://docs.newrelic.com/docs/apm/agents/python-agent/configuration/python-agent-configuration/#ca-bundle-path)) to the cloud.gov certificates and this seems to work. 

To replicate the error, `cf ssh` staging and run:

`newrelic-admin record-deploy newrelic.ini "testing"`

This will fail with: ```
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1007)```

To confirm the fix works:

`NEW_RELIC_CA_BUNDLE_PATH=/etc/ssl/certs/ newrelic-admin record-deploy newrelic.ini "testing"`