### PR TITLE
Timecard report fields

### DIFF
--- a/tock/employees/models.py
+++ b/tock/employees/models.py
@@ -157,6 +157,16 @@ class UserData(models.Model):
         return ''
 
     @property
+    def unit_name(self):
+        """
+        Returns the unit name associated with the employee or an empty string
+        if no unit is set.
+        """
+        if self.unit is not None:
+            return self.unit.name
+        return ''
+
+    @property
     def is_late(self):
         """
         Checks if user has a timecard submitted for the

--- a/tock/hours/tests/test_views.py
+++ b/tock/hours/tests/test_views.py
@@ -107,7 +107,11 @@ class BulkTimecardsTests(TestCase):
             'employee',
             'start_date',
             'end_date',
+            'is_weekly_bill',
             'hours_spent',
+            'project_allocation',
+            'billable_expectation',
+            'target_hours',
             'agency',
             'flat_rate',
             'active',
@@ -118,6 +122,7 @@ class BulkTimecardsTests(TestCase):
             'expense_profit_loss_account',
             'expense_profit_loss_account_name',
             'employee_organization',
+            'employee_unit',
             'project_organization',
         ))
         rows_read = 0

--- a/tock/hours/views.py
+++ b/tock/hours/views.py
@@ -44,10 +44,20 @@ class BulkTimecardSerializer(serializers.Serializer):
     end_date = serializers.DateField(
         source='timecard.reporting_period.end_date'
     )
-    hours_spent = serializers.DecimalField(max_digits=5, decimal_places=2)
+    is_weekly_bill = serializers.BooleanField(
+        source='project.is_weekly_bill'
+    )
+    hours_spent = serializers.DecimalField(decimal_places=2, max_digits=5)
+    project_allocation = serializers.DecimalField(decimal_places=3, max_digits=6)
     billable = serializers.BooleanField(
         source='project.accounting_code.billable'
     )
+    billable_expectation = serializers.DecimalField(decimal_places=2,
+        max_digits=3,
+        source='timecard.billable_expectation')
+    target_hours = serializers.DecimalField(decimal_places=2,
+        max_digits=5,
+        source='timecard.target_hours')
     agency = serializers.CharField(
         source='project.accounting_code.agency.name'
     )
@@ -75,6 +85,9 @@ class BulkTimecardSerializer(serializers.Serializer):
     )
     employee_organization = serializers.CharField(
         source='timecard.user.user_data.organization_name'
+    )
+    employee_unit = serializers.CharField(
+        source='timecard.user.user_data.unit_name'
     )
     project_organization = serializers.CharField(
         source='project.organization_name'

--- a/tock/tock/templates/hours/reports_list.html
+++ b/tock/tock/templates/hours/reports_list.html
@@ -10,6 +10,13 @@
     <div class="grid-row grid-gap">
       <div class="grid-col-6">
       <h2>Regular Reports</h2>
+      <div class="usa-alert usa-alert--info usa-alert--slim">
+        <div class="usa-alert__body">
+          <p class="usa-alert__text">
+            Large reports may fail to download. Change the date range in the report URL to work around this limitation.
+          </p>
+        </div>
+      </div>
       <ul>
         <li>Complete timecard data:
           <a href="{% url 'reports:BulkTimecardList' %}?after={{starting_report_date|date:'Y-m-d'}}">All</a>


### PR DESCRIPTION
## Description

Adds fields to the "complete timecard data" report.

| Field           | Type            | Description | 
| ----------- | ----------- | ----------- | 
| is_weekly_bill | boolean | True if weekly billing, false if hourly project |
| project_allocation | decimal 0 - 1| Weekly billing allocation (50% is .5, 100% is 1, etc)|
| billable_expectation | decimal 0 - 1 | The % of a week expected to be spent on billable work (.8 == 32 hours) |
| target_hours | decimal | Estimated hours that should be billed to a project (based on expectation, OOO time, etc) |
| employee_unit | string | Chapter or other inter-org component (ex: 18F engineering) | 

These fields allow for analysis not currently possible through the reports, such as whether a person staff person
was likely FT or PT during a given week on a project and the number of people from each chapter who contributed to a project.

## Additional information

See https://github.com/18F/TLC-crew/issues/597 for more information about the data requested from tock