### PR TITLE
Remove google-analytics.com from the egress proxy allow list

### DIFF
--- a/docs/egress.md
+++ b/docs/egress.md
@@ -68,6 +68,8 @@ Copy these files from from your local `tock` repo into your `cf-egress-proxy` re
 1. [tock.vars.yml](../egress_proxy/tock.vars.yml)
 2. [manifest.yml](../egress_proxy/manifest.yml)
 
+Delete the code comments from `tock.vars.yml`.
+
 #### Set username and password
 
 In your `cf-egress-proxy` repo, manually set the `username` and `password` values in `tock.vars.yml`.
@@ -82,6 +84,7 @@ Retrieve the existing proxy username and password from the deployed egress proxy
 
 ```bash
 cf env staging-egress | grep PROXY_USERNAME
+cf env staging-egress | grep PROXY_PASSWORD
 ```
 
 Paste each value into the vars file for the appropriate key.

--- a/egress_proxy/tock.vars.yml
+++ b/egress_proxy/tock.vars.yml
@@ -6,7 +6,6 @@ password:   (generated)          # eg output of uuidgen
 proxydeny:
 proxyallow: |
   uaa.fr.cloud.gov
-  google-analytics.com
   api.newrelic.com
   gov-collector.newrelic.com
   *.apps.internal


### PR DESCRIPTION
## Description

Remove `google-analytics.com` from the egress proxy allow list. @cantsin and I haven't found any reason that we would be sending data there from Tock's server side, and I've applied that update in staging without issue.

This PR also tidies up some small omissions in the egress proxy deployment docs.

This follows up work for #1792.

## Deployment

After merge, I will apply the egress proxy config change in production following [these docs](https://github.com/18F/tock/blob/main/docs/egress.md#tock-staging-setup).

This PR doesn't include any changes in the deployed Tock application code, so there's no need for an immediate production release.
