### PR TITLE
Emphasize current reporting period and reverse order

### DIFF
--- a/tock/hours/views.py
+++ b/tock/hours/views.py
@@ -386,7 +386,7 @@ class ReportingPeriodListView(PermissionMixin, ListView):
 
         context['uncompleted_reporting_periods'] = sorted(list(chain(
             unstarted_reporting_periods, unfinished_reporting_periods)),
-            key=attrgetter('start_date'), reverse=True)
+            key=attrgetter('start_date'), reverse=False)
 
         context['today'] = dt.datetime.utcnow().date()
 

--- a/tock/tock/templates/hours/reporting_period_list.html
+++ b/tock/tock/templates/hours/reporting_period_list.html
@@ -28,7 +28,7 @@
         {% for reporting_period in uncompleted_reporting_periods %}
             <li class="reporting-period--item{% if reporting_period.end_date < today %} overdue{% endif %}">
               {% if reporting_period.end_date < today %}<span>Overdue: </span>{% endif %}
-              <a href="{% url 'reportingperiod:UpdateTimesheet' reporting_period %}">{{ reporting_period.end_date | date:"F j, Y" }}</a>
+              <a class="{% if today > reporting_period.start_date and today < reporting_period.end_date %}text-bold{% endif %}" href="{% url 'reportingperiod:UpdateTimesheet' reporting_period %}">{{ reporting_period.end_date | date:"F j, Y" }}</a>
             </li>
         {% endfor %}
         </ul>


### PR DESCRIPTION
## Description

Reverses the order of uncompleted reporting periods and bolds the current week.

## Additional information

This is a solution to #1770, but not the one that was suggested and mocked up for reasons described [here](https://github.com/18F/tock/issues/1770#issuecomment-2394308218).

 
