### PR TITLE
Replace deprecated applymap() and use two decimal places for formatting

### DIFF
--- a/tock/utilization/analytics.py
+++ b/tock/utilization/analytics.py
@@ -243,5 +243,5 @@ def project_chart_and_table(timecardobject_queryset):
     # is more typical, so let's replace the NaNs with zeroes before we
     # format the numbers
     datatable = datatable.fillna(0)
-    datatable = datatable.map("{:.0f}".format)
+    datatable = datatable.map("{:.2f}".format)
     return plot_div, datatable

--- a/tock/utilization/views.py
+++ b/tock/utilization/views.py
@@ -184,7 +184,7 @@ class UtilizationAnalyticsView(FilteredAnalyticsView, TemplateView):
                 "headcount_data": headcount_data_frame.pivot(
                     index="start_date", values="headcount", columns="organization"
                 )
-                .applymap("{:.0f}".format)
+                .map("{:.2f}".format)
                 .replace("nan", ""),
 
                 # we use mark_safe intentionally here because we trust that

--- a/tock/utilization/views.py
+++ b/tock/utilization/views.py
@@ -184,7 +184,7 @@ class UtilizationAnalyticsView(FilteredAnalyticsView, TemplateView):
                 "headcount_data": headcount_data_frame.pivot(
                     index="start_date", values="headcount", columns="organization"
                 )
-                .map("{:.2f}".format)
+                .map("{:.0f}".format)
                 .replace("nan", ""),
 
                 # we use mark_safe intentionally here because we trust that


### PR DESCRIPTION
## Description

This attempts to resolve #1642 

## Additional information

Include any of the following (as necessary):

* For a project view (/projects/{pk_id}), we were previously formatting the total hours in the data table using `:.0f`, I've updated that to format using `:.2f` instead. This seems to correctly stop truncating hours and the test suite passes.

* The original ticket also mentions `DataTable.applymap()` being deprecated and replaced by `DataTable.map()`. I found that `DataTable.map()` was already being used in the [utilization/analytics.py](https://github.com/18F/tock/blob/main/tock/utilization/analytics.py) file but the terminal complained about `DataTable.applymap()` in [utilization/views.py on line 187](https://github.com/18F/tock/blob/main/tock/utilization/views.py#L187), I've replaced `DataTable.applymap()` with `DataTable.map()` and that didn't seem to upset anything.
