### PR TITLE
Fix projects view when timecards have None hours_spent

### DIFF
--- a/tock/projects/tests.py
+++ b/tock/projects/tests.py
@@ -470,6 +470,26 @@ class ProjectViewTests(WebTest):
 
         self.assertEqual(float(response.html.select('#totalHoursAll')[0].string), 15)
 
+    def test_project_view_none_hours_spent(self):
+        """Ensure that the project view works with None hours_spent."""
+        TimecardObject.objects.filter().delete()
+        Timecard.objects.get(pk=1).submitted=True
+        TimecardObject.objects.create(
+            timecard = Timecard.objects.get(pk=1),
+            project=Project.objects.get(pk=1),
+            hours_spent= None
+        )
+        TimecardObject.objects.create(
+            timecard = Timecard.objects.get(pk=2),
+            project=Project.objects.get(pk=1),
+            hours_spent= 10
+        )
+        response = self.app.get(
+            reverse('projects:ProjectView', kwargs={'pk': '1'}),
+            user=User.objects.get(email='aaron.snow@gsa.gov')
+        )
+        self.assertContains(response, "Tock Projects" )
+
 
 class ProjectEngagementTests(WebTest):
 

--- a/tock/utilization/analytics.py
+++ b/tock/utilization/analytics.py
@@ -238,5 +238,10 @@ def project_chart_and_table(timecardobject_queryset):
     # datatable
     datatable = data_frame.pivot(
                     index="start_date", values="hours_spent", columns="user"
-                ).applymap("{:.0f}".format).replace("nan", "")
+                )
+    # there can be some None in "hours_spent" rather than 0 which
+    # is more typical, so let's replace the NaNs with zeroes before we
+    # format the numbers
+    datatable = datatable.fillna(0)
+    datatable = datatable.map("{:.0f}".format)
     return plot_div, datatable


### PR DESCRIPTION
## Description

#1615 tracked down a situation where the individual project view can fail when a timecard object has `None` for the `hours_spent` field. This is uncommon, but does happen in our production data.

This fixes that situation by filling with `None`s in the data frame with zeroes which is the more common case for our data.
There is a failing test case that fails without the fix and passes with this change.