### PR TITLE
Set NEW_RELIC_PROXY_HOST env var during app initialization

### DIFF
--- a/.profile
+++ b/.profile
@@ -4,3 +4,4 @@
 ##
 export http_proxy=$egress_proxy
 export https_proxy=$egress_proxy
+export NEW_RELIC_PROXY_HOST=$egress_proxy

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -42,10 +42,9 @@ DEPLOYMENT_DESCRIPTION="Recording deployment of ${VERSION}."
 echo "${DEPLOYMENT_DESCRIPTION}"
 
 # Record deployment using the New Relic Python Admin CLI.
-# NOTES:
-# 1. New Relic wants its own proxy environment variable
-# 2. Specify a host value specific to record-deploy execution, since that command is incompatible with the FedRAMP compliant collector host value
-if NEW_RELIC_PROXY_HOST=$https_proxy NEW_RELIC_HOST=$NEW_RELIC_ADMIN_HOST newrelic-admin record-deploy "${NEW_RELIC_CONFIG_FILE}" "${DEPLOYMENT_DESCRIPTION}"
+# Specify a NEW_RELIC_HOST value specific to record-deploy execution, since that command is incompatible
+# with the FedRAMP compliant NEW_RELIC_HOST value that we want to run the agent with.
+if NEW_RELIC_HOST=$NEW_RELIC_ADMIN_HOST newrelic-admin record-deploy "${NEW_RELIC_CONFIG_FILE}" "${DEPLOYMENT_DESCRIPTION}"
 then
   echo "New Relic deployment recorded successfully."
 else


### PR DESCRIPTION
## Description

Set the `NEW_RELIC_PROXY_HOST` environment variable to the egress proxy URL during app initialization.

Previously we set that only for the `newrelic-admin record-deploy` script command on startup, but the New Relic agent likely needs that configuration as well.

Compare to the notifications-api configuration, which is successfully running the New Relic Python agent against their FedRAMP-compliant collector through an egress proxy: https://github.com/GSA/notifications-api/blob/main/.profile#L8

## Testing

Merge the change and deploy it to staging; I'll shake out that container manually once it's there.
