### PR TITLE
add REQUESTS_CA_BUNDLE env var to prod

### DIFF
--- a/manifest-production.yml
+++ b/manifest-production.yml
@@ -15,6 +15,7 @@ applications:
     NEW_RELIC_ENV: production
     NEW_RELIC_LOG: stdout
     NEW_RELIC_CA_BUNDLE_PATH: /etc/ssl/certs
+    REQUESTS_CA_BUNDLE: "/etc/ssl/certs/ca-certificates.crt"
   instances: 4
   services:
   - tockdb


### PR DESCRIPTION
We forgot to add this environment variable for production (this was already set in staging). This env var allows python libraries to pick up the system ssl certificates on the cloud.gov instance.