### PR TITLE
Allow zero for project allocation on hourly projects

### DIFF
--- a/tock/hours/tests/test_forms.py
+++ b/tock/hours/tests/test_forms.py
@@ -394,3 +394,10 @@ class TimecardInlineFormSetTests(TestCase):
         self.assertEqual(formset.errors[0]['project'][0],
                          'You cannot submit hourly billing for a '
                          'project under weekly billing')
+
+    def test_zero_project_allocation_to_hourly_project(self):
+        """Should be able to submit zero project allocation to an hourly billing project"""
+        form_data = self.form_data()
+        form_data["timecardobjects-0-project_allocation"] = "0"
+        formset = TimecardFormSet(form_data, instance=self.timecard)
+        self.assertTrue(formset.is_valid())


### PR DESCRIPTION
## Description

#1728 was tracked down to a situation where the timecard form might submit "0" for project allocation even for hourly billing projects. This changes the form cleaning code to allow that possibility without raising the error message from the bug.

We add a test for the situation that fails in our current code and passes with the fix.

## Additional information

There are a couple unrelated changes where `or None` was removed where it wasn't doing anything.

Fixes #1728