### PR TITLE
Fix New Relic agent configuration

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@
 - [Deployment process](deployment-process.md)
 - [Developer onboarding](onboarding.md)
 - [Developer offboarding](offboarding.md)
+- [Egress filtering](egress.md)
 - [Google Script Integration](google-script-integration.md)
 - [Logging](logging.md)
 - [Backup and Restore Database](backup-and-restore-database.md)

--- a/docs/deployment-process.md
+++ b/docs/deployment-process.md
@@ -65,6 +65,7 @@ configured in the `manifest-*.yaml`.
 | **public** | `NEW_RELIC_CONFIG_FILE` | The New Relic configuration file used by the `newrelic-admin` commands and New Relic libraries. |
 | **public** | `NEW_RELIC_APP_NAME` | The application name that appears in the New Relic interface. Changing this will change will cause New Relic data to be gathered under a different application name. |
 | **public** | `NEW_RELIC_ENV` | The application environment that appears in the New Relic interface. |
+| **public** | `NEW_RELIC_HOST` | The New Relic endpoint used to collect APM data from the Python agent. Per [New Relic documentation](https://docs.newrelic.com/docs/security/security-privacy/compliance/fedramp-compliant-endpoints/#apm-endpoints), the default endpoint will not ensure FedRAMP compliance. |
 | **public** | `NEW_RELIC_LOG` | Logging that New Relic should listen to: e.g. `stdout`. |
 
 Variables with the designation **secret** are stored in the `tock-credentials` User-Provided Service (UPS).

--- a/egress_proxy/tock.vars.yml
+++ b/egress_proxy/tock.vars.yml
@@ -8,4 +8,5 @@ proxyallow: |
   uaa.fr.cloud.gov
   google-analytics.com
   api.newrelic.com
+  gov-collector.newrelic.com
   *.apps.internal

--- a/manifest-production.yml
+++ b/manifest-production.yml
@@ -13,6 +13,7 @@ applications:
     NEW_RELIC_APP_NAME: Tock (Production)
     NEW_RELIC_CONFIG_FILE: /home/vcap/app/newrelic.ini
     NEW_RELIC_ENV: production
+    NEW_RELIC_HOST: gov-collector.newrelic.com
     NEW_RELIC_LOG: stdout
     NEW_RELIC_CA_BUNDLE_PATH: /etc/ssl/certs
     REQUESTS_CA_BUNDLE: "/etc/ssl/certs/ca-certificates.crt"

--- a/manifest-staging.yml
+++ b/manifest-staging.yml
@@ -13,6 +13,7 @@ applications:
     NEW_RELIC_APP_NAME: Tock (Staging)
     NEW_RELIC_CONFIG_FILE: /home/vcap/app/newrelic.ini
     NEW_RELIC_ENV: staging
+    NEW_RELIC_HOST: gov-collector.newrelic.com
     NEW_RELIC_LOG: stdout
     NEW_RELIC_CA_BUNDLE_PATH: /etc/ssl/certs
     REQUESTS_CA_BUNDLE: "/etc/ssl/certs/ca-certificates.crt"


### PR DESCRIPTION
## Description

Make two configuration changes in the New Relic agent configuration:

- Configure the Python agent to send data to `gov-collector.newrelic.com` to ensure FedRAMP compliance.
- Add the `gov-collector.newrelic.com` endpoint to Tock's egress proxy allow list, which should enable the Python agent to report APM data to New Relic again.

We are recording Deployment events successfully because Tock sends them via the `newrelic_admin` script. It sends data to `api.newrelic.com`, which we've already allowed through the egress proxy and which doesn't require a FedRAMP-specific setting.

Resolves #1792.

## Testing

The change in system behavior can only be confirmed in a deployed environment with an egress proxy.

Review that the egress proxy configuration change is unlikely to do harm and that the automated testing and checks pass.

After merge and deployment to staging, @nateborr will confirm whether New Relic is successfully receiving APM data.

## Additional information

* https://docs.newrelic.com/docs/new-relic-solutions/get-started/networks/#new-relic-endpoints
* https://docs.newrelic.com/docs/security/security-privacy/compliance/fedramp-compliant-endpoints/#agents
* https://docs.newrelic.com/docs/apm/agents/python-agent/installation/python-agent-admin-script-advanced-usage/#record-deploy
* https://github.com/18F/tock/pull/1734 
