### PR TITLE
Catch newrelic-admin errors in run script

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -43,7 +43,12 @@ echo "${DEPLOYMENT_DESCRIPTION}"
 
 # Record deployment using the New Relic Python Admin CLI
 # NOTE: New relic wants its own proxy environment variable
-NEW_RELIC_PROXY_HOST=$https_proxy newrelic-admin record-deploy "${NEW_RELIC_CONFIG_FILE}" "${DEPLOYMENT_DESCRIPTION}"
+if NEW_RELIC_PROXY_HOST=$https_proxy newrelic-admin record-deploy "${NEW_RELIC_CONFIG_FILE}" "${DEPLOYMENT_DESCRIPTION}"
+then
+  echo "New Relic deployment recorded successfully."
+else
+  echo "Failed to record New Relic deployment."
+fi
 
 python manage.py collectstatic --settings=tock.settings.production --noinput
 gunicorn -t 120 -k gevent -w 2 tock.wsgi:application


### PR DESCRIPTION
## Description

In the startup script, wrap the `newrelic-admin` call in an if/then clause to catch errors from it. The output from that call should still be logged.

Currently, a failure in recording the deployment with New Relic causes the run.sh script to crash, which prevents an application instance from starting.

I don't have a good mechanism in mind to test this other than deploying to staging and observing its behavior there. At this moment staging start-up is failing due to errors in the newrelic-admin call (ultimately due to egress proxy issues), so there's not much to lose in that environment.

We can view recent deploys via the cloud.gov dashboard so compromising the New Relic deployment information is low-risk in the short term.