### PR TITLE
Workaround to override zope sub dependency setuptools@39.0.1

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -33,7 +33,7 @@ factory-boy = "*"
 "flake8" = "*"
 nplusone = "*"
 codecov = "==2.1.13"
-setuptools = ">=65.5.1"
+setuptools = ">=39.0.1"
 
 [requires]
 python_version = "3.10"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7082ce00268aebd098e51992d8dc788e56dcf7a1048cdd248c8cc9398f3ad820"
+            "sha256": "b69ea22cef14b27f984a1080045e72e4c6ccd77d23f73301d58eb064446ab23c"
         },
         "pipfile-spec": 6,
         "requires": {


### PR DESCRIPTION
## Description

Draft PR to test upgrading setuptools@39.0.1
