### PR TITLE
Troubleshoot New Relic configuration

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -41,9 +41,11 @@ DEPLOYMENT_DESCRIPTION="Recording deployment of ${VERSION}."
 
 echo "${DEPLOYMENT_DESCRIPTION}"
 
-# Record deployment using the New Relic Python Admin CLI
-# NOTE: New relic wants its own proxy environment variable
-if NEW_RELIC_PROXY_HOST=$https_proxy newrelic-admin record-deploy "${NEW_RELIC_CONFIG_FILE}" "${DEPLOYMENT_DESCRIPTION}"
+# Record deployment using the New Relic Python Admin CLI.
+# NOTES:
+# 1. New Relic wants its own proxy environment variable
+# 2. Specify a host value specific to record-deploy execution, since that command is incompatible with the FedRAMP compliant collector host value
+if NEW_RELIC_PROXY_HOST=$https_proxy NEW_RELIC_HOST=$NEW_RELIC_ADMIN_HOST newrelic-admin record-deploy "${NEW_RELIC_CONFIG_FILE}" "${DEPLOYMENT_DESCRIPTION}"
 then
   echo "New Relic deployment recorded successfully."
 else

--- a/manifest-production.yml
+++ b/manifest-production.yml
@@ -10,6 +10,7 @@ applications:
   - route: tock.18f.gov
   - route: tock.18f.gov/api
   env:
+    NEW_RELIC_ADMIN_HOST: api.newrelic.com
     NEW_RELIC_APP_NAME: Tock (Production)
     NEW_RELIC_CONFIG_FILE: /home/vcap/app/newrelic.ini
     NEW_RELIC_ENV: production

--- a/manifest-staging.yml
+++ b/manifest-staging.yml
@@ -10,6 +10,7 @@ applications:
   - route: tock.app.cloud.gov
   - route: tock.app.cloud.gov/api
   env:
+    NEW_RELIC_ADMIN_HOST: api.newrelic.com
     NEW_RELIC_APP_NAME: Tock (Staging)
     NEW_RELIC_CONFIG_FILE: /home/vcap/app/newrelic.ini
     NEW_RELIC_ENV: staging

--- a/newrelic.ini
+++ b/newrelic.ini
@@ -61,7 +61,7 @@ log_file = /tmp/newrelic-python-agent.log
 # of information very quickly, so it is best not to keep the
 # agent at this level for longer than it takes to reproduce the
 # problem you are experiencing.
-log_level = info
+log_level = debug
 
 # The Python Agent communicates with the New Relic service using
 # SSL by default. Note that this does result in an increase in

--- a/newrelic.ini
+++ b/newrelic.ini
@@ -163,7 +163,7 @@ error_collector.enabled = true
 # To stop specific errors from reporting to the UI, set this to
 # a space separated list of the Python exception type names to
 # ignore. The exception name should be of the form 'module:class'.
-error_collector.ignore_errors =
+error_collector.ignore_classes =
 
 # Browser monitoring is the Real User Monitoring feature of the UI.
 # For those Python web frameworks that are supported, this


### PR DESCRIPTION
## Description

1. Add a new `NEW_RELIC_ADMIN_HOST` environment variable, set it to `api.newrelic.com` via the manifest files, and set it as the value of `NEW_RELIC_HOST` for the `newrelic-admin record-deploy` script call on startup. This works around a bug in the New Relic script command that makes it fail when the app's New Relic host is set to `gov-collector.newrelic.com`.
2. Update a deprecated setting name in `newrelic.ini`. The setting is disabled but this will keep the deprecation warning out of the New Relic log file in the application container.
3. Set the New Relic log level to `debug`. This should be set back to `info` once we've resolved our New Relic issue.
