### PR TITLE
Tell New Relic to use our proxy

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -42,7 +42,8 @@ DEPLOYMENT_DESCRIPTION="Recording deployment of ${VERSION}."
 echo "${DEPLOYMENT_DESCRIPTION}"
 
 # Record deployment using the New Relic Python Admin CLI
-newrelic-admin record-deploy "${NEW_RELIC_CONFIG_FILE}" "${DEPLOYMENT_DESCRIPTION}"
+# NOTE: New relic wants its own proxy environment variable
+NEW_RELIC_PROXY_HOST=$https_proxy newrelic-admin record-deploy "${NEW_RELIC_CONFIG_FILE}" "${DEPLOYMENT_DESCRIPTION}"
 
 python manage.py collectstatic --settings=tock.settings.production --noinput
 gunicorn -t 120 -k gevent -w 2 tock.wsgi:application


### PR DESCRIPTION
## Description

This is one step towards #1695. New Relic doesn't appear to respect the `https_proxy` environment variable, so we specify it explicitly when we call `newrelic-admin`.

## Additional information

This appears to fix New Relic's stopping of deploy when we remove the public egress security group, as long as the proxy is correctly configured.