### PR TITLE
Add Total Hours Counter even with Weekly Billing Projects in Reporting Period Page #1638

### DIFF
--- a/tock/tock/static/js/components/timecard.js
+++ b/tock/tock/static/js/components/timecard.js
@@ -150,16 +150,6 @@ function populateHourTotals() {
   billableElement.querySelector('.number-label').innerHTML =
     totals.billableHours;
 
-  if (totals.totalHours === 0) {
-    totalElement.classList.remove('valid', 'invalid');
-  } else if (totals.totalHours === totalHoursTarget) {
-    totalElement.classList.add('valid');
-    totalElement.classList.remove('invalid');
-  } else {
-    totalElement.classList.add('invalid');
-    totalElement.classList.remove('valid');
-  }
-
   if (totals.billableHours === 0) {
     billableElement.classList.remove('valid', 'invalid');
   } else if (
@@ -393,7 +383,6 @@ function handleBillingElementState(visibility) {
     addItemWrapper.classList.remove('grid-col-8');
     addItemWrapper.classList.add('grid-col-2');
     weeklyBillingAlertElement.classList.remove('entry-hidden');
-    totalReportedElement.classList.add('entry-hidden');
     totalBillableElement.classList.add('entry-hidden');
   }
 }

--- a/tock/tock/tests/js/integration/timecard.test.js
+++ b/tock/tock/tests/js/integration/timecard.test.js
@@ -173,9 +173,10 @@ describe("Timecard", () => {
 
       const _totalReportedHidden = _totalReportedClassList.includes("entry-hidden");
       const _totalBillableHidden = _totalBillableClassList.includes("entry-hidden");
-      const bothSummationElementsHidden = _totalReportedHidden && _totalBillableHidden;
+      // const bothSummationElementsHidden = _totalReportedHidden && _totalBillableHidden;
 
-      expect(bothSummationElementsHidden).toBe(true);
+      expect(_totalReportedHidden).toBe(false);
+      expect(_totalBillableHidden).toBe(true);
 
       const _weeklyBillingAlertElement = await page.$eval("#weekly-billing-alert", el => el.classList);
       const _weeklyBillingAlertClassList = Array.from(Object.values(_weeklyBillingAlertElement));


### PR DESCRIPTION
## Description

To close #1638, the Total hours counter is always visible in this PR. The color was changed to grey while billing hours remained the same. 

![image](https://github.com/18F/tock/assets/4247796/b08bfd2e-77ae-40d0-bc17-a670adfc8c78)




